### PR TITLE
Support for Microchip ATTPM20

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Tested with:
 * Infineon OPTIGA (TM) Trusted Platform Module 2.0 SLB 9670.
 * LetsTrust: http://letstrust.de (https://buyzero.de/collections/andere-platinen/products/letstrust-hardware-tpm-trusted-platform-module). Compact Raspberry Pi TPM 2.0 board based on Infineon SLB 9670.
 * ST ST33TP* TPM 2.0 module (SPI and I2C)
+* Microchip ATTPM20
 
 #### Device Identification
 
@@ -85,6 +86,10 @@ Mfg IFX (1), Vendor SLB9670, Fw 7.85 (4555), FIPS 140-2 1, CC-EAL4 1
 ST ST33TP SPI
 TPM2: Caps 0x1a7e2882, Did 0x0000, Vid 0x104a, Rid 0x4e
 Mfg STM  (2), Vendor , Fw 74.8 (1151341959), FIPS 140-2 1, CC-EAL4 0
+
+Microchip ATTPM20
+TPM2: Caps 0x30000695, Did 0x3205, Vid 0x1114, Rid 0x 1 
+Mfg MCHP (3), Vendor , Fw 512.20481 (0), FIPS 140-2 0, CC-EAL4 0
 
 ## Building
 
@@ -130,6 +135,16 @@ For the I2C support on Raspberry Pi you may need to enable I2C. Here are the ste
 2. Uncomment `dtparam=i2c_arm=on`
 3. Reboot `sudo reboot`
 
+### Building Microchip ATTPM20
+
+Build wolfTPM:
+
+```
+./autogen.sh
+./configure --enable-mchp
+make
+```
+
 
 ### Build options and defines
 
@@ -141,6 +156,7 @@ For the I2C support on Raspberry Pi you may need to enable I2C. Here are the ste
 --enable-advio          Enable Advanced IO (default: disabled) - WOLFTPM_ADV_IO
 --enable-st33           Enable ST33 TPM Support (default: disabled) - WOLFTPM_ST33
 --enable-i2c            Enable I2C TPM Support (default: disabled) - WOLFTPM_I2C
