### PR TITLE
Fix bug with native test shutdown and added I2C instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Build wolfTPM:
 make
 ```
 
+For the I2C support on Raspberry Pi you may need to enable I2C. Here are the steps:
+1. Edit `sudo vim /boot/config.txt`
+2. Uncomment `dtparam=i2c_arm=on`
+3. Reboot
+
+
 ### Build options and defines
 
 ```

--- a/examples/native/native_test.c
+++ b/examples/native/native_test.c
@@ -1270,7 +1270,6 @@ exit:
     rc = TPM2_Shutdown(&cmdIn.shutdown);
     if (rc != TPM_RC_SUCCESS) {
         printf("TPM2_Shutdown failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
-        goto exit;
     }
 
     TPM2_Cleanup(&tpm2Ctx);


### PR DESCRIPTION
Added instructions for enabling I2C on the Raspberry Pi. Fix bug with native example where TPM2_Shutdown failure would loop.