### PR TITLE
Fixes and improvements for TLS examples and Crypto Callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ examples/tls/tls_client
 examples/pkcs7/pkcs7
 pkcs7tpmsigned.p7s
 examples/tls/tls_server
+examples/tls/tls_client_notpm
 
 # Generated Cert Files
 certs/ca-*.pem

--- a/examples/bench/bench.c
+++ b/examples/bench/bench.c
@@ -25,7 +25,7 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 
-#ifndef WOLFTPM2_NO_WRAPPER
+#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(NO_TPM_BENCH)
 
 #include <examples/tpm_io.h>
 #include <examples/tpm_test.h>
@@ -36,26 +36,16 @@
 #define TPM2_BENCH_DURATION_KEYGEN_SEC  15
 static int gUseBase2 = 1;
 
-#include <sys/time.h>
-
-static double current_time(int reset)
-{
-    struct timeval tv;
-    (void)reset;
-    gettimeofday(&tv, 0);
-    return (double)tv.tv_sec + (double)tv.tv_usec / 1000000;
-}
-
 static inline void bench_stats_start(int* count, double* start)
 {
     *count = 0;
-    *start = current_time(1);
+    *start = gettime_secs(1);
 }
 
 static inline int bench_stats_check(double start, int* count, double maxDurSec)
 {
     (*count)++;
-    return ((current_time(0) - start) < maxDurSec);
+    return ((gettime_secs(0) - start) < maxDurSec);
 }
 
 /* countSz is number of bytes that 1 count represents. Normally bench_size,
@@ -66,7 +56,7 @@ static void bench_stats_sym_finish(const char* desc, int count, int countSz,
     double total, persec = 0, blocks = count;
     const char* blockType;
 
-    total = current_time(0) - start;
+    total = gettime_secs(0) - start;
 
     /* calculate actual bytes */
     blocks *= countSz;
@@ -117,7 +107,7 @@ static void bench_stats_asym_finish(const char* algo, int strength,
 {
     double total, each = 0, opsSec, milliEach;
 
-    total = current_time(0) - start;
+    total = gettime_secs(0) - start;
     if (count > 0)
         each  = total / count; /* per second  */
     opsSec = count / total;    /* ops second */
@@ -460,14 +450,14 @@ exit:
 /* --- END Bench Wrapper -- */
 /******************************************************************************/
 
-#endif /* !WOLFTPM2_NO_WRAPPER */
+#endif /* !WOLFTPM2_NO_WRAPPER && !NO_TPM_BENCH */
 
 #ifndef NO_MAIN_DRIVER
 int main(void)
 {
     int rc = -1;
 
-#ifndef WOLFTPM2_NO_WRAPPER
+#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(NO_TPM_BENCH)
     rc = TPM2_Wrapper_Bench(NULL);
 #else
     printf("Wrapper code not compiled in\n");

--- a/examples/tls/include.am
+++ b/examples/tls/include.am
@@ -10,6 +10,14 @@ examples_tls_tls_client_SOURCES      = examples/tls/tls_client.c \
 examples_tls_tls_client_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_tls_tls_client_DEPENDENCIES = src/libwolftpm.la
 
+noinst_PROGRAMS += examples/tls/tls_client_notpm
+noinst_HEADERS  += examples/tls/tls_client.h \
+                   examples/tls/tls_common.h
+examples_tls_tls_client_notpm_SOURCES      = examples/tls/tls_client_notpm.c \
+									   examples/tpm_io.c
+examples_tls_tls_client_notpm_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
+examples_tls_tls_client_notpm_DEPENDENCIES = src/libwolftpm.la
+
 noinst_PROGRAMS += examples/tls/tls_server
 noinst_HEADERS  += examples/tls/tls_server.h \
                    examples/tls/tls_common.h

--- a/examples/tls/tls_client.c
+++ b/examples/tls/tls_client.c
@@ -394,9 +394,11 @@ int TPM2_TLS_Client(void* userCtx)
         }
     } while (rc == WOLFSSL_ERROR_WANT_WRITE);
 #ifdef TLS_BENCH_MODE
-    start = gettime_secs(0) - start;
-    printf("Write: %d bytes in %9.3f sec (%9.3f KB/sec)\n",
-        rc, start, rc / start / 1024);
+    if (rc >= 0) {
+        start = gettime_secs(0) - start;
+        printf("Write: %d bytes in %9.3f sec (%9.3f KB/sec)\n",
+            rc, start, rc / start / 1024);
+    }
 #endif
 
     /* perform read */
@@ -410,9 +412,11 @@ int TPM2_TLS_Client(void* userCtx)
         }
     } while (rc == WOLFSSL_ERROR_WANT_READ);
 #ifdef TLS_BENCH_MODE
