### PR TITLE
Added way to include generated `wolftpm/options.h`

### DIFF
--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -29,6 +29,11 @@
 #include <wolftpm/visibility.h>
 #include <stdint.h>
 
+#ifdef WOLFTPM_USER_SETTINGS
+    /* use generated options.h or a custom one */
+    #include <wolftpm/options.h>
+#endif
+
 /* ---------------------------------------------------------------------------*/
 /* TPM TYPES */
 /* ---------------------------------------------------------------------------*/


### PR DESCRIPTION
Added way to include generated `wolftpm/options.h` (or customized one) using `WOLFTPM_USER_SETTINGS`.