### PR TITLE
Added new API to init/test TPM module

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Mfg MCHP (3), Vendor , Fw 512.20481 (0), FIPS 140-2 0, CC-EAL4 0
 git clone https://github.com/wolfSSL/wolfssl.git
 cd wolfssl
 ./autogen.sh
-./configure --enable-certgen --enable-certreq --enable-certext --enable-pkcs7 --enable-cryptodev
+./configure --enable-certgen --enable-certreq --enable-certext --enable-pkcs7 --enable-cryptocb
 make
 sudo make install
 sudo ldconfig

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -115,6 +115,10 @@ int TPM2_Wrapper_Test(void* userCtx)
 
     printf("TPM2 Demo for Wrapper API's\n");
 
+    /* Demonstrate single-shot API to test and init TPM hardware */
+    rc = wolfTPM2_Test(TPM2_IoCb, userCtx, NULL);
+    if (rc != 0) goto exit;
+
 
     /* Init the TPM2 device */
     rc = wolfTPM2_Init(&dev, TPM2_IoCb, userCtx);

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -91,7 +91,7 @@ typedef struct WOLFTPM2_CAPS {
 
 
 /* Wrapper API's to simplify TPM use */
-
+WOLFTPM_API int wolfTPM2_Test(TPM2HalIoCb ioCb, void* userCtx, WOLFTPM2_CAPS* caps);
 WOLFTPM_API int wolfTPM2_Init(WOLFTPM2_DEV* dev, TPM2HalIoCb ioCb, void* userCtx);
 WOLFTPM_API int wolfTPM2_Cleanup(WOLFTPM2_DEV* dev);
 


### PR DESCRIPTION
Added new API `wolfTPM2_Test` for testing for TPM and optionally returning capabilities. This API is useful for providing a "single shot" call (without context) to confirm TPM communication, initialize/startup TPM module, perform self-test and optionally get capabilities.