### PR TITLE
Decoupled the fixed algorithms from wolfCrypt build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Tested with:
 Build wolfSSL:
 
 ```
+git clone https://github.com/wolfSSL/wolfssl.git
+cd wolfssl
 ./autogen.sh
 ./configure --enable-certgen --enable-certreq --enable-certext --enable-pkcs7 --enable-cryptodev 
 make
@@ -86,11 +88,15 @@ sudo make install
 sudo ldconfig
 ```
 
+autogen.sh requires: automake and libtool: `sudo apt-get install automake libtool`
+
 ### Building Infineon SLB9670
 
 Build wolfTPM:
 
 ```
+git clone https://github.com/wolfSSL/wolfTPM.git
+cd wolfTPM
 ./autogen.sh
 ./configure
 make
@@ -164,6 +170,14 @@ For the I2C support on Raspberry Pi you may need to enable I2C. Here are the ste
 
 ## Running Examples
 
+## Device Identification
+
+Infineon SLB9670:
+TPM2: Caps 0x30000697, Did 0x001b, Vid 0x15d1, Rid 0x10
+
+ST ST33TP SPI
+TPM2: Caps 0x1a7e2882, Did 0x0000, Vid 0x104a, Rid 0x4e
+
 ### TPM2 Wrapper Tests
 
 ```