-    start = gettime_secs(0) - start;
-    printf("Read: %d bytes in %9.3f sec (%9.3f KB/sec)\n",
-        rc, start, rc / start / 1024);
+    if (rc >= 0) {
+        start = gettime_secs(0) - start;
+        printf("Read: %d bytes in %9.3f sec (%9.3f KB/sec)\n",
+            rc, start, rc / start / 1024);
+    }
 #else
     if (rc >= 0) {
         /* null terminate */

--- a/examples/tls/tls_client.c
+++ b/examples/tls/tls_client.c
@@ -34,6 +34,12 @@
 
 #include <wolfssl/ssl.h>
 
+#undef  USE_CERT_BUFFERS_2048
+#define USE_CERT_BUFFERS_2048
+#undef  USE_CERT_BUFFERS_256
+#define USE_CERT_BUFFERS_256
+#include <wolfssl/certs_test.h>
+
 /*
  * Generating the Client Certificate
  *
@@ -232,10 +238,19 @@ int TPM2_TLS_Client(void* userCtx)
 #else
     wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER, myVerify);
 #ifdef NO_FILESYSTEM
-    /* example loading from buffer */
-    #if 0
-        if (wolfSSL_CTX_load_verify(ctx, ca.buffer, (long)ca.size,
-            WOLFSSL_FILETYPE_ASN1) != WOLFSSL_SUCCESS) }
+    /* Load CA Certificates from Buffer */
+    #if !defined(NO_RSA) && !defined(TLS_USE_ECC)
+        if (wolfSSL_CTX_load_verify_buffer(ctx,
+                ca_cert_der_2048, sizeof_ca_cert_der_2048,
+                WOLFSSL_FILETYPE_ASN1) != WOLFSSL_SUCCESS) {
+            printf("Error loading ca_cert_der_2048 DER cert\n");
+            goto exit;
+        }
+    #elif defined(HAVE_ECC)
+        if (wolfSSL_CTX_load_verify_buffer(ctx,
+                ca_ecc_cert_der_256, sizeof_ca_ecc_cert_der_256,
+                WOLFSSL_FILETYPE_ASN1) != WOLFSSL_SUCCESS) {
+            printf("Error loading ca_ecc_cert_der_256 DER cert\n");
             goto exit;
         }
     #endif

--- a/examples/tls/tls_client.h
+++ b/examples/tls/tls_client.h
@@ -24,5 +24,6 @@
 
 
 int TPM2_TLS_Client(void* userCtx);
+int TLS_Client(void);
 
 #endif /* _TPM_TLS_CLIENT_H_ */

--- a/examples/tls/tls_client_notpm.c
+++ b/examples/tls/tls_client_notpm.c
@@ -50,12 +50,8 @@
  * These can be overriden using `TLS_HOST` and `TLS_PORT`.
  *
  * You can validate using the wolfSSL example server this like:
- *   ./examples/server/server -b -p 11111 -g -d
+ *   ./examples/server/server -b -p 11111 -g
  *
- * To validate client certificate add the following wolfSSL example server args:
- * ./examples/server/server -b -p 11111 -g -A ./certs/tpm-ca-rsa-cert.pem
- * or
- * ./examples/server/server -b -p 11111 -g -A ./certs/tpm-ca-ecc-cert.pem
  * If using an ECDSA cipher suite add:
  * "-l ECDHE-ECDSA-AES128-SHA -c ./certs/server-ecc.pem -k ./certs/ecc-key.pem"
  */