+--enable-mchp           Enable Microchip TPM Support (default: disabled) - WOLFTPM_MCHP
 ```
 
 ## Release Notes

--- a/configure.ac
+++ b/configure.ac
@@ -183,6 +183,18 @@ fi
 AM_CONDITIONAL([BUILD_ST33], [test "x$ENABLED_ST33" = "xyes"])
 
 
+# MCHP Support
+AC_ARG_ENABLE([mchp],
+    [AS_HELP_STRING([--enable-mchp],[Enable TPM 2.0 Support (default: disabled)])],
+    [ ENABLED_MCHP=$enableval ],
+    [ ENABLED_MCHP=no ]
+    )
+if test "x$ENABLED_MCHP" = "xyes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_MCHP"
+fi
+AM_CONDITIONAL([BUILD_MCHP], [test "x$ENABLED_MCHP" = "xyes"])
+
 
 # HARDEN FLAGS
 AX_HARDEN_CC_COMPILER_FLAGS

--- a/examples/bench/bench.c
+++ b/examples/bench/bench.c
@@ -163,7 +163,7 @@ static int bench_sym_aes(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* storageKey,
 
     XMEMSET(&aesKey, 0, sizeof(aesKey));
     rc = wolfTPM2_GetKeyTemplate_Symmetric(&publicTemplate, keyBits, algo,
-        YES, YES);
+        NO, YES);
     if (rc != 0) goto exit;
     rc = wolfTPM2_CreateAndLoadKey(dev, &aesKey, &storageKey->handle,
         &publicTemplate, (byte*)gUsageAuth, sizeof(gUsageAuth)-1);
@@ -247,7 +247,6 @@ int TPM2_Wrapper_Bench(void* userCtx)
     } while (bench_stats_check(start, &count));
     bench_stats_sym_finish("RNG", count, sizeof(message.buffer), start);
 
-#ifndef WOLFTPM_MCHP
     /* AES Benchmarks */
     /* AES CBC */
     rc = bench_sym_aes(&dev, &storageKey, "AES-128-CBC-enc", TPM_ALG_CBC, 128,
@@ -290,7 +289,6 @@ int TPM2_Wrapper_Bench(void* userCtx)
     rc = bench_sym_aes(&dev, &storageKey, "AES-256-CFB-dec", TPM_ALG_CFB, 256,
         message.buffer, cipher.buffer, sizeof(message.buffer), WOLFTPM2_DECRYPT);
     if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
-#endif
 
     /* Hashing Benchmarks */
     /* SHA1 */

--- a/examples/bench/bench.c
+++ b/examples/bench/bench.c
@@ -247,6 +247,7 @@ int TPM2_Wrapper_Bench(void* userCtx)
     } while (bench_stats_check(start, &count));
     bench_stats_sym_finish("RNG", count, sizeof(message.buffer), start);
 
+#ifndef WOLFTPM_MCHP
     /* AES Benchmarks */
     /* AES CBC */
     rc = bench_sym_aes(&dev, &storageKey, "AES-128-CBC-enc", TPM_ALG_CBC, 128,
@@ -289,7 +290,7 @@ int TPM2_Wrapper_Bench(void* userCtx)
     rc = bench_sym_aes(&dev, &storageKey, "AES-256-CFB-dec", TPM_ALG_CFB, 256,
         message.buffer, cipher.buffer, sizeof(message.buffer), WOLFTPM2_DECRYPT);
     if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
-
+#endif
 
     /* Hashing Benchmarks */
     /* SHA1 */

--- a/examples/bench/bench.c
+++ b/examples/bench/bench.c
@@ -163,7 +163,7 @@ static int bench_sym_aes(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* storageKey,
 
     XMEMSET(&aesKey, 0, sizeof(aesKey));
     rc = wolfTPM2_GetKeyTemplate_Symmetric(&publicTemplate, keyBits, algo,
-        NO, YES);
+        YES, YES);
     if (rc != 0) goto exit;
     rc = wolfTPM2_CreateAndLoadKey(dev, &aesKey, &storageKey->handle,
         &publicTemplate, (byte*)gUsageAuth, sizeof(gUsageAuth)-1);

--- a/examples/native/native_test.c
+++ b/examples/native/native_test.c
@@ -347,12 +347,16 @@ int TPM2_Native_Test(void* userCtx)
                 TPM2_GetRCString(rc));
             goto exit;
         }
-        printf("TPM2_PCR_Read: Index %d, Digest Sz %d, Update Counter %d\n",
-            pcrIndex,
-            (int)cmdOut.pcrRead.pcrValues.digests[0].size,
-            (int)cmdOut.pcrRead.pcrUpdateCounter);
-        TPM2_PrintBin(cmdOut.pcrRead.pcrValues.digests[0].buffer,
-                       cmdOut.pcrRead.pcrValues.digests[0].size);
+        printf("TPM2_PCR_Read: Index %d, Count %d\n",
+            pcrIndex, (int)cmdOut.pcrRead.pcrValues.count);
+        if (cmdOut.pcrRead.pcrValues.count > 0) {
+            printf("TPM2_PCR_Read: Index %d, Digest Sz %d, Update Counter %d\n",
+                pcrIndex,
+                (int)cmdOut.pcrRead.pcrValues.digests[0].size,
+                (int)cmdOut.pcrRead.pcrUpdateCounter);
+            TPM2_PrintBin(cmdOut.pcrRead.pcrValues.digests[0].buffer,
+                          cmdOut.pcrRead.pcrValues.digests[0].size);
+        }
     }
 
     /* PCR Extend and Verify */
@@ -380,13 +384,16 @@ int TPM2_Native_Test(void* userCtx)
         printf("TPM2_PCR_Read failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
         goto exit;
     }
-    printf("TPM2_PCR_Read: Index %d, Digest Sz %d, Update Counter %d\n",
-        pcrIndex,
-        (int)cmdOut.pcrRead.pcrValues.digests[0].size,
-        (int)cmdOut.pcrRead.pcrUpdateCounter);
-    TPM2_PrintBin(cmdOut.pcrRead.pcrValues.digests[0].buffer,
-                   cmdOut.pcrRead.pcrValues.digests[0].size);
-
+    printf("TPM2_PCR_Read: Index %d, Count %d\n",
+            pcrIndex, (int)cmdOut.pcrRead.pcrValues.count);
+    if (cmdOut.pcrRead.pcrValues.count > 0) {
+        printf("TPM2_PCR_Read: Index %d, Digest Sz %d, Update Counter %d\n",
+            pcrIndex,
+            (int)cmdOut.pcrRead.pcrValues.digests[0].size,
+            (int)cmdOut.pcrRead.pcrUpdateCounter);
+        TPM2_PrintBin(cmdOut.pcrRead.pcrValues.digests[0].buffer,
+                      cmdOut.pcrRead.pcrValues.digests[0].size);
+    }
 
 
     /* Start Auth Session */

--- a/examples/native/native_test.c
+++ b/examples/native/native_test.c
@@ -340,7 +340,7 @@ int TPM2_Native_Test(void* userCtx)
         pcrIndex = i;
         XMEMSET(&cmdIn.pcrRead, 0, sizeof(cmdIn.pcrRead));
         TPM2_SetupPCRSel(&cmdIn.pcrRead.pcrSelectionIn,
-            TPM_ALG_SHA256, pcrIndex);
+            TEST_WRAP_DIGEST, pcrIndex);
         rc = TPM2_PCR_Read(&cmdIn.pcrRead, &cmdOut.pcrRead);
         if (rc != TPM_RC_SUCCESS) {
             printf("TPM2_PCR_Read failed 0x%x: %s\n", rc,
@@ -364,7 +364,7 @@ int TPM2_Native_Test(void* userCtx)
     XMEMSET(&cmdIn.pcrExtend, 0, sizeof(cmdIn.pcrExtend));
     cmdIn.pcrExtend.pcrHandle = pcrIndex;
     cmdIn.pcrExtend.digests.count = 1;
-    cmdIn.pcrExtend.digests.digests[0].hashAlg = TPM_ALG_SHA256;
+    cmdIn.pcrExtend.digests.digests[0].hashAlg = TEST_WRAP_DIGEST;
     for (i=0; i<TPM_SHA256_DIGEST_SIZE; i++) {
         cmdIn.pcrExtend.digests.digests[0].digest.H[i] = i;
     }
@@ -378,7 +378,7 @@ int TPM2_Native_Test(void* userCtx)
 
     XMEMSET(&cmdIn.pcrRead, 0, sizeof(cmdIn.pcrRead));
     TPM2_SetupPCRSel(&cmdIn.pcrRead.pcrSelectionIn,
-        TPM_ALG_SHA256, pcrIndex);
+        TEST_WRAP_DIGEST, pcrIndex);
     rc = TPM2_PCR_Read(&cmdIn.pcrRead, &cmdOut.pcrRead);
     if (rc != TPM_RC_SUCCESS) {
         printf("TPM2_PCR_Read failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
@@ -1169,7 +1169,7 @@ int TPM2_Native_Test(void* userCtx)
     cmdIn.create.inPublic.publicArea.nameAlg = TPM_ALG_SHA256;
     cmdIn.create.inPublic.publicArea.objectAttributes = (
         TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
-        TPMA_OBJECT_noDA | TPMA_OBJECT_sign | TPMA_OBJECT_decrypt);
+        TPMA_OBJECT_noDA | TPMA_OBJECT_decrypt);
     cmdIn.create.inPublic.publicArea.parameters.symDetail.sym.algorithm = TPM_ALG_AES;
     cmdIn.create.inPublic.publicArea.parameters.symDetail.sym.keyBits.aes = MAX_AES_KEY_BITS;
     cmdIn.create.inPublic.publicArea.parameters.symDetail.sym.mode.aes = TEST_AES_MODE;

--- a/examples/native/native_test.c
+++ b/examples/native/native_test.c
@@ -95,7 +95,11 @@ int TPM2_Native_Test(void* userCtx)
         ECC_Parameters_In eccParam;
         ECDH_KeyGen_In ecdh;
         ECDH_ZGen_In ecdhZ;
+    #ifdef WOLFTPM_MCHP
+        EncryptDecrypt_In encDec;
+    #else
         EncryptDecrypt2_In encDec;
+    #endif
         HMAC_In hmac;
         HMAC_Start_In hmacStart;
 #ifdef WOLFTPM_ST33
@@ -129,7 +133,11 @@ int TPM2_Native_Test(void* userCtx)
         ECC_Parameters_Out eccParam;
         ECDH_KeyGen_Out ecdh;
         ECDH_ZGen_Out ecdhZ;
+    #ifdef WOLFTPM_MCHP
+        EncryptDecrypt_Out encDec;
+    #else
         EncryptDecrypt2_Out encDec;
+    #endif
         HMAC_Out hmac;
         HMAC_Start_Out hmacStart;
         byte maxOutput[MAX_RESPONSE_SIZE];
@@ -1167,9 +1175,16 @@ int TPM2_Native_Test(void* userCtx)
         cmdIn.create.inSensitive.sensitive.userAuth.size);
     cmdIn.create.inPublic.publicArea.type = TPM_ALG_SYMCIPHER;
     cmdIn.create.inPublic.publicArea.nameAlg = TPM_ALG_SHA256;
+#ifdef WOLFTPM_MCHP
+    /* workaround for issue with both sign and decrypt being set */
     cmdIn.create.inPublic.publicArea.objectAttributes = (
         TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
         TPMA_OBJECT_noDA | TPMA_OBJECT_decrypt);
+#else
+    cmdIn.create.inPublic.publicArea.objectAttributes = (
+        TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
+        TPMA_OBJECT_noDA | TPMA_OBJECT_sign | TPMA_OBJECT_decrypt);
+#endif
     cmdIn.create.inPublic.publicArea.parameters.symDetail.sym.algorithm = TPM_ALG_AES;
     cmdIn.create.inPublic.publicArea.parameters.symDetail.sym.keyBits.aes = MAX_AES_KEY_BITS;
     cmdIn.create.inPublic.publicArea.parameters.symDetail.sym.mode.aes = TEST_AES_MODE;
@@ -1214,7 +1229,11 @@ int TPM2_Native_Test(void* userCtx)
     XMEMCPY(cmdIn.encDec.inData.buffer, message.buffer, cmdIn.encDec.inData.size);
     cmdIn.encDec.decrypt = NO;
     cmdIn.encDec.mode = TEST_AES_MODE;
+#ifdef WOLFTPM_MCHP
+    rc = TPM2_EncryptDecrypt(&cmdIn.encDec, &cmdOut.encDec);
+#else
     rc = TPM2_EncryptDecrypt2(&cmdIn.encDec, &cmdOut.encDec);
+#endif
     if (rc == TPM_RC_COMMAND_CODE) { /* some TPM's may not support command */
         printf("TPM2_EncryptDecrypt2: Is not a supported feature without enabling due to export controls\n");
     }
@@ -1233,7 +1252,11 @@ int TPM2_Native_Test(void* userCtx)
         cmdOut.encDec.outData.size);
     cmdIn.encDec.decrypt = YES;
     cmdIn.encDec.mode = TEST_AES_MODE;
+#ifdef WOLFTPM_MCHP
+    rc = TPM2_EncryptDecrypt(&cmdIn.encDec, &cmdOut.encDec);
+#else
     rc = TPM2_EncryptDecrypt2(&cmdIn.encDec, &cmdOut.encDec);
+#endif
     if (rc == TPM_RC_COMMAND_CODE) { /* some TPM's may not support command */
         printf("TPM2_EncryptDecrypt2: Is not a supported feature without enabling due to export controls\n");
     }

--- a/examples/tpm_io.c
+++ b/examples/tpm_io.c
@@ -55,7 +55,14 @@
         #define TPM2_I2C_DEV  "/dev/i2c-1"
     #else
         /* SPI */
-        #ifdef WOLFTPM_ST33
+        #ifdef WOLFTPM_MCHP
+            /* SPI uses CE0 */
+            #define TPM2_SPI_DEV "/dev/spidev0.0"
+            #ifndef WOLFTPM_CHECK_WAIT_STATE
+                #define WOLFTPM_CHECK_WAIT_STATE
+            #endif
+
+        #elif defined(WOLFTPM_ST33)
             /* ST33HTPH SPI uses CE0 */
             #define TPM2_SPI_DEV "/dev/spidev0.0"
 

--- a/examples/tpm_io.c
+++ b/examples/tpm_io.c
@@ -56,8 +56,10 @@
     #else
         /* SPI */
         #ifdef WOLFTPM_MCHP
+            /* Microchip ATTPM20 */
             /* SPI uses CE0 */
             #define TPM2_SPI_DEV "/dev/spidev0.0"
+            /* Requires SPI wait states */
             #ifndef WOLFTPM_CHECK_WAIT_STATE
                 #define WOLFTPM_CHECK_WAIT_STATE
             #endif
@@ -193,8 +195,8 @@
         int timeout = TPM_SPI_WAIT_RETRY;
     #endif
 
-        /* 1Mhz - PI has issue with 5-10Mhz on packets sized over 130 */
-        unsigned int maxSpeed = 1000000;
+        /* 33Mhz - PI has issue with 5-10Mhz on packets sized over 130 */
+        unsigned int maxSpeed = 33000000; /* ST=33, INF=43, MCHP=36 */
         int mode = 0; /* mode 0 */
         int bits_per_word = 8; /* 8-bits */
 

--- a/examples/tpm_test.h
+++ b/examples/tpm_test.h
@@ -45,6 +45,13 @@ static const char gUsageAuth[] =      "ThisIsASecretUsageAuth";
     #define TEST_AES_MODE TPM_ALG_CBC
 #endif
 
+#ifdef WOLFTPM_MCHP
+    /* workaround due to issue with older firmware */
+    #define TEST_WRAP_DIGEST TPM_ALG_SHA1
+#else
+    #define TEST_WRAP_DIGEST TPM_ALG_SHA256
+#endif
+
 
 /* RAW KEY MATERIAL */
 

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -327,6 +327,7 @@ int TPM2_Wrapper_Test(void* userCtx)
         TPMA_OBJECT_sign | TPMA_OBJECT_noDA,
         TPM_ECC_NIST_P256, TPM_ALG_ECDSA);
     if (rc != 0) goto exit;
+    publicTemplate.nameAlg = TPM_ALG_SHA256; /* make sure its SHA256 */
     rc = wolfTPM2_CreateAndLoadKey(&dev, &eccKey, &storageKey.handle,
         &publicTemplate, (byte*)gKeyAuth, sizeof(gKeyAuth)-1);
     if (rc != 0) goto exit;
@@ -355,6 +356,7 @@ int TPM2_Wrapper_Test(void* userCtx)
         TPMA_OBJECT_decrypt | TPMA_OBJECT_noDA,
         TPM_ECC_NIST_P256, TPM_ALG_ECDH);
     if (rc != 0) goto exit;
+    publicTemplate.nameAlg = TPM_ALG_SHA256; /* make sure its SHA256 */
     rc = wolfTPM2_CreateAndLoadKey(&dev, &eccKey, &storageKey.handle,
         &publicTemplate, (byte*)gKeyAuth, sizeof(gKeyAuth)-1);
     if (rc != 0) goto exit;
@@ -551,7 +553,7 @@ int TPM2_Wrapper_Test(void* userCtx)
     /* ENCRYPT/DECRYPT TESTS */
     /*------------------------------------------------------------------------*/
     rc = wolfTPM2_GetKeyTemplate_Symmetric(&publicTemplate, 128, TEST_AES_MODE,
-        YES, YES);
+        NO, YES);
     if (rc != 0) goto exit;
     rc = wolfTPM2_CreateAndLoadKey(&dev, &aesKey, &storageKey.handle,
         &publicTemplate, (byte*)gUsageAuth, sizeof(gUsageAuth)-1);

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -553,7 +553,7 @@ int TPM2_Wrapper_Test(void* userCtx)
     /* ENCRYPT/DECRYPT TESTS */
     /*------------------------------------------------------------------------*/
     rc = wolfTPM2_GetKeyTemplate_Symmetric(&publicTemplate, 128, TEST_AES_MODE,
-        NO, YES);
+        YES, YES);
     if (rc != 0) goto exit;
     rc = wolfTPM2_CreateAndLoadKey(&dev, &aesKey, &storageKey.handle,
         &publicTemplate, (byte*)gUsageAuth, sizeof(gUsageAuth)-1);

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -125,6 +125,9 @@ static int wolfTPM2_ParseCapabilities(WOLFTPM2_CAPS* caps,
                 else if (XMEMCMP(&caps->mfgStr, "STM", 3) == 0) {
                     caps->mfg = TPM_MFG_STM;
                 }
+                else if (XMEMCMP(&caps->mfgStr, "MCHP", 4) == 0) {
+                    caps->mfg = TPM_MFG_MCHP;
+                }
                 break;
             case TPM_PT_VENDOR_STRING_1:
             case TPM_PT_VENDOR_STRING_2:

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -64,6 +64,7 @@ typedef enum WOLFTPM2_MFG {
     TPM_MFG_UNKNOWN = 0,
     TPM_MFG_INFINEON,
     TPM_MFG_STM,
+    TPM_MFG_MCHP,
 } WOLFTPM2_MFG;
 typedef struct WOLFTPM2_CAPS {
     WOLFTPM2_MFG mfg;


### PR DESCRIPTION
Initial support for ATTPM20.
Adds `./configure --enable-mchp` build option.

Known issues that we have implemented workarounds for:
1. The default algorithm for PCR is SHA1.
2. The symmetric key creation object attributes cannot have sign and decrypt set.
3. The TPM2_EncryptDecrypt2 is not implemented, but TPM2_EncryptDecrypt is.