### PR TITLE
Refactor to eliminate the packed TPM2_HEADER

### DIFF
--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -106,7 +106,7 @@ static TPM_RC TPM2_SendCommandAuth(TPM2_CTX* ctx, TPM2_Packet* packet,
 
     /* parameter encryption */
     if (*tag == TPM_ST_SESSIONS) {
-        param = cmd + sizeof(TPM2_HEADER) + (inHandleCnt * sizeof(TPM_HANDLE));
+        param = cmd + TPM2_HEADER_SIZE + (inHandleCnt * sizeof(TPM_HANDLE));
 
         paramSz = *(UINT32*)param;
         param += sizeof(UINT32); /* skip the param size */
@@ -131,7 +131,7 @@ static TPM_RC TPM2_SendCommandAuth(TPM2_CTX* ctx, TPM2_Packet* packet,
                 /* check for object handle auth and append to key */
                 if (i < inHandleCnt) {
                     TPM_HANDLE* objHandle = (TPM_HANDLE*)(cmd +
-                        sizeof(TPM2_HEADER) + (i * sizeof(TPM_HANDLE)));
+                        TPM2_HEADER_SIZE + (i * sizeof(TPM_HANDLE)));
                     if (*objHandle == auth->objHandle) {
                         /* append to key */
                         XMEMCPY(key.buffer + key.size, auth->objAuth.buffer,
@@ -188,7 +188,7 @@ static TPM_RC TPM2_SendCommandAuth(TPM2_CTX* ctx, TPM2_Packet* packet,
                 /* check for object handle auth and append to key */
                 if (i < outHandleCnt) {
                     TPM_HANDLE* objHandle = (TPM_HANDLE*)(cmd +
-                        sizeof(TPM2_HEADER) + (i * sizeof(TPM_HANDLE)));
+                        TPM2_HEADER_SIZE + (i * sizeof(TPM_HANDLE)));
                     if (*objHandle == auth->objHandle) {
                         /* append to key */
                         XMEMCPY(key.buffer + key.size, auth->objAuth.buffer,

--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -123,15 +123,9 @@ UINT64 TPM2_Packet_SwapU64(UINT64 data) {
 
 void TPM2_Packet_Init(TPM2_CTX* ctx, TPM2_Packet* packet)
 {
-    /* compile time trap for detecting improper packing on TPM2_HEADER */
-    /* build failure here indicates improper setup for WOLFTPM_PACK_BEG and
-       WOLFTPM_PACK_END */
-    typedef char tpm2_header_test[sizeof(TPM2_HEADER) == TPM2_HEADER_SIZE ? 1 : -1];
-    (void)sizeof(tpm2_header_test);
-
     if (ctx && packet) {
         packet->buf  = ctx->cmdBuf;
-        packet->pos = sizeof(TPM2_HEADER); /* skip header (fill during finalize) */
+        packet->pos = TPM2_HEADER_SIZE; /* skip header (fill during finalize) */
         packet->size = sizeof(ctx->cmdBuf);
     }
 }

--- a/wolftpm/tpm2_packet.h
+++ b/wolftpm/tpm2_packet.h
@@ -26,8 +26,8 @@
 
 #define TPM2_HEADER_SIZE 10 /* expected TPM2 header size */
 
-/* Note: The TPM2_HEADER structure must be packed */
-typedef WOLFTPM_PACK_BEG struct TPM2_HEADER {
+/* For reference here is the TPM2 header (not used) */
+typedef struct TPM2_HEADER {
     UINT16 tag;
     UINT32 size;
     union {
@@ -35,7 +35,7 @@ typedef WOLFTPM_PACK_BEG struct TPM2_HEADER {
         TPM_CC cc;
         TPM_RC rc;
     };
-} WOLFTPM_PACK_END TPM2_HEADER;
+} TPM2_HEADER;
 
 typedef struct TPM2_Packet {
     byte* buf;

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -109,29 +109,6 @@ typedef int64_t  INT64;
 
 
 /* ---------------------------------------------------------------------------*/
-/* PACKED MACROS */
-/* ---------------------------------------------------------------------------*/
-#ifndef WOLFTPM_PACK_BEG
-    #if defined(__GNUC__)
-        #define WOLFTPM_PACK_BEG
-    #elif defined(__ICCARM__)
-        #define WOLFTPM_PACK_BEG __packed
-    #else
-        #define WOLFTPM_PACK_BEG
-    #endif
-#endif
-#ifndef WOLFTPM_PACK_END
-    #if defined(__GNUC__) || defined(__TI_COMPILER_VERSION__)
-        #define WOLFTPM_PACK_END __attribute__ ((packed))
-    #elif defined(__ICCARM__)
-        #define WOLFTPM_PACK_END
-    #else
-        #define WOLFTPM_PACK_END
-    #endif
-#endif
-
-
-/* ---------------------------------------------------------------------------*/
 /* ALGORITHMS */
 /* ---------------------------------------------------------------------------*/
 #define TPM_MD5_DIGEST_SIZE    16


### PR DESCRIPTION
Adds better portability for source code.