--- a/examples/tls/tls_client_notpm.c
+++ b/examples/tls/tls_client_notpm.c
@@ -1,0 +1,317 @@
+/* tls_client_notpm.c
+ *
+ * Copyright (C) 2006-2018 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+
+#include <wolftpm/tpm2.h>
+#include <wolftpm/tpm2_wrap.h>
+
+#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
+    !defined(NO_WOLFSSL_CLIENT)
+
+#include <examples/tpm_io.h>
+#include <examples/tpm_test.h>
+#include <examples/tls/tls_common.h>
+#include <examples/tls/tls_client.h>
+
+#include <wolfssl/ssl.h>
+
+#undef  USE_CERT_BUFFERS_2048
+#define USE_CERT_BUFFERS_2048
+#undef  USE_CERT_BUFFERS_256
+#define USE_CERT_BUFFERS_256
+#include <wolfssl/certs_test.h>
+
+#ifdef TLS_BENCH_MODE
+    double benchStart;
+#endif
+
+/******************************************************************************/
+/* --- BEGIN TLS Client Example -- */
+/******************************************************************************/
+int TLS_Client(void)
+{
+    int rc = 0;
+    SockIoCbCtx sockIoCtx;
+    WOLFSSL_CTX* ctx = NULL;
+    WOLFSSL* ssl = NULL;
+#ifndef TLS_BENCH_MODE
+    const char webServerMsg[] = "GET /index.html HTTP/1.0\r\n\r\n";
+#endif
+    char msg[MAX_MSG_SZ];
+    int msgSz = 0;
+    int total_size;
+#ifdef TLS_BENCH_MODE
+    int i;
+#endif
+
+    /* initialize variables */
+    XMEMSET(&sockIoCtx, 0, sizeof(sockIoCtx));
+    sockIoCtx.fd = -1;
+
+    printf("TLS Client Example\n");
+
+    /* Setup the WOLFSSL context (factory) */
+    if ((ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method())) == NULL) {
+        rc = MEMORY_E; goto exit;
+    }
+
+    /* Setup IO Callbacks */
+    wolfSSL_CTX_SetIORecv(ctx, SockIORecv);
+    wolfSSL_CTX_SetIOSend(ctx, SockIOSend);
+
+    /* Server certificate validation */
+#if 0
+    /* skip server cert validation for this test */
+    wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, myVerify);
+#else
+    wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER, myVerify);
+
+#ifdef NO_FILESYSTEM
+    /* Load CA Certificates from Buffer */
+	#if !defined(NO_RSA) && !defined(TLS_USE_ECC)
+    	if (wolfSSL_CTX_load_verify_buffer(ctx,
+                ca_cert_der_2048, sizeof_ca_cert_der_2048,
+                WOLFSSL_FILETYPE_ASN1) != WOLFSSL_SUCCESS) {
+			printf("Error loading ca_cert_der_2048 DER cert\n");
+			goto exit;
+		}
+	#elif defined(HAVE_ECC)
+    	if (wolfSSL_CTX_load_verify_buffer(ctx,
+                ca_ecc_cert_der_256, sizeof_ca_ecc_cert_der_256,
+                WOLFSSL_FILETYPE_ASN1) != WOLFSSL_SUCCESS) {
+			printf("Error loading ca_ecc_cert_der_256 DER cert\n");
+			goto exit;
+		}
+	#endif
+#else
+    /* Load CA Certificates */
+    #if !defined(NO_RSA) && !defined(TLS_USE_ECC)
+    if (wolfSSL_CTX_load_verify_locations(ctx, "./certs/ca-cert.pem",
+        0) != WOLFSSL_SUCCESS) {
+        printf("Error loading ./certs/ca-cert.pem cert\n");
+        goto exit;
+    }
+    #elif defined(HAVE_ECC)
+    if (wolfSSL_CTX_load_verify_locations(ctx, "./certs/ca-ecc-cert.pem",
+        0) != WOLFSSL_SUCCESS) {
+        printf("Error loading ./certs/ca-ecc-cert.pem cert\n");
+        goto exit;
+    }
+    #endif
+#endif /* !NO_FILESYSTEM */
+#endif
+
+#ifndef NO_TLS_MUTUAL_AUTH
+#ifdef NO_FILESYSTEM
+    /* Client Certificate and Key using buffer */
+    #if !defined(NO_RSA) && !defined(TLS_USE_ECC)
+        if (wolfSSL_CTX_use_certificate_buffer(ctx,
+                client_cert_der_2048, sizeof_client_cert_der_2048,
+                WOLFSSL_FILETYPE_ASN1) != WOLFSSL_SUCCESS) {
+            goto exit;
+        }
+        if (wolfSSL_CTX_use_PrivateKey_buffer(ctx,
+                client_key_der_2048, sizeof_client_key_der_2048,
+                WOLFSSL_FILETYPE_ASN1) != WOLFSSL_SUCCESS) {
+            goto exit;
+        }
+    #elif defined(HAVE_ECC)
+        if (wolfSSL_CTX_use_certificate_buffer(ctx,
+                cliecc_cert_der_256, sizeof_cliecc_cert_der_256,
+                WOLFSSL_FILETYPE_ASN1) != WOLFSSL_SUCCESS) {
+            goto exit;
+        }
+        if (wolfSSL_CTX_use_PrivateKey_buffer(ctx,
+                ecc_clikey_der_256, sizeof_ecc_clikey_der_256,
+                WOLFSSL_FILETYPE_ASN1) != WOLFSSL_SUCCESS) {
+            goto exit;
+        }
+    #endif
+#else
+    /* Client certificate and key (mutual auth) */
+    #if !defined(NO_RSA) && !defined(TLS_USE_ECC)
+    if ((rc = wolfSSL_CTX_use_certificate_file(ctx, "./certs/client-cert.pem",
+        WOLFSSL_FILETYPE_PEM)) != WOLFSSL_SUCCESS) {
+        printf("Error loading ./certs/client-cert.pem RSA client cert\n");
+        goto exit;
+    }
+    if (wolfSSL_CTX_use_PrivateKey_file(ctx, "./certs/client-key.pem",
+        WOLFSSL_FILETYPE_PEM) != WOLFSSL_SUCCESS) {
+        printf("Error loading ./certs/client-key.pem RSA client key\n");
+        goto exit;
+    }
+    #elif defined(HAVE_ECC)
+    if ((rc = wolfSSL_CTX_use_certificate_file(ctx, "./certs/client-ecc-cert.pem",
+        WOLFSSL_FILETYPE_PEM)) != WOLFSSL_SUCCESS) {
+        printf("Error loading ./certs/client-ecc-cert.pem ECC client cert\n");
+        goto exit;
+    }
+    if (wolfSSL_CTX_use_PrivateKey_file(ctx, "./certs/ecc-client-key.pem",
+        WOLFSSL_FILETYPE_PEM) != WOLFSSL_SUCCESS) {
+        printf("Error loading ./certs/ecc-client-key.pem ECC client key\n");
+        goto exit;
+    }
+    #endif
+#endif /* !NO_FILESYSTEM */
+#endif /* !NO_TLS_MUTUAL_AUTH */
+
+#ifdef TLS_CIPHER_SUITE
+    /* Optionally choose the cipher suite */
+    rc = wolfSSL_CTX_set_cipher_list(ctx, TLS_CIPHER_SUITE);
+    if (rc != WOLFSSL_SUCCESS) {
+        goto exit;
+    }
+#endif
+
+    /* Create wolfSSL object/session */
+    if ((ssl = wolfSSL_new(ctx)) == NULL) {
+        rc = wolfSSL_get_error(ssl, 0);
+        goto exit;
+    }
+
+    /* Setup socket and connection */
+    rc = SetupSocketAndConnect(&sockIoCtx, TLS_HOST, TLS_PORT);
+    if (rc != 0) goto exit;
+
+    /* Setup read/write callback contexts */
+    wolfSSL_SetIOReadCtx(ssl, &sockIoCtx);
+    wolfSSL_SetIOWriteCtx(ssl, &sockIoCtx);
+
+    /* perform connect */
+#ifdef TLS_BENCH_MODE
+    benchStart = gettime_secs(1);
+#endif
+    do {
+        rc = wolfSSL_connect(ssl);
+        if (rc != WOLFSSL_SUCCESS) {
+            rc = wolfSSL_get_error(ssl, 0);
+        }
+    } while (rc == WOLFSSL_ERROR_WANT_READ || rc == WOLFSSL_ERROR_WANT_WRITE);
+    if (rc != WOLFSSL_SUCCESS) {
+        goto exit;
+    }
+#ifdef TLS_BENCH_MODE
+    benchStart = gettime_secs(0) - benchStart;
+    printf("Connect: %9.3f sec (%9.3f CPS)\n", benchStart, 1/benchStart);
+#endif
+
+    printf("Cipher Suite: %s\n", wolfSSL_get_cipher(ssl));
+
+    rc = 0;
+    total_size = 0;
+    while (rc == 0 && total_size < TOTAL_MSG_SZ) {
+        /* initialize write */
+    #ifdef TLS_BENCH_MODE
+        msgSz = sizeof(msg); /* sequence */
+        for (i=0; i<msgSz; i++) {
+            msg[i] = (i & 0xff);
+        }
+    #else
+        msgSz = sizeof(webServerMsg);
+        XMEMCPY(msg, webServerMsg, msgSz);
+        printf("Write (%d): %s\n", msgSz, msg);
+    #endif
+        total_size += msgSz;
+
+        /* perform write */
+    #ifdef TLS_BENCH_MODE
+        benchStart = gettime_secs(1);
+    #endif
+        do {
+            rc = wolfSSL_write(ssl, msg, msgSz);
+            if (rc != msgSz) {
+                rc = wolfSSL_get_error(ssl, 0);
+            }
+        } while (rc == WOLFSSL_ERROR_WANT_WRITE);
+    #ifdef TLS_BENCH_MODE
+        if (rc >= 0) {
+            benchStart = gettime_secs(0) - benchStart;
+            printf("Write: %d bytes in %9.3f sec (%9.3f KB/sec)\n",
+                rc, benchStart, rc / benchStart / 1024);
+        }
+    #endif
+
+        /* perform read */
+    #ifdef TLS_BENCH_MODE
+        benchStart = 0; /* use the read callback to trigger timing */
+    #endif
+        do {
+            rc = wolfSSL_read(ssl, msg, sizeof(msg));
+            if (rc < 0) {
+                rc = wolfSSL_get_error(ssl, 0);
+            }
+        } while (rc == WOLFSSL_ERROR_WANT_READ);
+    #ifdef TLS_BENCH_MODE
+        if (rc >= 0) {
+            benchStart = gettime_secs(0) - benchStart;
+            printf("Read: %d bytes in %9.3f sec (%9.3f KB/sec)\n",
+                rc, benchStart, rc / benchStart / 1024);
+        }
+    #else
+        if (rc >= 0) {
+            /* null terminate */
+            msgSz = rc;
+            if (msgSz >= (int)sizeof(msg))
+                msgSz = (int)sizeof(msg) - 1;
+            msg[msgSz] = '\0';
+            rc = 0; /* success */
+        }
+        printf("Read (%d): %s\n", msgSz, msg);
+    #endif
+        rc = 0; /* success */
+    }
+
+exit:
+
+    if (rc != 0) {
+        printf("Failure %d (0x%x): %s\n", rc, rc, wolfSSL_ERR_reason_error_string(rc));
+    }
+
+    wolfSSL_shutdown(ssl);
+
+    CloseAndCleanupSocket(&sockIoCtx);
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+
+    return rc;
+}
+
+/******************************************************************************/
+/* --- END TLS Client Example -- */
+/******************************************************************************/
+#endif /* !WOLFTPM2_NO_WRAPPER && !WOLFTPM2_NO_WOLFCRYPT && !NO_WOLFSSL_CLIENT */
+
+
+#ifndef NO_MAIN_DRIVER
+int main(void)
+{
+    int rc = -1;
+
+#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
+    !defined(NO_WOLFSSL_CLIENT)
+    rc = TLS_Client();
+#else
+    printf("WolfSSL Client code not compiled in\n");
+#endif
+
+    return rc;
+}
+#endif /* !NO_MAIN_DRIVER */

