### PR TITLE
TIS cleanup to improve return code and timeout handling

### DIFF
--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -1046,7 +1046,6 @@ int wolfTPM2_NVCreate(WOLFTPM2_DEV* dev, TPM_HANDLE authHandle,
 #endif
 
     return rc;
-
 }
 
 int wolfTPM2_NVWrite(WOLFTPM2_DEV* dev, TPM_HANDLE authHandle,

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1580,7 +1580,7 @@ typedef struct TPMS_AUTH_COMMAND {
     /* Implementation specific */
     /* These are used for parameter encrypt/decrypt */
 
-    /* The symmetric and hash alorithms to use */
+    /* The symmetric and hash algorithms to use */
     TPMT_SYM_DEF symmetric;
     TPMI_ALG_HASH authHash;
 

--- a/wolftpm/tpm2_tis.h
+++ b/wolftpm/tpm2_tis.h
@@ -25,15 +25,19 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_packet.h>
 
+/* The default locality to use */
+#ifndef WOLFTPM_LOCALITY_DEFAULT
+#define WOLFTPM_LOCALITY_DEFAULT 0
+#endif
 
-WOLFTPM_LOCAL int TPM2_TIS_GetBurstCount(TPM2_CTX* ctx);
+WOLFTPM_LOCAL int TPM2_TIS_GetBurstCount(TPM2_CTX* ctx, word16* burstCount);
 WOLFTPM_LOCAL int TPM2_TIS_SendCommand(TPM2_CTX* ctx, byte* cmd, word16 cmdSz);
 WOLFTPM_LOCAL int TPM2_TIS_Ready(TPM2_CTX* ctx);
-WOLFTPM_LOCAL byte TPM2_TIS_WaitForStatus(TPM2_CTX* ctx, byte status, byte status_mask);
-WOLFTPM_LOCAL byte TPM2_TIS_Status(TPM2_CTX* ctx);
+WOLFTPM_LOCAL int TPM2_TIS_WaitForStatus(TPM2_CTX* ctx, byte status, byte status_mask);
+WOLFTPM_LOCAL int TPM2_TIS_Status(TPM2_CTX* ctx, byte* status);
 WOLFTPM_LOCAL int TPM2_TIS_GetInfo(TPM2_CTX* ctx);
 WOLFTPM_LOCAL int TPM2_TIS_RequestLocality(TPM2_CTX* ctx, int timeout);
-WOLFTPM_LOCAL int TPM2_TIS_CheckLocality(TPM2_CTX* ctx, int locality);
+WOLFTPM_LOCAL int TPM2_TIS_CheckLocality(TPM2_CTX* ctx, int locality, byte* access);
 WOLFTPM_LOCAL int TPM2_TIS_StartupWait(TPM2_CTX* ctx, int timeout);
 WOLFTPM_LOCAL int TPM2_TIS_SpiWrite(TPM2_CTX* ctx, word32 addr, const byte* value, word32 len);
 WOLFTPM_LOCAL int TPM2_TIS_SpiRead(TPM2_CTX* ctx, word32 addr, byte* result, word32 len);

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -44,24 +44,13 @@ typedef int32_t  INT32;
 typedef uint64_t UINT64;
 typedef int64_t  INT64;
 
-#ifndef TRUE
-#define TRUE 1
-#endif
-#ifndef FALSE
-#define FALSE 0
-#endif
 #ifndef YES
 #define YES 1
 #endif
 #ifndef NO
 #define NO 0
 #endif
-#ifndef SET
-#define SET 1
-#endif
-#ifndef CLEAR
-#define CLEAR 0
-#endif
+
 
 /* ---------------------------------------------------------------------------*/
 /* WOLFCRYPT */
@@ -142,7 +131,7 @@ typedef int64_t  INT64;
 #endif
 
 #ifndef TPM_TIMEOUT_TRIES
-#define TPM_TIMEOUT_TRIES 100000
+#define TPM_TIMEOUT_TRIES 1000000
 #endif
 
 #ifndef MAX_SYM_BLOCK_SIZE
@@ -154,25 +143,39 @@ typedef int64_t  INT64;
 #ifndef LABEL_MAX_BUFFER
 #define LABEL_MAX_BUFFER 128
 #endif
-
 #ifndef MAX_RSA_KEY_BITS
 #define MAX_RSA_KEY_BITS 2048
 #endif
 #ifndef MAX_RSA_KEY_BYTES
-#define MAX_RSA_KEY_BYTES ((MAX_RSA_KEY_BITS/8)*2)
+#define MAX_RSA_KEY_BYTES (((MAX_RSA_KEY_BITS+7)/8)*2)
 #endif
 
 #ifndef MAX_ECC_KEY_BITS
 #define MAX_ECC_KEY_BITS 521
 #endif
 #ifndef MAX_ECC_KEY_BYTES
-#define MAX_ECC_KEY_BYTES ((MAX_ECC_KEY_BITS/8)*2)
+#define MAX_ECC_KEY_BYTES (((MAX_ECC_KEY_BITS+7)/8)*2)
+#endif
+
+#ifndef MAX_AES_KEY_BITS
+#define MAX_AES_KEY_BITS 128
+#endif
+#ifndef MAX_AES_BLOCK_SIZE_BYTES
+#define MAX_AES_BLOCK_SIZE_BYTES 16
+#endif
+#ifndef MAX_AES_KEY_BYTES
+#define MAX_AES_KEY_BYTES (MAX_AES_KEY_BITS/8)
 #endif
 
 
 /* ---------------------------------------------------------------------------*/
 /* IMPLEMENTATION SPECIFIC VALUES */
 /* ---------------------------------------------------------------------------*/
+
+/* Optional delay between polling */
+#ifndef XTPM_WAIT
+#define XTPM_WAIT() /* just poll without delay by default */
+#endif
 
 #ifndef BUFFER_ALIGNMENT
 #define BUFFER_ALIGNMENT 4


### PR DESCRIPTION
* Added overridable define `WOLFTPM_LOCALITY_DEFAULT` for the locality used.
* Added `XTPM_WAIT()` macro to enable custom wait between polling.
* Increased the default `TPM_TIMEOUT_TRIES` to give enough time on Pi to do a key gen.
* Removed unused SET, CLEAR, TRUE, FALSE macros.
* Minor spelling fixes.