### PR TITLE
wolfTPM v1.5 release preparation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,107 @@
+## Release Notes
+
+### wolfTPM Release 1.5 (02/20/2019)
+
+**Summary**
+
+Adds support for the Microchip ATTPM20 TPM 2.0 module and Barebox bootloader. Improvements for TLS client/server examples and overall performance. Adds TPM wrappers for HMAC, AES Key Loading and Benchmarking support for RNG/AES/Hashing/TLS.
+
+**Detail**
+
+* Fixed issue with cleanup not unregistering the crypto callback. (PR #60)
+* Added support for Microchip ATTPM20 part. (PR #59)
+* Added support for Barebox (experimental). (PR #52)
+* Added TLS benchmarking for CPS and KB/Sec. Enabled with `TLS_BENCH_MODE`. (PR #56)
+* Added TLS client/server support for symmetric AES/HMAC/RNG and mutual auth. (PR #56)
+* Added TIS locking protection for concurrent process access. Enabled using `WOLFTPM_TIS_LOCK`. (PR #56)
+* Added symmetric AES encrypt and decrypt wrappers and examples. (PR #54 and PR #55)
+* Added HMAC wrappers and examples. (PR #56)
+* Added wrappers and examples for loading external HMAC and AES keys. (PR #56) 
+* Added delete key wrapper and example. (PR #58)
+* Added ECDH support for ephemeral key generation and shared secret. (PR #50)
+* Added benchmark support for RNG, AES (CTR, CBC, CFB) 128/256 and SHA-1, SHA-256, SHA-384 and SHA-512. (PR #54)
+* Added new `wolfTPM2_GetCapabilities` wrapper API for getting chip info. (PR #51)
+* Added command and response logging use `./configure --enable-debug=verbose` or `#define WOLFTPM_DEBUG_VERBOSE`. (PR #54)
+* Added option to enable raw IO logging using `WOLFTPM_DEBUG_IO`. (PR #54)
+* Added option to disable TPM Benchmark code using `NO_TPM_BENCH`. (#60)
+* Added examples/README.md for setup instructions.
+* Tuned max SPI clock and performance for supported TPM 2.0 chips. (PR #56)
+* Cleanup to move common test parameters into examples/tpm_test.h. (PR #54)
+* Updated benchmarks and console output for examples in README.md.
+
+### wolfTPM Release 1.4 (11/13/2018)
+
+* Fixed cryptodev ECC callback to use R and S for the signature verify. (PR #39)
+* Fixed printf type warnings with `DEBUG_WOLFTPM` defined. (PR #37)
+* Fixed detection of correct hash algorithm in `wolfTPM2_VerifyHash`. (PR #39)
+* Fix bug with native example where TPM2_Shutdown failure would loop. (PR #34)
+* Fix to decoupled the fixed TPM algorithms/sizes from wolfCrypt build options. (PR #35)
+* Fix for building with different wolfCrypt options. (PR #26)
+* Fix for byte swap build error. (PR #26)
+* Fix CSR example CertName to use designated initializers to resolve use against different wolfSSL versions. (PR #25)
+* Improved portability by eliminating the packed TPM2_HEADER. (PR #45)
+* Improved stack reduction by eliminating the private section from WOLFTPM2_KEY struct. (PR #31)
+* Added TLS server example for wolfTPM. (PR #30)
+* Added more RSA and ECC key loading examples. (PR #47)
+* Added support for loading an external private keys using new API's `wolfTPM2_LoadPrivateKey`, `wolfTPM2_LoadRsaPrivateKey`, and `wolfTPM2_LoadEccPrivateKey`. (PR #46)
+* Added example for reading the firmware version using `TPM2_GetCapability` with `TPM_PT_FIRMWARE_VERSION_1`. (PR #44)
+* Added hashing wrappers and tests using new API's: `wolfTPM2_HashStart`, `wolfTPM2_HashUpdate` and `wolfTPM2_HashFinish`. (PR #40)
+* Added PKCS7 7 sign/verify example demonstrating large data case using chunked buffer and new `_ex` functions. (PR #32)
+* Added Key Generation to benchmark. (PR #33)
+* Added ST33TP I2C TPM 2.0 support (`./configure --enable-st33 --enable-i2c`). (PR #33)
+* Added ST33TP SPI TPM 2.0 support (`--enable-st33` or `#define WOLFTPM_ST33`). (PR #25)
+* Added support for Atmel ASF SPI. (PR #25)
+* Added example for IAR EWARM. (PR #27)
+* Added ECC verify test using public key and NIST test vectors. (PR #39)
+* Added new RNG wrapper API `wolfTPM2_GetRandom`. (PR #36)
+* Added macro for hardware RNG max request as `MAX_RNG_REQ_SIZE`. (PR #36)
+* Added instructions for enabling SPI and I2C on the Raspberry Pi. (PR #34)
+* Added support for symmetric AES encrypt/decrypt. (PR #29)
+* Added wrapper to help with creation of symmetric keys. (PR #29)
+* Added advanced IO callback support (enabled using `--enable-advio` or `#define WOLFTPM_ADV_IO`). (PR #25)
+* Added overridable define `WOLFTPM_LOCALITY_DEFAULT` for the locality used. (PR #28)
+* Added `XTPM_WAIT()` macro to enable custom wait between polling. (PR #28)
+* Added build option to disable wolfCrypt dependency using `./configure --disable-wolfcrypt` or `#define WOLFTPM2_NO_WOLFCRYPT`. (PR #24)
+* Removed unused SET, CLEAR, TRUE, FALSE macros. (PR #28)
+* Cleanup DEBUG_WOLFTPM ifdef's around all printfs in library proper. (PR #38)
+* Cleanup of line lengths. (PR #37)
+* Cleanup of wrapper test to move test data into `tpm_test.h`. (PR #47)
+* Cleanup of the packet code to handle determining of size (mark/place). (PR #46)
+* Cleanup of the IO callback examples. (PR #25)
+* Cleanup of TIS layer improve return code and timeout handling. (PR #28)
+* Cleanup to move types and configuration/port specific items into new `tpm2_types.h`. (PR #24)
+
+### wolfTPM Release 1.3 (07/20/2018)
+
+* Fixed the TIS TPM_BASE_ADDRESS to conform to specification. (PR #19)
+* Fixed static analysis warnings. (PR #20)
+* Fixed minor build warnings with different compilers. (PR #21)
+* Fixed TPM failure for RSA exponents less than 7 by using software based RSA. (PR #23)
+* Added TPM benchmarking support. (PR #16)
+* Added functions to import/export public keys as wolf format. (PR #15)
+* Added PKCS7 example to show sign/verify with TPM. (PR #17)
+* Added CSR example to generate certificate request based on TPM key. (PR #17)
+* Added CSR signing script `./certs/certreq.sh` to create certificate using self-signed CA. (PR #17)
+* Added TLS Client example that uses TPM based key for client certificate. (PR #17)
+* Added support for wolfSSL `WOLF_CRYPT_DEV` callbacks to enable TPM based ECC and RSA private keys. (PR #17)
+* Added ability to clear/reset TPM using `./examples/wrap/wrap_test 1` (PR #17)
+* Moved some of the example configuration into `./examples/tpm_io.h`. (PR #17)
+
+### wolfTPM Release 1.1 (03/09/2018)
+
+* Added TPM2 wrapper layer to simplify key creation, RSA encrypt/decrypt, ECC sign/verify and ECDH.
+* Added TPM2 wrapper example code.
+* Added Linux SPI support for running on Raspberry Pi.
+* Fixes for TPM2 command and response assembly and parsing.
+* Fixes to support authentication for command and response.
+* Progress on supporting parameter encryption/decryption.
+* Refactor of TIS and Packet layers into new files.
+* Fixes/improvements to `wolfTPM2_GetRCString` for error code and string reporting.
+* Added new `TPM2_Cleanup` function.
+* New tests for TPM2 native API's (test coverage is about 75%).
+
+### wolfTPM Release 1.0 (02/06/2018)
+
+* Support for all TPM2 native API's using TIS and SPI IO callback.
+* Helper for getting TPM return code string `TPM2_GetRCString`.
+* TPM 2.0 demo code in `examples/tpm/tpm2_demo.c` with support for STM32 CubeMX SPI as reference.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,7 +12,8 @@ Adds support for the Microchip ATTPM20 TPM 2.0 module and Barebox bootloader. Im
 * Added support for Microchip ATTPM20 part. (PR #59)
 * Added support for Barebox (experimental). (PR #52)
 * Added TLS benchmarking for CPS and KB/Sec. Enabled with `TLS_BENCH_MODE`. (PR #56)
-* Added TLS client/server support for symmetric AES/HMAC/RNG and mutual auth. (PR #56)
+* Added TLS client/server support for symmetric AES/HMAC/RNG. Enabled with `WOLFTPM_USE_SYMMETRIC`. (PR #56)
+* Added TLS client/server support for mutual authentication. (PR #56)
 * Added TIS locking protection for concurrent process access. Enabled using `WOLFTPM_TIS_LOCK`. (PR #56)
 * Added symmetric AES encrypt and decrypt wrappers and examples. (PR #54 and PR #55)
 * Added HMAC wrappers and examples. (PR #56)
@@ -21,7 +22,7 @@ Adds support for the Microchip ATTPM20 TPM 2.0 module and Barebox bootloader. Im
 * Added ECDH support for ephemeral key generation and shared secret. (PR #50)
 * Added benchmark support for RNG, AES (CTR, CBC, CFB) 128/256 and SHA-1, SHA-256, SHA-384 and SHA-512. (PR #54)
 * Added new `wolfTPM2_GetCapabilities` wrapper API for getting chip info. (PR #51)
-* Added command and response logging use `./configure --enable-debug=verbose` or `#define WOLFTPM_DEBUG_VERBOSE`. (PR #54)
+* Added command and response logging using `./configure --enable-debug=verbose` or `#define WOLFTPM_DEBUG_VERBOSE`. (PR #54)
 * Added option to enable raw IO logging using `WOLFTPM_DEBUG_IO`. (PR #54)
 * Added option to disable TPM Benchmark code using `NO_TPM_BENCH`. (#60)
 * Added examples/README.md for setup instructions.

--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,7 @@ include IDE/include.am
 include certs/include.am
 
 EXTRA_DIST+= README.md
+EXTRA_DIST+= ChangeLog.md
 EXTRA_DIST+= LICENSE
 EXTRA_DIST+= autogen.sh
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Portable TPM 2.0 project designed for embedded use.
 ## Project Features
 
 * This implementation provides all TPM 2.0 API’s in compliance with the specification.
-* Wrappers provided to simplify Key Generation, RSA encrypt/decrypt, ECC sign/verify, ECDH and NV.
-* Testing done using the ST33TP* SPI/I2C and Infineon OPTIGA SLB9670 / LetsTrust TPM modules.
+* Wrappers provided to simplify Key Generation/Loading, RSA encrypt/decrypt, ECC sign/verify, ECDH, NV, Hashing/Hmac and AES.
+* Testing done using the STM ST33TP* SPI/I2C, Infineon OPTIGA SLB9670 and Microchip ATTPM20 TPM 2.0 modules.
 * This uses the TPM Interface Specification (TIS) to communicate over SPI.
-* Platform support Raspberry Pi and STM32 with CubeMX.
+* Platform support for Raspberry Pi, STM32 with CubeMX, Atmel ASF and Barebox.
 * The design allows for easy portability to different platforms:
 	* Native C code designed for embedded use.
 	* Single IO callback for hardware SPI interface.
@@ -17,11 +17,12 @@ Portable TPM 2.0 project designed for embedded use.
 	* Compact code size and minimal memory use.
 * Includes example code for:
     * Most TPM2 native API’s
-    * All TPM2 wrappers
+    * All TPM2 wrapper API's
 	* PKCS 7
 	* Certificate Signing Request (CSR)
 	* TLS Client
 	* TLS Server
+	* Benchmarking TPM algorithms and TLS
 
 Note: See `examples/README.md` for details on using the examples.
 
@@ -88,7 +89,7 @@ Mfg MCHP (3), Vendor , Fw 512.20481 (0), FIPS 140-2 0, CC-EAL4 0
 
 ## Building
 
-Build wolfSSL:
+### Building wolfSSL
 
 ```
 git clone https://github.com/wolfSSL/wolfssl.git
@@ -101,6 +102,23 @@ sudo ldconfig
 ```
 
 autogen.sh requires: automake and libtool: `sudo apt-get install automake libtool`
+
+### Build options and defines
+
+```
+--enable-debug          Add debug code/turns off optimizations (yes|no|verbose) - DEBUG_WOLFTPM, WOLFTPM_DEBUG_VERBOSE, WOLFTPM_DEBUG_IO
+--enable-examples       Enable Examples (default: enabled)
+--enable-wrapper        Enable wrapper code (default: enabled) - WOLFTPM2_NO_WRAPPER
+--enable-wolfcrypt      Enable wolfCrypt hooks for RNG, Auth Sessions and Parameter encryption (default: enabled) - WOLFTPM2_NO_WOLFCRYPT
+--enable-advio          Enable Advanced IO (default: disabled) - WOLFTPM_ADV_IO
+--enable-st33           Enable ST33 TPM Support (default: disabled) - WOLFTPM_ST33
+--enable-i2c            Enable I2C TPM Support (default: disabled, requires advio) - WOLFTPM_I2C
+--enable-mchp           Enable Microchip TPM Support (default: disabled) - WOLFTPM_MCHP
+WOLFTPM_TIS_LOCK        Enable Linux Named Semaphore for locking access to SPI device for concurrent access between processes.
+WOLFTPM_USE_SYMMETRIC   Enables symmetric AES/Hashing/HMAC support for TLS examples.
+TLS_BENCH_MODE          Enables TLS benchmarking mode.
+NO_TPM_BENCH            Disables the TPM benchmarking example.
+```
 
 ### Building Infineon SLB9670
 
@@ -137,20 +155,6 @@ Build wolfTPM:
 ./autogen.sh
 ./configure --enable-mchp
 make
-```
-
-### Build options and defines
-
-```
---enable-debug          Add debug code/turns off optimizations (yes|no|verbose) - DEBUG_WOLFTPM, WOLFTPM_DEBUG_VERBOSE, WOLFTPM_DEBUG_IO
---enable-examples       Enable Examples (default: enabled)
---enable-wrapper        Enable wrapper code (default: enabled) - WOLFTPM2_NO_WRAPPER
---enable-wolfcrypt      Enable wolfCrypt hooks for RNG, Auth Sessions and Parameter encryption (default: enabled) - WOLFTPM2_NO_WOLFCRYPT
---enable-advio          Enable Advanced IO (default: disabled) - WOLFTPM_ADV_IO
---enable-st33           Enable ST33 TPM Support (default: disabled) - WOLFTPM_ST33
---enable-i2c            Enable I2C TPM Support (default: disabled, requires advio) - WOLFTPM_I2C
---enable-mchp           Enable Microchip TPM Support (default: disabled) - WOLFTPM_MCHP
-WOLFTPM_TIS_LOCK        Enable Linux Named Semaphore for locking access to SPI device for concurrent access between processes.
 ```
 
 ## Running Examples

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ Build wolfTPM:
 make
 ```
 
-
 ### Build options and defines
 
 ```
@@ -153,88 +152,6 @@ make
 --enable-mchp           Enable Microchip TPM Support (default: disabled) - WOLFTPM_MCHP
 WOLFTPM_TIS_LOCK        Enable Linux Named Semaphore for locking access to SPI device for concurrent access between processes.
 ```
-
-## Release Notes
-
-
-### wolfTPM Release 1.4 (11/13/2018)
-
-* Fixed cryptodev ECC callback to use R and S for the signature verify. (PR #39)
-* Fixed printf type warnings with `DEBUG_WOLFTPM` defined. (PR #37)
-* Fixed detection of correct hash algorithm in `wolfTPM2_VerifyHash`. (PR #39)
-* Fix bug with native example where TPM2_Shutdown failure would loop. (PR #34)
-* Fix to decoupled the fixed TPM algorithms/sizes from wolfCrypt build options. (PR #35)
-* Fix for building with different wolfCrypt options. (PR #26)
-* Fix for byte swap build error. (PR #26)
-* Fix CSR example CertName to use designated initializers to resolve use against different wolfSSL versions. (PR #25)
-* Improved portability by eliminating the packed TPM2_HEADER. (PR #45)
-* Improved stack reduction by eliminating the private section from WOLFTPM2_KEY struct. (PR #31)
-* Added TLS server example for wolfTPM. (PR #30)
-* Added more RSA and ECC key loading examples. (PR #47)
-* Added support for loading an external private keys using new API's `wolfTPM2_LoadPrivateKey`, `wolfTPM2_LoadRsaPrivateKey`, and `wolfTPM2_LoadEccPrivateKey`. (PR #46)
-* Added example for reading the firmware version using `TPM2_GetCapability` with `TPM_PT_FIRMWARE_VERSION_1`. (PR #44)
-* Added hashing wrappers and tests using new API's: `wolfTPM2_HashStart`, `wolfTPM2_HashUpdate` and `wolfTPM2_HashFinish`. (PR #40)
-* Added PKCS7 7 sign/verify example demonstrating large data case using chunked buffer and new `_ex` functions. (PR #32)
-* Added Key Generation to benchmark. (PR #33)
-* Added ST33TP I2C TPM 2.0 support (`./configure --enable-st33 --enable-i2c`). (PR #33)
-* Added ST33TP SPI TPM 2.0 support (`--enable-st33` or `#define WOLFTPM_ST33`). (PR #25)
-* Added support for Atmel ASF SPI. (PR #25)
-* Added example for IAR EWARM. (PR #27)
-* Added ECC verify test using public key and NIST test vectors. (PR #39)
-* Added new RNG wrapper API `wolfTPM2_GetRandom`. (PR #36)
-* Added macro for hardware RNG max request as `MAX_RNG_REQ_SIZE`. (PR #36)
-* Added instructions for enabling SPI and I2C on the Raspberry Pi. (PR #34)
-* Added support for symmetric AES encrypt/decrypt. (PR #29)
-* Added wrapper to help with creation of symmetric keys. (PR #29)
-* Added advanced IO callback support (enabled using `--enable-advio` or `#define WOLFTPM_ADV_IO`). (PR #25)
-* Added overridable define `WOLFTPM_LOCALITY_DEFAULT` for the locality used. (PR #28)
-* Added `XTPM_WAIT()` macro to enable custom wait between polling. (PR #28)
-* Added build option to disable wolfCrypt dependency using `./configure --disable-wolfcrypt` or `#define WOLFTPM2_NO_WOLFCRYPT`. (PR #24)
-* Removed unused SET, CLEAR, TRUE, FALSE macros. (PR #28)
-* Cleanup DEBUG_WOLFTPM ifdef's around all printfs in library proper. (PR #38)
-* Cleanup of line lengths. (PR #37)
-* Cleanup of wrapper test to move test data into `tpm_test.h`. (PR #47)
-* Cleanup of the packet code to handle determining of size (mark/place). (PR #46)
-* Cleanup of the IO callback examples. (PR #25)
-* Cleanup of TIS layer improve return code and timeout handling. (PR #28)
-* Cleanup to move types and configuration/port specific items into new `tpm2_types.h`. (PR #24)
-
-
-### wolfTPM Release 1.3 (07/20/2018)
-
-* Fixed the TIS TPM_BASE_ADDRESS to conform to specification. (PR #19)
-* Fixed static analysis warnings. (PR #20)
-* Fixed minor build warnings with different compilers. (PR #21)
-* Fixed TPM failure for RSA exponents less than 7 by using software based RSA. (PR #23)
-* Added TPM benchmarking support. (PR #16)
-* Added functions to import/export public keys as wolf format. (PR #15)
-* Added PKCS7 example to show sign/verify with TPM. (PR #17)
-* Added CSR example to generate certificate request based on TPM key. (PR #17)
-* Added CSR signing script `./certs/certreq.sh` to create certificate using self-signed CA. (PR #17)
-* Added TLS Client example that uses TPM based key for client certificate. (PR #17)
-* Added support for wolfSSL `WOLF_CRYPT_DEV` callbacks to enable TPM based ECC and RSA private keys. (PR #17)
-* Added ability to clear/reset TPM using `./examples/wrap/wrap_test 1` (PR #17)
-* Moved some of the example configuration into `./examples/tpm_io.h`. (PR #17)
-
-### wolfTPM Release 1.1 (03/09/2018)
-
-* Added TPM2 wrapper layer to simplify key creation, RSA encrypt/decrypt, ECC sign/verify and ECDH.
-* Added TPM2 wrapper example code.
-* Added Linux SPI support for running on Raspberry Pi.
-* Fixes for TPM2 command and response assembly and parsing.
-* Fixes to support authentication for command and response.
-* Progress on supporting parameter encryption/decryption.
-* Refactor of TIS and Packet layers into new files.
-* Fixes/improvements to `wolfTPM2_GetRCString` for error code and string reporting.
-* Added new `TPM2_Cleanup` function.
-* New tests for TPM2 native API's (test coverage is about 75%).
-
-### wolfTPM Release 1.0 (02/06/2018)
-
-* Support for all TPM2 native API's using TIS and SPI IO callback.
-* Helper for getting TPM return code string `TPM2_GetRCString`.
-* TPM 2.0 demo code in `examples/tpm/tpm2_demo.c` with support for STM32 CubeMX SPI as reference.
-
 
 ## Running Examples
 

--- a/certs/certreq.sh
+++ b/certs/certreq.sh
@@ -15,8 +15,12 @@ if [ ! -f ./certs/crlnumber ]; then
 fi
 
 if [ "$1" == "clean" ]; then
-	rm ./certs/*.pem
-	rm ./certs/*.der
+	rm ./certs/1*.pem
+	rm ./certs/ca-*.pem
+	rm ./certs/client-*.pem
+	rm ./certs/client-*.der
+	rm ./certs/server-*.pem
+	rm ./certs/server-*.der
 	rm ./certs/*.old
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 # All right reserved.
 
 AC_COPYRIGHT([Copyright (C) 2014-2018 wolfSSL Inc.])
-AC_INIT([wolftpm],[1.4.0],[https://github.com/wolfssl/wolfTPM/issues],[wolftpm],[http://www.wolfssl.com])
+AC_INIT([wolftpm],[1.5.0],[https://github.com/wolfssl/wolfTPM/issues],[wolftpm],[http://www.wolfssl.com])
 
 AC_PREREQ([2.63])
 AC_CONFIG_AUX_DIR([build-aux])
@@ -23,7 +23,7 @@ AC_ARG_PROGRAM
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([src/config.h])
 
-WOLFTPM_LIBRARY_VERSION=4:0:0
+WOLFTPM_LIBRARY_VERSION=5:0:0
 #                        | | |
 #                 +------+ | +---+
 #                 |        |     |

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,7 +62,9 @@ The result is displayed to stdout on the console.
 
 The TLS example uses TPM based ECDHE (ECC Ephemeral key) support. It can be disabled using `CFLAGS="-DWOLFTPM2_USE_SW_ECDHE"` or `#define WOLFTPM2_USE_SW_ECDHE`. We are also looking into using the 2-phase `TPM2_EC_Ephemeral` and `TPM2_ZGen_2Phase` methods for improved performance and scalability.
 
-Note: To force ECC use with wolfSSL when RSA is enabled define `TLS_USE_ECC`.
+To force ECC use with wolfSSL when RSA is enabled define `TLS_USE_ECC`.
+
+To use symmetric AES/Hashing/Hmac with the TPM define `WOLFTPM_USE_SYMMETRIC`.
 
 Generation of the Client and Server Certificates requires running:
 1. `./examples/csr/csr`
@@ -82,9 +84,9 @@ You can validate using the wolfSSL example server this like:
 `./examples/server/server -b -p 11111 -g -d`
  
 To validate client certificate use the following wolfSSL example server command:
-`./examples/server/server -b -p 11111 -g -A ./certs/ca-rsa-cert.pem`
+`./examples/server/server -b -p 11111 -g -A ./certs/tpm-ca-rsa-cert.pem`
 or
-`./examples/server/server -b -p 11111 -g -A ./certs/ca-ecc-cert.pem`
+`./examples/server/server -b -p 11111 -g -A ./certs/tpm-ca-ecc-cert.pem`
 
 Then run the wolfTPM TLS client example:
 `./examples/tls/tls_client`. 
@@ -103,9 +105,9 @@ Then run the wolfSSL example client this like:
 `./examples/client/client -h localhost -p 11111 -g -d`
 
 To validate server certificate use the following wolfSSL example client comment:
-`./examples/client/client -h localhost -p 11111 -g -A ./certs/ca-rsa-cert.pem`
+`./examples/client/client -h localhost -p 11111 -g -A ./certs/tpm-ca-rsa-cert.pem`
 or
-`./examples/client/client -h localhost -p 11111 -g -A ./certs/ca-ecc-cert.pem`
+`./examples/client/client -h localhost -p 11111 -g -A ./certs/tpm-ca-ecc-cert.pem`
 
 
 Or using your browser: `https://localhost:11111`

--- a/examples/tls/tls_client.c
+++ b/examples/tls/tls_client.c
@@ -391,7 +391,6 @@ int TPM2_TLS_Client(void* userCtx)
     #else
         msgSz = sizeof(webServerMsg);
         XMEMCPY(msg, webServerMsg, msgSz);
-        printf("Write (%d): %s\n", msgSz, msg);
     #endif
 
         /* perform write */
@@ -410,9 +409,12 @@ int TPM2_TLS_Client(void* userCtx)
             benchStart = gettime_secs(0) - benchStart;
             printf("Write: %d bytes in %9.3f sec (%9.3f KB/sec)\n",
                 msgSz, benchStart, msgSz / benchStart / 1024);
+        #else
+            printf("Write (%d): %s\n", msgSz, msg);
         #endif
             rc = 0; /* success */
         }
+        if (rc != 0) goto exit;
 
         /* perform read */
     #ifdef TLS_BENCH_MODE

--- a/examples/tls/tls_client_notpm.c
+++ b/examples/tls/tls_client_notpm.c
@@ -205,7 +205,6 @@ int TLS_Client(void)
     #else
         msgSz = sizeof(webServerMsg);
         XMEMCPY(msg, webServerMsg, msgSz);
-        printf("Write (%d): %s\n", msgSz, msg);
     #endif
 
         /* perform write */
@@ -224,9 +223,12 @@ int TLS_Client(void)
             benchStart = gettime_secs(0) - benchStart;
             printf("Write: %d bytes in %9.3f sec (%9.3f KB/sec)\n",
                 msgSz, benchStart, msgSz / benchStart / 1024);
+        #else
+            printf("Write (%d): %s\n", msgSz, msg);
         #endif
             rc = 0; /* success */
         }
+        if (rc != 0) goto exit;
 
         /* perform read */
     #ifdef TLS_BENCH_MODE

--- a/examples/tls/tls_common.h
+++ b/examples/tls/tls_common.h
@@ -60,6 +60,7 @@
 #if 0
     #define NO_TLS_MUTUAL_AUTH
 #endif
+
 /* enable for testing ECC key/cert when RSA is enabled */
 #if 0
     #define TLS_USE_ECC
@@ -69,6 +70,7 @@
 #if 0
     #define TLS_BENCH_MODE
 #endif
+
 #ifdef TLS_BENCH_MODE
     extern double benchStart;
 #endif

--- a/examples/tls/tls_server.c
+++ b/examples/tls/tls_server.c
@@ -406,6 +406,7 @@ int TPM2_TLS_Server(void* userCtx)
         #endif
             rc = 0; /* success */
         }
+        if (rc != 0) goto exit;
 
         /* perform write */
     #ifdef TLS_BENCH_MODE
@@ -413,7 +414,6 @@ int TPM2_TLS_Server(void* userCtx)
     #else
         msgSz = sizeof(webServerMsg);
         XMEMCPY(msg, webServerMsg, msgSz);
-        printf("Write (%d): %s\n", msgSz, webServerMsg);
     #endif
         do {
             rc = wolfSSL_write(ssl, msg, msgSz);
@@ -427,6 +427,8 @@ int TPM2_TLS_Server(void* userCtx)
             benchStart = gettime_secs(0) - benchStart;
             printf("Write: %d bytes in %9.3f sec (%9.3f KB/sec)\n",
                 msgSz, benchStart, msgSz / benchStart / 1024);
+        #else
+            printf("Write (%d): %s\n", msgSz, msg);
         #endif
             rc = 0; /* success */
         }

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -629,6 +629,7 @@ int TPM2_Wrapper_Test(void* userCtx)
         printf("Encrypt/Decrypt test failed, result not as expected!\n");
         goto exit;
     }
+    if (rc != 0) goto exit;
 
 
     rc = wolfTPM2_GetKeyTemplate_Symmetric(&publicTemplate, 128, TEST_AES_MODE,

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -690,7 +690,7 @@ int wolfTPM2_LoadPrivateKey(WOLFTPM2_DEV* dev, const WOLFTPM2_KEY* parentKey,
 
     /* Load key to get handle */
     XMEMSET(&loadIn, 0, sizeof(loadIn));
-    loadIn.parentHandle = parentKey->handle.hndl;
+    loadIn.parentHandle = parentHandle;
     loadIn.inPrivate = importOut.outPrivate;
     loadIn.inPublic = key->pub;
     rc = TPM2_Load(&loadIn, &loadOut);
@@ -2414,7 +2414,7 @@ int wolfTPM2_EncryptDecrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const byte* in, byte* out, word32 inOutSz,
     byte* iv, word32 ivSz, int isDecrypt)
 {
-    int rc;
+    int rc = 0;
     word32 pos = 0, xfer;
 
     while (pos < inOutSz) {
@@ -3211,8 +3211,10 @@ int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
                             hashCtx->cacheBuf, hashCtx->cacheSz);
                 }
             }
-            rc = wolfTPM2_HashFinish(tlsCtx->dev, &hash, info->hash.digest,
-                &digestSz);
+            if (rc == 0) {
+                rc = wolfTPM2_HashFinish(tlsCtx->dev, &hash, info->hash.digest,
+                    &digestSz);
+            }
         }
         /* if final or failure cleanup */
         if (info->hash.digest != NULL || rc != 0) {

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -92,7 +92,7 @@ typedef int64_t  INT64;
     #endif
     #ifndef WOLFCRYPT_ONLY
         /* for additional error codes */
-        extern const char* wolfSSL_ERR_reason_error_string(unsigned long);
+        #include <wolfssl/ssl.h> /* for wolfSSL_ERR_reason_error_string */
     #endif
 
 	#ifdef DEBUG_WOLFTPM

--- a/wolftpm/version.h
+++ b/wolftpm/version.h
@@ -34,8 +34,8 @@
 extern "C" {
 #endif
 
-#define LIBWOLFTPM_VERSION_STRING "1.4.0"
-#define LIBWOLFTPM_VERSION_HEX 0x01004000
+#define LIBWOLFTPM_VERSION_STRING "1.5.0"
+#define LIBWOLFTPM_VERSION_HEX 0x01005000
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
* Moved the release notes to `ChangeLog.md`.
* Fixes for various scan-build and G++ warnings.
* Fix for `./certs/certreq.sh clean` to not remove wolf certs.
* Updates to README.md files.