--- a/examples/tls/tls_common.h
+++ b/examples/tls/tls_common.h
@@ -36,7 +36,7 @@
 
 /* TLS Configuration */
 #ifndef TLS_HOST
-    #define TLS_HOST "192.168.0.10"
+    #define TLS_HOST "localhost"
 #endif
 #ifndef TLS_PORT
     #define TLS_PORT 11111
@@ -50,7 +50,7 @@
 #endif
 
 /* force use of a TLS cipher suite */
-#if 1
+#if 0
     #ifndef TLS_CIPHER_SUITE
         #define TLS_CIPHER_SUITE "ECDHE-RSA-AES128-SHA256"
     #endif

--- a/examples/tls/tls_common.h
+++ b/examples/tls/tls_common.h
@@ -65,7 +65,7 @@
 #endif
 
 /* enable benchmarking mode */
-#if 0
+#ifndef NO_TPM_BENCH
     #define TLS_BENCH_MODE
 #endif
 
@@ -314,22 +314,6 @@ static inline void CloseAndCleanupSocket(SockIoCbCtx* sockIoCtx)
 /******************************************************************************/
 /* --- BEGIN Supporting TLS functions --- */
 /******************************************************************************/
-
-#ifdef TLS_BENCH_MODE
-    #include <sys/time.h>
-    static inline double gettime_secs(int reset)
-    {
-    #ifdef XTIME
-    	extern double current_time(int reset);
-        return current_time(reset);
-    #else
-        struct timeval tv;
-        gettimeofday(&tv, 0);
-        (void)reset;
-        return (double)tv.tv_sec + (double)tv.tv_usec / 1000000;
-    #endif
-    }
-#endif
 
 static inline int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
 {

--- a/examples/tls/tls_common.h
+++ b/examples/tls/tls_common.h
@@ -25,9 +25,7 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 
-#if !defined(WOLFTPM2_NO_WRAPPER) && \
-    (defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB)) && \
-    !defined(WOLFTPM2_NO_WOLFCRYPT)
+#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT)
 
 #include <examples/tpm_io.h>
 #include <examples/tpm_test.h>