@@ -217,7 +231,7 @@ ECDHE    256 agree          5 ops took 1.248 sec, avg 249.669 ms,  4.005 ops/sec
 ```
 ./examples/native/native_test
 TPM2 Demo using Native API's
-TPM2: Caps 0x1a7e2882, Did 0x0000, Vid 0x104a, Rid 0x4e 
+TPM2: Caps 0x1a7e2882, Did 0x0000, Vid 0x104a, Rid 0x4e
 TPM2_Startup pass
 TPM2_SelfTest pass
 TPM2_GetTestResult: Size 12, Rc 0x0

--- a/examples/bench/bench.c
+++ b/examples/bench/bench.c
@@ -166,7 +166,7 @@ int TPM2_Wrapper_Bench(void* userCtx)
 
 
     /* Perform RSA encrypt / decrypt (OAEP pad) */
-    message.size = WC_SHA256_DIGEST_SIZE; /* test message 0x11,0x11,etc */
+    message.size = TPM_SHA256_DIGEST_SIZE; /* test message 0x11,0x11,etc */
     XMEMSET(message.buffer, 0x11, message.size);
 
     bench_stats_start(&count, &start);
@@ -210,7 +210,7 @@ int TPM2_Wrapper_Bench(void* userCtx)
     bench_stats_asym_finish("ECC", 256, "key gen", count, start);
 
     /* Perform sign / verify */
-    message.size = WC_SHA256_DIGEST_SIZE; /* test message 0x11,0x11,etc */
+    message.size = TPM_SHA256_DIGEST_SIZE; /* test message 0x11,0x11,etc */
     XMEMSET(message.buffer, 0x11, message.size);
 
     bench_stats_start(&count, &start);

--- a/examples/native/native_test.c
+++ b/examples/native/native_test.c
@@ -154,10 +154,10 @@ int TPM2_Native_Test(void* userCtx)
     TPM2B_PUBLIC_KEY_RSA message;
 
 #ifndef WOLFTPM2_NO_WOLFCRYPT
-    byte pcr[WC_SHA256_DIGEST_SIZE];
-    int pcr_len = WC_SHA256_DIGEST_SIZE;
-    byte hash[WC_SHA256_DIGEST_SIZE];
-    int hash_len = WC_SHA256_DIGEST_SIZE;
+    byte pcr[TPM_SHA256_DIGEST_SIZE];
+    int pcr_len = TPM_SHA256_DIGEST_SIZE;
+    byte hash[TPM_SHA256_DIGEST_SIZE];
+    int hash_len = TPM_SHA256_DIGEST_SIZE;
 #endif
 
     TpmRsaKey endorse;
@@ -192,7 +192,7 @@ int TPM2_Native_Test(void* userCtx)
     rsaKey.handle = TPM_RH_NULL;
     aesKey.handle = TPM_RH_NULL;
 
-    message.size = WC_SHA256_DIGEST_SIZE;
+    message.size = TPM_SHA256_DIGEST_SIZE;
     XMEMSET(message.buffer, 0x11, message.size);
 
 
@@ -286,16 +286,16 @@ int TPM2_Native_Test(void* userCtx)
 
     /* Random */
     XMEMSET(&cmdIn.getRand, 0, sizeof(cmdIn.getRand));
-    cmdIn.getRand.bytesRequested = WC_SHA256_DIGEST_SIZE;
+    cmdIn.getRand.bytesRequested = TPM_SHA256_DIGEST_SIZE;
     rc = TPM2_GetRandom(&cmdIn.getRand, &cmdOut.getRand);
     if (rc != TPM_RC_SUCCESS) {
         printf("TPM2_GetRandom failed 0x%x: %s\n", rc,
             TPM2_GetRCString(rc));
         goto exit;
     }
-    if (cmdOut.getRand.randomBytes.size != WC_SHA256_DIGEST_SIZE) {
+    if (cmdOut.getRand.randomBytes.size != TPM_SHA256_DIGEST_SIZE) {
         printf("TPM2_GetRandom length mismatch %d != %d\n",
-            cmdOut.getRand.randomBytes.size, WC_SHA256_DIGEST_SIZE);
+            cmdOut.getRand.randomBytes.size, TPM_SHA256_DIGEST_SIZE);
         goto exit;
     }
     printf("TPM2_GetRandom: Got %d bytes\n", cmdOut.getRand.randomBytes.size);
@@ -343,7 +343,7 @@ int TPM2_Native_Test(void* userCtx)
     cmdIn.pcrExtend.pcrHandle = pcrIndex;
     cmdIn.pcrExtend.digests.count = 1;
     cmdIn.pcrExtend.digests.digests[0].hashAlg = TPM_ALG_SHA256;
-    for (i=0; i<WC_SHA256_DIGEST_SIZE; i++) {
+    for (i=0; i<TPM_SHA256_DIGEST_SIZE; i++) {
         cmdIn.pcrExtend.digests.digests[0].digest.H[i] = i;
     }
     rc = TPM2_PCR_Extend(&cmdIn.pcrExtend);
@@ -378,7 +378,7 @@ int TPM2_Native_Test(void* userCtx)
     cmdIn.authSes.sessionType = TPM_SE_POLICY;
     cmdIn.authSes.symmetric.algorithm = TPM_ALG_NULL;
     cmdIn.authSes.authHash = TPM_ALG_SHA256;
-    cmdIn.authSes.nonceCaller.size = WC_SHA256_DIGEST_SIZE;
+    cmdIn.authSes.nonceCaller.size = TPM_SHA256_DIGEST_SIZE;
     rc = TPM2_GetNonce(cmdIn.authSes.nonceCaller.buffer,
                        cmdIn.authSes.nonceCaller.size);
     if (rc < 0) {
@@ -507,9 +507,9 @@ int TPM2_Native_Test(void* userCtx)
             TPM2_GetRCString(rc));
         goto exit;
     }
-    if (cmdOut.seqComp.result.size != WC_SHA256_DIGEST_SIZE &&
+    if (cmdOut.seqComp.result.size != TPM_SHA256_DIGEST_SIZE &&
         XMEMCMP(cmdOut.seqComp.result.buffer, hashTestDig,
-                                                WC_SHA256_DIGEST_SIZE) != 0) {
+                                                TPM_SHA256_DIGEST_SIZE) != 0) {
         printf("Hash SHA256 test failed, result not as expected!\n");
         goto exit;
     }
@@ -629,7 +629,7 @@ int TPM2_Native_Test(void* userCtx)
     /* Make a credential */
     XMEMSET(&cmdIn.makeCred, 0, sizeof(cmdIn.makeCred));
     cmdIn.makeCred.handle = handle;
-    cmdIn.makeCred.credential.size = WC_SHA256_DIGEST_SIZE;
+    cmdIn.makeCred.credential.size = TPM_SHA256_DIGEST_SIZE;
     XMEMSET(cmdIn.makeCred.credential.buffer, 0x11,
         cmdIn.makeCred.credential.size);
     cmdIn.makeCred.objectName = endorse.name;
@@ -732,7 +732,7 @@ int TPM2_Native_Test(void* userCtx)
     XMEMSET(&cmdIn.objChgAuth, 0, sizeof(cmdIn.objChgAuth));
     cmdIn.objChgAuth.objectHandle = hmacKey.handle;
     cmdIn.objChgAuth.parentHandle = storage.handle;
-    cmdIn.objChgAuth.newAuth.size = WC_SHA256_DIGEST_SIZE;
+    cmdIn.objChgAuth.newAuth.size = TPM_SHA256_DIGEST_SIZE;
     rc = TPM2_GetNonce(cmdIn.objChgAuth.newAuth.buffer,
                        cmdIn.objChgAuth.newAuth.size);
     if (rc < 0) {
@@ -1065,7 +1065,7 @@ int TPM2_Native_Test(void* userCtx)
     cmdIn.nvDefine.publicInfo.nvPublic.nameAlg = TPM_ALG_SHA256;
     cmdIn.nvDefine.publicInfo.nvPublic.attributes = (
         TPMA_NV_OWNERWRITE | TPMA_NV_OWNERREAD | TPMA_NV_NO_DA);
-    cmdIn.nvDefine.publicInfo.nvPublic.dataSize = WC_SHA256_DIGEST_SIZE;
+    cmdIn.nvDefine.publicInfo.nvPublic.dataSize = TPM_SHA256_DIGEST_SIZE;
     rc = TPM2_NV_DefineSpace(&cmdIn.nvDefine);
     if (rc != TPM_RC_SUCCESS) {
         printf("TPM2_NV_DefineSpace failed 0x%x: %s\n", rc,

--- a/examples/pkcs7/pkcs7.c
+++ b/examples/pkcs7/pkcs7.c
@@ -87,7 +87,7 @@ static int PKCS7_SignVerifyEx(WOLFTPM2_DEV* dev, int tpmDevId, WOLFTPM2_BUFFER* 
     PKCS7 pkcs7;
     wc_HashAlg       hash;
     enum wc_HashType hashType = WC_HASH_TYPE_SHA256;
-    byte             hashBuf[WC_SHA256_DIGEST_SIZE];
+    byte             hashBuf[TPM_SHA256_DIGEST_SIZE];
     word32           hashSz = wc_HashGetDigestSize(hashType);
     WOLFTPM2_BUFFER  outputHead, outputFoot;
     byte dataChunk[MY_DATA_CHUNKS];

--- a/examples/tpm_io.c
+++ b/examples/tpm_io.c
@@ -47,6 +47,7 @@
         #include <linux/spi/spidev.h>
     #endif
     #include <fcntl.h>
+    #include <unistd.h>
 
     #ifdef WOLFTPM_ST33
         #ifdef WOLFTPM_I2C

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -227,7 +227,7 @@ int TPM2_Wrapper_Test(void* userCtx)
     printf("RSA Encrypt/Decrypt Test Passed\n");
 
     /* Perform RSA encrypt / decrypt (OAEP pad) */
-    message.size = WC_SHA256_DIGEST_SIZE; /* test message 0x11,0x11,etc */
+    message.size = TPM_SHA256_DIGEST_SIZE; /* test message 0x11,0x11,etc */
     XMEMSET(message.buffer, 0x11, message.size);
     cipher.size = sizeof(cipher.buffer); /* encrypted data */
     rc = wolfTPM2_RsaEncrypt(&dev, &rsaKey, TPM_ALG_OAEP,
@@ -287,7 +287,7 @@ int TPM2_Wrapper_Test(void* userCtx)
     if (rc != 0) goto exit;
 
     /* Perform sign / verify */
-    message.size = WC_SHA256_DIGEST_SIZE; /* test message 0x11,0x11,etc */
+    message.size = TPM_SHA256_DIGEST_SIZE; /* test message 0x11,0x11,etc */
     XMEMSET(message.buffer, 0x11, message.size);
     cipher.size = sizeof(cipher.buffer); /* signature */
     rc = wolfTPM2_SignHash(&dev, &eccKey, message.buffer, message.size,

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -280,6 +280,7 @@ TPM_RC TPM2_Init(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx)
 
     wolfCrypt_Init();
 
+#ifndef WC_NO_RNG
     rc = wc_InitRng(&ctx->rng);
     if (rc < 0) {
 #ifdef DEBUG_WOLFTPM
@@ -287,6 +288,7 @@ TPM_RC TPM2_Init(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx)
 #endif
         return rc;
     }
+#endif /* !WC_NO_RNG */
 
 #ifndef SINGLE_THREADED
     if (wc_InitMutex(&ctx->hwLock) != 0) {
@@ -340,7 +342,9 @@ TPM_RC TPM2_Cleanup(TPM2_CTX* ctx)
     }
 
 #ifndef WOLFTPM2_NO_WOLFCRYPT
+    #ifndef WC_NO_RNG
     wc_FreeRng(&ctx->rng);
+    #endif
 #ifndef SINGLE_THREADED
     wc_FreeMutex(&ctx->hwLock);
 #endif

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -4541,22 +4541,14 @@ int TPM2_SetCommandSet(SetCommandSet_In* in)
 int TPM2_GetHashDigestSize(TPMI_ALG_HASH hashAlg)
 {
     switch (hashAlg) {
-    #ifndef NO_SHA
         case TPM_ALG_SHA1:
-            return WC_SHA_DIGEST_SIZE;
-    #endif
-    #ifndef NO_SHA256
+            return TPM_SHA_DIGEST_SIZE;
         case TPM_ALG_SHA256:
-            return WC_SHA256_DIGEST_SIZE;
-    #endif
-#ifdef WOLFSSL_SHA512
-    #ifdef WOLFSSL_SHA384
+            return TPM_SHA256_DIGEST_SIZE;
         case TPM_ALG_SHA384:
-            return WC_SHA384_DIGEST_SIZE;
-    #endif
+            return TPM_SHA384_DIGEST_SIZE;
         case TPM_ALG_SHA512:
-            return WC_SHA512_DIGEST_SIZE;
-#endif /* WOLFSSL_SHA512 */
+            return TPM_SHA512_DIGEST_SIZE;
         default:
             return 0;
     }

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -1219,10 +1219,12 @@ int wolfTPM2_NVDelete(WOLFTPM2_DEV* dev, TPM_HANDLE authHandle,
 }
 
 #ifndef WOLFTPM2_NO_WOLFCRYPT
-WC_RNG* wolfTPM2_GetRng(WOLFTPM2_DEV* dev)
+struct WC_RNG* wolfTPM2_GetRng(WOLFTPM2_DEV* dev)
 {
+#ifndef WC_NO_RNG
     if (dev)
         return &dev->ctx.rng;
+#endif
     return NULL;
 }
 #endif

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -778,25 +778,13 @@ typedef struct TPMS_ALGORITHM_DESCRIPTION {
 
 
 typedef union TPMU_HA {
-#ifdef WOLFSSL_SHA512
-    BYTE sha512[WC_SHA512_DIGEST_SIZE];
-#endif
-#ifdef WOLFSSL_SHA384
-    BYTE sha384[WC_SHA384_DIGEST_SIZE];
-#endif
-#ifndef NO_SHA256
-    BYTE sha256[WC_SHA256_DIGEST_SIZE];
-#endif
-#ifdef WOLFSSL_SHA224
-    BYTE sha224[WC_SHA224_DIGEST_SIZE];
-#endif
-#ifndef NO_SHA
-    BYTE sha[WC_SHA_DIGEST_SIZE];
-#endif
-#ifndef NO_MD5
-    BYTE md5[WC_MD5_DIGEST_SIZE];
-#endif
-    BYTE H[WC_MAX_DIGEST_SIZE];
+    BYTE sha512[TPM_SHA512_DIGEST_SIZE];
+    BYTE sha384[TPM_SHA384_DIGEST_SIZE];
+    BYTE sha256[TPM_SHA256_DIGEST_SIZE];
+    BYTE sha224[TPM_SHA224_DIGEST_SIZE];
+    BYTE sha[TPM_SHA_DIGEST_SIZE];
+    BYTE md5[TPM_MD5_DIGEST_SIZE];
+    BYTE H[TPM_MAX_DIGEST_SIZE];
 } TPMU_HA;
 
 typedef struct TPMT_HA {
@@ -1081,21 +1069,15 @@ typedef struct TPM2B_ATTEST {
 /* Algorithm Parameters and Structures */
 
 /* Symmetric */
-#ifndef NO_AES
 typedef TPM_KEY_BITS TPMI_AES_KEY_BITS;
-#endif
 
 typedef union TPMU_SYM_KEY_BITS {
-#ifndef NO_AES
     TPMI_AES_KEY_BITS aes;
-#endif
     TPM_KEY_BITS sym;
 } TPMU_SYM_KEY_BITS;
 
 typedef union TPMU_SYM_MODE {
-#ifndef NO_AES
     TPMI_ALG_SYM_MODE aes;
-#endif
     TPMI_ALG_SYM_MODE sym;
 } TPMU_SYM_MODE;
 

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1620,7 +1620,9 @@ typedef struct TPM2_CTX {
 #ifndef SINGLE_THREADED
     wolfSSL_Mutex hwLock;
 #endif
+    #ifndef WC_NO_RNG
     WC_RNG rng;
+    #endif
 #endif /* !WOLFTPM2_NO_WOLFCRYPT */
 
     /* TPM TIS Info */

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -30,7 +30,7 @@
 #include <stdint.h>
 
 /* ---------------------------------------------------------------------------*/
-/* TYPES */
+/* TPM TYPES */
 /* ---------------------------------------------------------------------------*/
 
 typedef uint8_t  UINT8;
@@ -82,15 +82,6 @@ typedef int64_t  INT64;
     typedef uint32_t word32;
     typedef uint64_t word64;
 
-    #define MAX_ECC_KEY_BYTES     66
-    #define WC_MAX_BLOCK_SIZE     128
-    #define WC_MD5_DIGEST_SIZE    16
-    #define WC_SHA_DIGEST_SIZE    20
-    #define WC_SHA256_DIGEST_SIZE 32
-    #define WC_SHA384_DIGEST_SIZE 48
-    #define WC_SHA512_DIGEST_SIZE 64
-    #define WC_MAX_DIGEST_SIZE    WC_SHA512_DIGEST_SIZE
-
     #define BAD_FUNC_ARG          -173  /* Bad function argument provided */
     #define BUFFER_E              -132  /* output buffer too small or input too large */
     #define NOT_COMPILED_IN       -174  /* Feature not compiled in */
@@ -126,6 +117,29 @@ typedef int64_t  INT64;
 #else
     #define WOLFTPM_PACK_BEG
     #define WOLFTPM_PACK_END
+#endif
+
+
+/* ---------------------------------------------------------------------------*/
+/* ALGORITHMS */
+/* ---------------------------------------------------------------------------*/
+#define TPM_MD5_DIGEST_SIZE    16
+#define TPM_SHA_DIGEST_SIZE    20
+#define TPM_SHA224_DIGEST_SIZE 28
+#define TPM_SHA256_DIGEST_SIZE 32
+#define TPM_SHA384_DIGEST_SIZE 48
+#define TPM_SHA512_DIGEST_SIZE 64
+
+#ifndef MAX_ECC_KEY_BYTES
+#define MAX_ECC_KEY_BYTES     66
+#endif
+
+#ifndef TPM_MAX_BLOCK_SIZE
+#define TPM_MAX_BLOCK_SIZE     128
+#endif
+
+#ifndef TPM_MAX_DIGEST_SIZE
+#define TPM_MAX_DIGEST_SIZE    TPM_SHA512_DIGEST_SIZE
 #endif
 
 


### PR DESCRIPTION
* Decoupled the fixed algorithms sizes and build options from wolfCrypt. Now wolfCrypt can be built with algos like SHA256 and AES disabled, but they can still be supported in wolfTPM.
* Fix for handling the `WC_NO_RNG` case.
* Fix no case with `implicit declaration of function ‘close’`.
* Updated the README.md with a few additional build details.