### PR TITLE
Release v1.3 prep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ examples/wrap/wrap_test
 examples/native/native_test
 examples/bench/bench
 examples/csr/csr
-
+examples/tls/tls_client
 examples/pkcs7/pkcs7
 pkcs7tpmsigned.p7s
 

--- a/IDE/OPENSTM32/Inc/user_settings.h
+++ b/IDE/OPENSTM32/Inc/user_settings.h
@@ -38,8 +38,8 @@ extern "C" {
 
 #define HAVE_LWIP_NATIVE
 
-#define WOLF_TPM2
-
+//#define DEBUG_WOLFTPM
+//#define USE_HW_SPI_CS
 
 /* ------------------------------------------------------------------------- */
 /* Math Configuration */

--- a/IDE/OPENSTM32/Src/main.c
+++ b/IDE/OPENSTM32/Src/main.c
@@ -209,19 +209,22 @@ static void MX_RTC_Init(void)
 /* SPI1 init function */
 static void MX_SPI1_Init(void)
 {
-
   hspi1.Instance = SPI1;
   hspi1.Init.Mode = SPI_MODE_MASTER;
   hspi1.Init.Direction = SPI_DIRECTION_2LINES;
   hspi1.Init.DataSize = SPI_DATASIZE_8BIT;
   hspi1.Init.CLKPolarity = SPI_POLARITY_LOW;
   hspi1.Init.CLKPhase = SPI_PHASE_1EDGE;
+#ifdef USE_HW_SPI_CS
   hspi1.Init.NSS = SPI_NSS_HARD_OUTPUT;
-  hspi1.Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_64;
+#else
+  hspi1.Init.NSS = SPI_NSS_SOFT;
+#endif
+  hspi1.Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_64; /* 32=1.8MHz, 128=470kHz */
   hspi1.Init.FirstBit = SPI_FIRSTBIT_MSB;
   hspi1.Init.TIMode = SPI_TIMODE_DISABLE;
   hspi1.Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
-  hspi1.Init.CRCPolynomial = 10;
+  hspi1.Init.CRCPolynomial = 7;
   if (HAL_SPI_Init(&hspi1) != HAL_OK)
   {
     Error_Handler();

--- a/IDE/OPENSTM32/Src/wolftpm_example.c
+++ b/IDE/OPENSTM32/Src/wolftpm_example.c
@@ -88,7 +88,7 @@ void wolfTPMDemo(void const * argument)
 
         case 'm':
 			printf("\nTPM 2.0 Test\n");
-#ifdef WOLF_TPM2
+#ifndef WOLFTPM2_NO_WRAPPER
 			args.return_code = TPM2_Wrapper_Test(&hspi1);
 #endif
 			printf("TPM 2.0 Test: Return code %d\n", args.return_code);

--- a/README.md
+++ b/README.md
@@ -6,16 +6,21 @@ Portable TPM 2.0 project designed for embedded use.
 ## Project Features
 
 * This implementation provides all TPM 2.0 API’s in compliance with the specification.
+* Wrappers provided to simplify Key Generation, RSA encrypt/decrypt, ECC sign/verify, ECDH and NV.
+* Testing done using the Infineon OPTIGA SLB9670 and LetsTrust TPM modules.
 * This uses the TPM Interface Specification (TIS) to communicate over SPI.
+* Platform support Raspberry Pi and STM32 with CubeMX.
 * The design allows for easy portability to different platforms:
 	* Native C code designed for embedded use.
 	* Single IO callback for hardware SPI interface.
 	* No external dependencies.
 	* Compact code size and minimal memory use.
-* Examples for the Raspberry Pi and STM32 with CubeMX.
-* Includes example code for most TPM2 native API’s.
-* Includes wrappers for Key Generation, RSA encrypt/decrypt, ECC sign/verify and ECDH.
-* Testing done using the Infineon OPTIGA SLB9670 module and LetsTrust TPM for Raspberry Pi.
+* Includes example code for:
+    * Most TPM2 native API’s
+    * All TPM2 wrappers
+	* PKCS 7
+	* Certificate Signing Request (CSR)
+	* TLS Client
 
 
 ## TPM 2.0 Overview
@@ -72,7 +77,9 @@ Build wolfSSL:
 
 ```
 ./autogen.sh
-./configure --enable-ecc --enable-sha512 && make
+./configure --enable-ecc --enable-sha512
+make
+make check
 sudo make install
 sudo ldconfig
 ```
@@ -81,13 +88,33 @@ Build wolfTPM:
 
 ```
 ./autogen.sh
-./configure && make
+./configure
+make
 ./examples/wrap/wrap_test
 ./examples/native/native_test
+./examples/bench/bench
+./examples/csr/csr
+./examples/pkcs7/pkcs7
+./examples/tls/tls_client
 ```
 
 
 ## Release Notes
+
+### wolfTPM Release 1.3 (07/19/2018)
+
+* Fixed the TIS TPM_BASE_ADDRESS to conform to specification. (PR #19)
+* Fixed static analysis warnings. (PR #20)
+* Fixed minor build warnings with different compilers. (PR #21)
+* Added TPM bechmarking support. (PR #16)
+* Added functions to import/export public keys as wolf format. (PR #15)
+* Added PKCS7 example to show sign/verify with TPM. (PR #17)
+* Added CSR example to generate certificate request based on TPM key. (PR #17)
+* Added CSR signing script `./certs/certreq.sh` to create certificate using self-signed CA. (PR #17)
+* Added TLS Client example that uses TPM based key for client certificate. (PR #17)
+* Added support for wolfSSL `WOLF_CRYPT_DEV` callbacks to enable TPM based ECC and RSA private keys. (PR #17)
+* Added ability to clear/reset TPM using `./examples/wrap/wrap_test 1` (PR #17)
+* Moved some of the example configuration into `./examples/tpm_io.h`. (PR #17)
 
 ### wolfTPM Release 1.1 (03/09/2018)
 

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -4550,6 +4550,11 @@ const char* TPM2_GetRCString(int rc)
 {
     /* for negative return codes use wolfCrypt */
     if (rc < 0) {
+        switch (rc) {
+            TPM_RC_STR(TPM_RC_TIMEOUT, "Hardware timeout");
+            default:
+                break;
+        }
         return wc_GetErrorString(rc);
     }
 

--- a/src/tpm2_tis.c
+++ b/src/tpm2_tis.c
@@ -130,7 +130,7 @@ int TPM2_TIS_StartupWait(TPM2_CTX* ctx, int timeout)
             return 0;
     } while (rc == TPM_RC_SUCCESS && --timeout > 0);
 
-    return TPM_RC_INITIALIZE;
+    return TPM_RC_TIMEOUT;
 }
 
 int TPM2_TIS_CheckLocality(TPM2_CTX* ctx, int locality)
@@ -146,7 +146,7 @@ int TPM2_TIS_CheckLocality(TPM2_CTX* ctx, int locality)
         return locality;
     }
 
-    return TPM_RC_INITIALIZE;
+    return TPM_RC_TIMEOUT;
 }
 
 int TPM2_TIS_RequestLocality(TPM2_CTX* ctx, int timeout)
@@ -169,7 +169,7 @@ int TPM2_TIS_RequestLocality(TPM2_CTX* ctx, int timeout)
         } while (--timeout > 0);
     }
 
-    return TPM_RC_INITIALIZE;
+    return TPM_RC_TIMEOUT;
 }
 
 int TPM2_TIS_GetInfo(TPM2_CTX* ctx)

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -52,7 +52,7 @@
 #endif
 
 #ifndef TPM_TIMEOUT_TRIES
-#define TPM_TIMEOUT_TRIES 1000000
+#define TPM_TIMEOUT_TRIES 100000
 #endif
 
 #ifndef MAX_SYM_BLOCK_SIZE
@@ -600,6 +600,9 @@ typedef enum {
     TPM_RC_E        = 0xE00,
     TPM_RC_F        = 0xF00,
     TPM_RC_N_MASK   = 0xF00,
+
+    /* use negative codes for internal errors */
+    TPM_RC_TIMEOUT = -100,
 } TPM_RC_T;
 typedef INT32 TPM_RC; /* type is unsigned 16-bits, but internally use signed 32-bit */
 


### PR DESCRIPTION
Fix for timeout checking. Fixes for OpenSTM32 project example. Started on ST33 support. Updated README.md and release note for v1.3 prep.