@@ -38,18 +36,21 @@
 
 /* TLS Configuration */
 #ifndef TLS_HOST
-    #define TLS_HOST "localhost"
+    #define TLS_HOST "192.168.0.10"
 #endif
 #ifndef TLS_PORT
     #define TLS_PORT 11111
 #endif
 
 #ifndef MAX_MSG_SZ
-    #define MAX_MSG_SZ (1 * 1024)
+    #define MAX_MSG_SZ   (1 * 1024)
+#endif
+#ifndef TOTAL_MSG_SZ
+    #define TOTAL_MSG_SZ (16 * 1024)
 #endif
 
 /* force use of a TLS cipher suite */
-#if 0
+#if 1
     #ifndef TLS_CIPHER_SUITE
         #define TLS_CIPHER_SUITE "ECDHE-RSA-AES128-SHA256"
     #endif
@@ -65,11 +66,10 @@
 #endif
 
 /* enable benchmarking mode */
-#ifndef NO_TPM_BENCH
+#if 0
     #define TLS_BENCH_MODE
+    extern double benchStart;
 #endif
-
-
 
 
 /******************************************************************************/
@@ -80,7 +80,6 @@ typedef struct SockIoCbCtx {
     int listenFd;
     int fd;
 } SockIoCbCtx;
-
 
 #ifndef WOLFSSL_USER_IO
 /* socket includes */
