### PR TITLE
fix for clang warning on pi2 and scan-build

### DIFF
--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -35,9 +35,12 @@
     static inline word32 rotlFixed(word32 x, word32 y) {
         return (x << y) | (x >> (sizeof(y) * 8 - y));
     }
+
+    #if defined(FAST_ROTATE)
     static inline word32 rotrFixed(word32 x, word32 y) {
         return (x >> y) | (x << (sizeof(y) * 8 - y));
     }
+    #endif
 
     static inline word16 ByteReverseWord16(word16 value)
     {

--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -390,6 +390,13 @@ void TPM2_Packet_AppendEccPoint(TPM2_Packet* packet, TPMS_ECC_POINT* point)
 }
 void TPM2_Packet_ParseEccPoint(TPM2_Packet* packet, TPMS_ECC_POINT* point)
 {
+    if (point == NULL) {
+#ifdef DEBUG_WOLFTPM
+        printf("Error null argument passed to TPM2_Packet_ParseEccPoint()\n");
+#endif
+        return; /* help out static analysis */
+    }
+
     TPM2_Packet_ParseU16(packet, &point->x.size);
     TPM2_Packet_ParseBytes(packet, point->x.buffer, point->x.size);
     TPM2_Packet_ParseU16(packet, &point->y.size);


### PR DESCRIPTION
The scan-build static analysis is a false positive I think since most elements are static instead of dynamic but to help the tool out I added in a check.