@@ -100,34 +99,34 @@ static inline int SockIORecv(WOLFSSL* ssl, char* buff, int sz, void* ctx)
     if ((recvd = (int)recv(sockCtx->fd, buff, sz, 0)) == -1) {
         /* error encountered. Be responsible and report it in wolfSSL terms */
 
-        fprintf(stderr, "IO RECEIVE ERROR: ");
+        printf("IO RECEIVE ERROR: ");
         switch (errno) {
     #if EAGAIN != EWOULDBLOCK
         case EAGAIN: /* EAGAIN == EWOULDBLOCK on some systems, but not others */
     #endif
         case EWOULDBLOCK:
             if (wolfSSL_get_using_nonblock(ssl)) {
-                fprintf(stderr, "would block\n");
+                printf("would block\n");
                 return WOLFSSL_CBIO_ERR_WANT_READ;
             }
             else {
-                fprintf(stderr, "socket timeout\n");
+                printf("socket timeout\n");
                 return WOLFSSL_CBIO_ERR_TIMEOUT;
             }
         case ECONNRESET:
-            fprintf(stderr, "connection reset\n");
+            printf("connection reset\n");
             return WOLFSSL_CBIO_ERR_CONN_RST;
         case EINTR:
-            fprintf(stderr, "socket interrupted\n");
+            printf("socket interrupted\n");
             return WOLFSSL_CBIO_ERR_ISR;
         case ECONNREFUSED:
-            fprintf(stderr, "connection refused\n");
+            printf("connection refused\n");
             return WOLFSSL_CBIO_ERR_WANT_READ;
         case ECONNABORTED:
-            fprintf(stderr, "connection aborted\n");
+            printf("connection aborted\n");
             return WOLFSSL_CBIO_ERR_CONN_CLOSE;
         default:
-            fprintf(stderr, "general error\n");
+            printf("general error\n");
             return WOLFSSL_CBIO_ERR_GENERAL;
         }
     }
@@ -135,6 +134,12 @@ static inline int SockIORecv(WOLFSSL* ssl, char* buff, int sz, void* ctx)
         printf("Connection closed\n");
         return WOLFSSL_CBIO_ERR_CONN_CLOSE;
     }
+
+#ifdef TLS_BENCH_MODE
+    if (benchStart == 0.0) {
+        benchStart = gettime_secs(1);
+    }
+#endif
 
 #ifdef DEBUG_WOLFTPM
     /* successful receive */
@@ -155,25 +160,25 @@ static inline int SockIOSend(WOLFSSL* ssl, char* buff, int sz, void* ctx)
     if ((sent = (int)send(sockCtx->fd, buff, sz, 0)) == -1) {
         /* error encountered. Be responsible and report it in wolfSSL terms */
 
-        fprintf(stderr, "IO SEND ERROR: ");
+        printf("IO SEND ERROR: ");
         switch (errno) {
     #if EAGAIN != EWOULDBLOCK
         case EAGAIN: /* EAGAIN == EWOULDBLOCK on some systems, but not others */
     #endif
         case EWOULDBLOCK:
-            fprintf(stderr, "would block\n");
+            printf("would block\n");
             return WOLFSSL_CBIO_ERR_WANT_READ;
         case ECONNRESET:
-            fprintf(stderr, "connection reset\n");
+            printf("connection reset\n");
             return WOLFSSL_CBIO_ERR_CONN_RST;
         case EINTR:
-            fprintf(stderr, "socket interrupted\n");
+            printf("socket interrupted\n");
             return WOLFSSL_CBIO_ERR_ISR;
         case EPIPE:
-            fprintf(stderr, "socket EPIPE\n");
+            printf("socket EPIPE\n");
             return WOLFSSL_CBIO_ERR_CONN_CLOSE;
         default:
-            fprintf(stderr, "general error\n");
+            printf("general error\n");
             return WOLFSSL_CBIO_ERR_GENERAL;
         }
     }
@@ -205,7 +210,7 @@ static inline int SetupSocketAndListen(SockIoCbCtx* sockIoCtx, word32 port)
      * Sets the socket to be stream based (TCP),
      * 0 means choose the default protocol. */
     if ((sockIoCtx->listenFd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
-        fprintf(stderr, "ERROR: failed to create the socket\n");
+        printf("ERROR: failed to create the socket\n");
         return -1;
     }
 
@@ -218,12 +223,12 @@ static inline int SetupSocketAndListen(SockIoCbCtx* sockIoCtx, word32 port)
     /* Connect to the server */
     if (bind(sockIoCtx->listenFd, (struct sockaddr*)&servAddr,
                                                     sizeof(servAddr)) == -1) {
-        fprintf(stderr, "ERROR: failed to bind\n");
+        printf("ERROR: failed to bind\n");
         return -1;
     }
 
     if (listen(sockIoCtx->listenFd, 5) != 0) {
-        fprintf(stderr, "ERROR: failed to listen\n");
+        printf("ERROR: failed to listen\n");
         return -1;
     }
 
@@ -237,7 +242,7 @@ static inline int SocketWaitClient(SockIoCbCtx* sockIoCtx)
     socklen_t          size = sizeof(clientAddr);
 
     if ((connd = accept(sockIoCtx->listenFd, (struct sockaddr*)&clientAddr, &size)) == -1) {
-        fprintf(stderr, "ERROR: failed to accept the connection\n\n");
+        printf("ERROR: failed to accept the connection\n\n");
         return -1;
     }
     sockIoCtx->fd = connd;
@@ -269,14 +274,14 @@ static inline int SetupSocketAndConnect(SockIoCbCtx* sockIoCtx, const char* host
      * Sets the socket to be stream based (TCP),
      * 0 means choose the default protocol. */
     if ((sockIoCtx->fd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
-        fprintf(stderr, "ERROR: failed to create the socket\n");
+        printf("ERROR: failed to create the socket\n");
         return -1;
     }
 
     /* Connect to the server */
     if (connect(sockIoCtx->fd, (struct sockaddr*)&servAddr,
                                                     sizeof(servAddr)) == -1) {
-        fprintf(stderr, "ERROR: failed to connect\n");
+        printf("ERROR: failed to connect\n");
         return -1;
     }
 
@@ -347,6 +352,7 @@ static inline int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
     return 1;
 }
 
+#if defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB)
 /* Function checks key to see if its the "dummy" key */
 static inline int myTpmCheckKey(wc_CryptoInfo* info, TpmCryptoDevCtx* ctx)
 {
@@ -424,11 +430,12 @@ static inline int myTpmCheckKey(wc_CryptoInfo* info, TpmCryptoDevCtx* ctx)
         provided TPM handle will be used, not the wolf public key info */
     return ret;
 }
+#endif /* WOLF_CRYPTO_DEV || WOLF_CRYPTO_CB */
 
 /******************************************************************************/
 /* --- END Supporting TLS functions --- */
 /******************************************************************************/
 
-#endif /* !WOLFTPM2_NO_WRAPPER && WOLF_CRYPTO_DEV */
+#endif /* !WOLFTPM2_NO_WRAPPER && !WOLFTPM2_NO_WOLFCRYPT */
 
 #endif /* _TPM_TLS_COMMON_H_ */

--- a/examples/tpm_test.h
+++ b/examples/tpm_test.h
@@ -53,6 +53,25 @@ static const char gUsageAuth[] =      "ThisIsASecretUsageAuth";
 #endif
 
 
+#ifndef NO_TPM_BENCH
+    #ifndef WOLFSSL_USER_CURRTIME
+        #include <sys/time.h>
+    #endif
+    static inline double gettime_secs(int reset)
+    {
+    #ifdef WOLFSSL_USER_CURRTIME
+        extern double current_time(int reset);
+        return current_time(reset);
+    #else
+        struct timeval tv;
+        gettimeofday(&tv, 0);
+        (void)reset;
+        return (double)tv.tv_sec + (double)tv.tv_usec / 1000000;
+    #endif
+    }
+#endif /* !NO_TPM_BENCH */
+
+
 /* RAW KEY MATERIAL */
 
 /* from wolfSSL ./certs/client-key.der */

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -272,8 +272,16 @@ int wolfTPM2_Cleanup(WOLFTPM2_DEV* dev)
     int rc;
     Shutdown_In shutdownIn;
 
-    if (dev == NULL)
+    if (dev == NULL) {
         return BAD_FUNC_ARG;
+    }
+
+#if defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB)
+    /* make sure crypto dev callback is unregistered */
+    rc = wolfTPM2_ClearCryptoDevCb(dev, INVALID_DEVID);
+    if (rc != 0)
+    	return rc;
+#endif
 
     shutdownIn.shutdownType = TPM_SU_CLEAR;
     rc = TPM2_Shutdown(&shutdownIn);
@@ -3348,6 +3356,28 @@ int wolfTPM2_SetCryptoDevCb(WOLFTPM2_DEV* dev, CryptoDevCallbackFunc cb,
 
     if (pDevId) {
         *pDevId = devId;
+    }
+
+    return rc;
+}
+
+int wolfTPM2_ClearCryptoDevCb(WOLFTPM2_DEV* dev, int devId)
+{
+    int rc = 0;
+
+    if (dev == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* get device Id */
+    if (devId == INVALID_DEVID) {
+        rc = wolfTPM2_GetTpmDevId(dev);
+        if (rc >= 0) {
+            devId = rc;
+        }
+    }
+    if (devId != INVALID_DEVID) {
+        wc_CryptoCb_UnRegisterDevice(devId);
     }
 
     return rc;

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -276,7 +276,7 @@ int wolfTPM2_Cleanup(WOLFTPM2_DEV* dev)
         return BAD_FUNC_ARG;
     }
 
-#if defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB)
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && (defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB))
     /* make sure crypto dev callback is unregistered */
     rc = wolfTPM2_ClearCryptoDevCb(dev, INVALID_DEVID);
     if (rc != 0)
@@ -2242,6 +2242,7 @@ static int wolfTPM2_ComputeSymmetricUnique(WOLFTPM2_DEV* dev, int hashAlg,
         wc_HashFree(&hash, hashType);
     }
 #else
+    (void)hashAlg;
     rc = NOT_COMPILED_IN;
 #endif
 
@@ -2814,7 +2815,7 @@ int wolfTPM2_GetNvAttributesTemplate(TPM_HANDLE auth, word32* nvAttributes)
 /******************************************************************************/
 
 
-#if defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB)
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && (defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB))
 /******************************************************************************/
 /* --- BEGIN wolf Crypto Device Support -- */
 /******************************************************************************/
@@ -3387,7 +3388,7 @@ int wolfTPM2_ClearCryptoDevCb(WOLFTPM2_DEV* dev, int devId)
 /* --- END wolf Crypto Device Support -- */
 /******************************************************************************/
 
-#endif /* WOLF_CRYPTO_DEV */
+#endif /* !WOLFTPM2_NO_WOLFCRYPT && (WOLF_CRYPTO_DEV || WOLF_CRYPTO_CB) */
 
 
 #endif /* !WOLFTPM2_NO_WRAPPER */

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -222,6 +222,7 @@ typedef int64_t  INT64;
         #ifndef XTPM_WAIT_POLLING_US
             #define XTPM_WAIT_POLLING_US 10 /* 0.01ms */
         #endif
+        #include <unistd.h>
         #define XTPM_WAIT() usleep(XTPM_WAIT_POLLING_US);
     #endif
 #endif

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -289,6 +289,8 @@ typedef struct TpmCryptoDevCtx {
 WOLFTPM_API int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx);
 WOLFTPM_API int wolfTPM2_SetCryptoDevCb(WOLFTPM2_DEV* dev, CryptoDevCallbackFunc cb,
     TpmCryptoDevCtx* tpmCtx, int* pDevId);
+WOLFTPM_API int wolfTPM2_ClearCryptoDevCb(WOLFTPM2_DEV* dev, int devId);
+
 #endif /* WOLF_CRYPTO_CB */
 
 


### PR DESCRIPTION
* Fix to make sure the Crypto callback is unregistered on cleanup.
* Cleanup to combine benchmark time code and allow override using `WOLFSSL_USER_CURRTIME`. Benchmark modes can be disabled using `NO_TPM_BENCH`.
* Fix a few minor warnings.
* Enhancement to the TLS clients to support better throughput benchmarking. Improved the read elapsed time for more accurate RX benchmarking.
* Added a simple non-TPM TLS example that integrates with the wolfTPM environment.