### PR TITLE
TPM improvements for chip detection, compatibility and startup performance

### DIFF
--- a/examples/bench/bench.c
+++ b/examples/bench/bench.c
@@ -31,6 +31,8 @@
 #include <examples/tpm_test.h>
 #include <examples/bench/bench.h>
 
+#include <stdio.h>
+
 /* Configuration */
 #define TPM2_BENCH_DURATION_SEC         1
 #define TPM2_BENCH_DURATION_KEYGEN_SEC  15

--- a/examples/bench/bench.h
+++ b/examples/bench/bench.h
@@ -22,7 +22,14 @@
 #ifndef _WRAP_BENCH_H_
 #define _WRAP_BENCH_H_
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
 
 int TPM2_Wrapper_Bench(void* userCtx);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 
 #endif /* _WRAP_BENCH_H_ */

--- a/examples/csr/csr.c
+++ b/examples/csr/csr.c
@@ -32,6 +32,8 @@
 #include <examples/csr/csr.h>
 #include <wolfssl/wolfcrypt/asn_public.h>
 
+#include <stdio.h>
+
 static const char* gClientCertRsaFile = "./certs/tpm-rsa-cert.csr";
 static const char* gClientCertEccFile = "./certs/tpm-ecc-cert.csr";
 

--- a/examples/csr/csr.h
+++ b/examples/csr/csr.h
@@ -22,7 +22,14 @@
 #ifndef _TPM_CSR_EXAMPLE_H_
 #define _TPM_CSR_EXAMPLE_H_
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
 
 int TPM2_CSR_Example(void* userCtx);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 
 #endif /* _TPM_CSR_EXAMPLE_H_ */

--- a/examples/native/native_test.c
+++ b/examples/native/native_test.c
@@ -417,7 +417,7 @@ int TPM2_Native_Test(void* userCtx)
     rc = TPM2_GetNonce(cmdIn.authSes.nonceCaller.buffer,
                        cmdIn.authSes.nonceCaller.size);
     if (rc < 0) {
-        printf("wc_RNG_GenerateBlock failed 0x%x: %s\n", rc,
+        printf("TPM2_GetNonce failed 0x%x: %s\n", rc,
             TPM2_GetRCString(rc));
         goto exit;
     }
@@ -771,7 +771,7 @@ int TPM2_Native_Test(void* userCtx)
     rc = TPM2_GetNonce(cmdIn.objChgAuth.newAuth.buffer,
                        cmdIn.objChgAuth.newAuth.size);
     if (rc < 0) {
-        printf("wc_RNG_GenerateBlock failed 0x%x: %s\n", rc,
+        printf("TPM2_GetNonce failed 0x%x: %s\n", rc,
             TPM2_GetRCString(rc));
         goto exit;
     }

--- a/examples/native/native_test.c
+++ b/examples/native/native_test.c
@@ -27,6 +27,8 @@
 #include <examples/tpm_io.h>
 #include <examples/tpm_test.h>
 
+#include <stdio.h>
+
 /******************************************************************************/
 /* --- BEGIN TPM Native API Tests -- */
 /******************************************************************************/
@@ -426,7 +428,7 @@ int TPM2_Native_Test(void* userCtx)
         goto exit;
     }
     sessionHandle = cmdOut.authSes.sessionHandle;
-    printf("TPM2_StartAuthSession: sessionHandle 0x%x\n", sessionHandle);
+    printf("TPM2_StartAuthSession: sessionHandle 0x%x\n", (word32)sessionHandle);
 
 
     /* Policy Get Digest */
@@ -513,7 +515,7 @@ int TPM2_Native_Test(void* userCtx)
         goto exit;
     }
     handle = cmdOut.hashSeqStart.sequenceHandle;
-    printf("TPM2_HashSequenceStart: sequenceHandle 0x%x\n", handle);
+    printf("TPM2_HashSequenceStart: sequenceHandle 0x%x\n", (word32)handle);
 
     /* set auth for hashing handle */
     session[0].auth.size = sizeof(usageAuth)-1;
@@ -598,7 +600,7 @@ int TPM2_Native_Test(void* userCtx)
     endorse.name = cmdOut.createPri.name;
     endorse.symmetric = cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.symmetric;
     printf("TPM2_CreatePrimary: Endorsement 0x%x (%d bytes)\n",
-        endorse.handle, endorse.pub.size);
+        (word32)endorse.handle, endorse.pub.size);
 
 
     /* Create Primary (Storage) */
@@ -630,7 +632,7 @@ int TPM2_Native_Test(void* userCtx)
     storage.pub = cmdOut.createPri.outPublic;
     storage.name = cmdOut.createPri.name;
     printf("TPM2_CreatePrimary: Storage 0x%x (%d bytes)\n",
-        storage.handle, storage.pub.size);
+        (word32)storage.handle, storage.pub.size);
 
 #if 0
     /* Move new primary key into NV to persist */
@@ -657,7 +659,7 @@ int TPM2_Native_Test(void* userCtx)
         goto exit;
     }
     handle = cmdOut.loadExt.objectHandle;
-    printf("TPM2_LoadExternal: 0x%x\n", handle);
+    printf("TPM2_LoadExternal: 0x%x\n", (word32)handle);
 
     /* Make a credential */
     XMEMSET(&cmdIn.makeCred, 0, sizeof(cmdIn.makeCred));
@@ -687,7 +689,7 @@ int TPM2_Native_Test(void* userCtx)
         goto exit;
     }
     printf("TPM2_ReadPublic Handle 0x%x: pub %d, name %d, qualifiedName %d\n",
-        cmdIn.readPub.objectHandle,
+        (word32)cmdIn.readPub.objectHandle,
         cmdOut.readPub.outPublic.size, cmdOut.readPub.name.size,
         cmdOut.readPub.qualifiedName.size);
 
@@ -736,7 +738,7 @@ int TPM2_Native_Test(void* userCtx)
         goto exit;
     }
     hmacKey.handle = cmdOut.load.objectHandle;
-    printf("TPM2_Load New HMAC Key Handle 0x%x\n", hmacKey.handle);
+    printf("TPM2_Load New HMAC Key Handle 0x%x\n", (word32)hmacKey.handle);
 
     /* set auth for HMAC handle */
     session[0].auth.size = sizeof(usageAuth)-1;
@@ -856,7 +858,7 @@ int TPM2_Native_Test(void* userCtx)
         goto exit;
     }
     eccKey.handle = cmdOut.load.objectHandle;
-    printf("TPM2_Load ECDSA Key Handle 0x%x\n", eccKey.handle);
+    printf("TPM2_Load ECDSA Key Handle 0x%x\n", (word32)eccKey.handle);
 
     /* set session auth for ecc key */
     session[0].auth.size = sizeof(usageAuth)-1;
@@ -942,7 +944,7 @@ int TPM2_Native_Test(void* userCtx)
         goto exit;
     }
     eccKey.handle = cmdOut.load.objectHandle;
-    printf("TPM2_Load ECDH Key Handle 0x%x\n", eccKey.handle);
+    printf("TPM2_Load ECDH Key Handle 0x%x\n", (word32)eccKey.handle);
 
     /* set session auth for ecc key */
     session[0].auth.size = sizeof(usageAuth)-1;
@@ -1034,7 +1036,7 @@ int TPM2_Native_Test(void* userCtx)
         goto exit;
     }
     rsaKey.handle = cmdOut.load.objectHandle;
-    printf("TPM2_Load RSA Key Handle 0x%x\n", rsaKey.handle);
+    printf("TPM2_Load RSA Key Handle 0x%x\n", (word32)rsaKey.handle);
 
     /* set session auth for RSA key */
     session[0].auth.size = sizeof(usageAuth)-1;
@@ -1110,7 +1112,7 @@ int TPM2_Native_Test(void* userCtx)
             TPM2_GetRCString(rc));
         goto exit;
     }
-    printf("TPM2_NV_DefineSpace: 0x%x\n", nvIndex);
+    printf("TPM2_NV_DefineSpace: 0x%x\n", (word32)nvIndex);
 
     /* Read NV */
     XMEMSET(&cmdIn.nvReadPub, 0, sizeof(cmdIn.nvReadPub));
@@ -1124,9 +1126,9 @@ int TPM2_Native_Test(void* userCtx)
     printf("TPM2_NV_ReadPublic: Sz %d, Idx 0x%x, nameAlg %d, Attr 0x%x, "
             "authPol %d, dataSz %d, name %d\n",
         cmdOut.nvReadPub.nvPublic.size,
-        cmdOut.nvReadPub.nvPublic.nvPublic.nvIndex,
+		(word32)cmdOut.nvReadPub.nvPublic.nvPublic.nvIndex,
         cmdOut.nvReadPub.nvPublic.nvPublic.nameAlg,
-        cmdOut.nvReadPub.nvPublic.nvPublic.attributes,
+		(word32)cmdOut.nvReadPub.nvPublic.nvPublic.attributes,
         cmdOut.nvReadPub.nvPublic.nvPublic.authPolicy.size,
         cmdOut.nvReadPub.nvPublic.nvPublic.dataSize,
         cmdOut.nvReadPub.nvName.size);
@@ -1209,7 +1211,7 @@ int TPM2_Native_Test(void* userCtx)
         goto exit;
     }
     aesKey.handle = cmdOut.load.objectHandle;
-    printf("TPM2_Load New AES Key Handle 0x%x\n", aesKey.handle);
+    printf("TPM2_Load New AES Key Handle 0x%x\n", (word32)aesKey.handle);
 
     /* set auth for AES handle */
     session[0].auth.size = sizeof(usageAuth)-1;

--- a/examples/native/native_test.h
+++ b/examples/native/native_test.h
@@ -22,7 +22,14 @@
 #ifndef _NATIVE_TEST_H_
 #define _NATIVE_TEST_H_
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
 
 int TPM2_Native_Test(void* userCtx);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 
 #endif /* _NATIVE_TEST_H_ */

--- a/examples/pkcs7/pkcs7.c
+++ b/examples/pkcs7/pkcs7.c
@@ -32,6 +32,8 @@
 #include <examples/pkcs7/pkcs7.h>
 #include <wolfssl/wolfcrypt/pkcs7.h>
 
+#include <stdio.h>
+
 /* Sign PKCS7 using TPM based key:
  * Must Run:
  * 1. `./examples/csr/csr`

--- a/examples/pkcs7/pkcs7.h
+++ b/examples/pkcs7/pkcs7.h
@@ -22,7 +22,14 @@
 #ifndef _TPM_PKCS7_EXAMPLE_H_
 #define _TPM_PKCS7_EXAMPLE_H_
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
 
 int TPM2_PKCS7_Example(void* userCtx);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 
 #endif /* _TPM_PKCS7_EXAMPLE_H_ */

--- a/examples/tls/tls_client.c
+++ b/examples/tls/tls_client.c
@@ -40,6 +40,8 @@
 #define USE_CERT_BUFFERS_256
 #include <wolfssl/certs_test.h>
 
+#include <stdio.h>
+
 #ifdef TLS_BENCH_MODE
     double benchStart;
 #endif

--- a/examples/tls/tls_client.h
+++ b/examples/tls/tls_client.h
@@ -22,8 +22,15 @@
 #ifndef _TPM_TLS_CLIENT_H_
 #define _TPM_TLS_CLIENT_H_
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
 
 int TPM2_TLS_Client(void* userCtx);
 int TLS_Client(void);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 
 #endif /* _TPM_TLS_CLIENT_H_ */

--- a/examples/tls/tls_client_notpm.c
+++ b/examples/tls/tls_client_notpm.c
@@ -40,6 +40,8 @@
 #define USE_CERT_BUFFERS_256
 #include <wolfssl/certs_test.h>
 
+#include <stdio.h>
+
 #ifdef TLS_BENCH_MODE
     double benchStart;
 #endif

--- a/examples/tls/tls_common.h
+++ b/examples/tls/tls_common.h
@@ -34,6 +34,8 @@
 
 #include <wolfssl/ssl.h>
 
+#include <stdio.h>
+
 #ifdef __cplusplus
     extern "C" {
 #endif

--- a/examples/tls/tls_common.h
+++ b/examples/tls/tls_common.h
@@ -34,6 +34,10 @@
 
 #include <wolfssl/ssl.h>
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
 /* TLS Configuration */
 #ifndef TLS_HOST
     #define TLS_HOST "localhost"
@@ -441,6 +445,10 @@ static inline int myTpmCheckKey(wc_CryptoInfo* info, TpmCryptoDevCtx* ctx)
 /******************************************************************************/
 /* --- END Supporting TLS functions --- */
 /******************************************************************************/
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 
 #endif /* !WOLFTPM2_NO_WRAPPER && !WOLFTPM2_NO_WOLFCRYPT */
 

--- a/examples/tls/tls_server.c
+++ b/examples/tls/tls_server.c
@@ -34,6 +34,8 @@
 
 #include <wolfssl/ssl.h>
 
+#include <stdio.h>
+
 #ifdef TLS_BENCH_MODE
     double benchStart;
 #endif

--- a/examples/tls/tls_server.h
+++ b/examples/tls/tls_server.h
@@ -22,7 +22,14 @@
 #ifndef _TPM_TLS_SERVER_H_
 #define _TPM_TLS_SERVER_H_
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
 
 int TPM2_TLS_Server(void* userCtx);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 
 #endif /* _TPM_TLS_SERVER_H_ */

--- a/examples/tpm_io.h
+++ b/examples/tpm_io.h
@@ -24,13 +24,21 @@
 
 #include <wolftpm/tpm2.h>
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
 /* TPM2 IO Examples */
 #ifdef WOLFTPM_ADV_IO
 int TPM2_IoCb(TPM2_CTX*, int isRead, word32 addr, byte* buf, word16 size,
     void* userCtx);
 #else
-int   TPM2_IoCb(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
+int TPM2_IoCb(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
     word16 xferSz, void* userCtx);
+#endif
+
+#ifdef __cplusplus
+    }  /* extern "C" */
 #endif
 
 #endif /* _TPM_IO_H_ */

--- a/examples/tpm_test.h
+++ b/examples/tpm_test.h
@@ -23,6 +23,9 @@
 #ifndef _TPM_TEST_H_
 #define _TPM_TEST_H_
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
 
 /* Test Configuration */
 #define TPM2_DEMO_STORAGE_KEY_HANDLE    0x81000200  /* Persistent Storage Key Handle */
@@ -440,5 +443,9 @@ static const byte kTestAesCbc128Verify[] = {
     0x95,0x94,0x92,0x57,0x5f,0x42,0x81,0x53,
     0x2c,0xcc,0x9d,0x46,0x77,0xa2,0x33,0xcb
 };
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 
 #endif /* _TPM_TEST_H_ */

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -30,6 +30,8 @@
 #include <examples/tpm_test.h>
 #include <examples/wrap/wrap_test.h>
 
+#include <stdio.h>
+
 /* Configuration */
 #define TPM2_DEMO_NV_TEST_INDEX                 0x01800200
 #define TPM2_DEMO_NV_TEST_SIZE                  1024 /* max size on Infineon SLB9670 is 1664 */

--- a/examples/wrap/wrap_test.h
+++ b/examples/wrap/wrap_test.h
@@ -22,8 +22,15 @@
 #ifndef _WRAP_TEST_H_
 #define _WRAP_TEST_H_
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
 
 void TPM2_Wrapper_SetReset(int reset);
 int TPM2_Wrapper_Test(void* userCtx);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 
 #endif /* _WRAP_TEST_H_ */

--- a/src/tpm2_tis.c
+++ b/src/tpm2_tis.c
@@ -248,8 +248,11 @@ int TPM2_TIS_StartupWait(TPM2_CTX* ctx, int timeout)
 
     do {
         rc = TPM2_TIS_Read(ctx, TPM_ACCESS(0), &access, sizeof(access));
-        if (rc == TPM_RC_SUCCESS && (access & TPM_ACCESS_VALID))
+        /* if chip isn't present MISO will be high and return 0xFF */
+        if (rc == TPM_RC_SUCCESS && (access & TPM_ACCESS_VALID) &&
+                (access != 0xFF)) {
             return TPM_RC_SUCCESS;
+        }
         XTPM_WAIT();
     } while (rc == TPM_RC_SUCCESS && --timeout > 0);
     if (timeout <= 0)

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -34,7 +34,8 @@ static int wolfTPM2_GetCapabilities_NoDev(WOLFTPM2_CAPS* cap);
 /* --- BEGIN Wrapper Device Functions -- */
 /******************************************************************************/
 
-static int wolfTPM2_Init_NoDev(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx)
+static int wolfTPM2_Init_NoDev(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx,
+    int timeoutTries)
 {
     int rc;
     Startup_In startupIn;
@@ -45,7 +46,7 @@ static int wolfTPM2_Init_NoDev(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx)
     if (ctx == NULL)
         return BAD_FUNC_ARG;
 
-    rc = TPM2_Init(ctx, ioCb, userCtx);
+    rc = TPM2_Init_ex(ctx, ioCb, userCtx, timeoutTries);
     if (rc != TPM_RC_SUCCESS) {
     #ifdef DEBUG_WOLFTPM
         printf("TPM2_Init failed %d: %s\n", rc, wolfTPM2_GetRCString(rc));
@@ -101,7 +102,7 @@ int wolfTPM2_Test(TPM2HalIoCb ioCb, void* userCtx, WOLFTPM2_CAPS* caps)
     int rc;
     TPM2_CTX ctx;
 
-    rc = wolfTPM2_Init_NoDev(&ctx, ioCb, userCtx);
+    rc = wolfTPM2_Init_NoDev(&ctx, ioCb, userCtx, TPM_STARTUP_TEST_TRIES);
     if (rc != TPM_RC_SUCCESS) {
         return rc;
     }
@@ -110,6 +111,8 @@ int wolfTPM2_Test(TPM2HalIoCb ioCb, void* userCtx, WOLFTPM2_CAPS* caps)
     if (caps) {
         rc = wolfTPM2_GetCapabilities_NoDev(caps);
     }
+
+    TPM2_Cleanup(&ctx);
 
     return rc;
 }
@@ -121,7 +124,7 @@ int wolfTPM2_Init(WOLFTPM2_DEV* dev, TPM2HalIoCb ioCb, void* userCtx)
     if (dev == NULL)
         return BAD_FUNC_ARG;
 
-    rc = wolfTPM2_Init_NoDev(&dev->ctx, ioCb, userCtx);
+    rc = wolfTPM2_Init_NoDev(&dev->ctx, ioCb, userCtx, TPM_TIMEOUT_TRIES);
     if (rc != TPM_RC_SUCCESS) {
         return rc;
     }

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -142,7 +142,7 @@ int wolfTPM2_GetTpmDevId(WOLFTPM2_DEV* dev)
         return BAD_FUNC_ARG;
     }
 
-    return dev->ctx.did_vid; /* not INVALID_DEVID */
+    return dev->ctx.did_vid; /* return something besides INVALID_DEVID */
 }
 
 int wolfTPM2_SelfTest(WOLFTPM2_DEV* dev)
@@ -2028,9 +2028,10 @@ int wolfTPM2_NVDelete(WOLFTPM2_DEV* dev, TPM_HANDLE authHandle,
 #ifndef WOLFTPM2_NO_WOLFCRYPT
 struct WC_RNG* wolfTPM2_GetRng(WOLFTPM2_DEV* dev)
 {
-#ifndef WC_NO_RNG
-    if (dev)
+#ifdef WOLFTPM2_USE_WOLF_RNG
+    if (dev) {
         return &dev->ctx.rng;
+    }
 #endif
     return NULL;
 }

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1626,6 +1626,11 @@ typedef int (*TPM2HalIoCb)(struct TPM2_CTX*, const BYTE* txBuf, BYTE* rxBuf,
     UINT16 xferSz, void* userCtx);
 #endif
 
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(WC_NO_RNG) && \
+    !defined(WOLFTPM2_USE_HW_RNG)
+    #define WOLFTPM2_USE_WOLF_RNG
+#endif
+
 typedef struct TPM2_CTX {
     TPM2HalIoCb ioCb;
     void* userCtx;
@@ -1633,7 +1638,7 @@ typedef struct TPM2_CTX {
 #ifndef SINGLE_THREADED
     wolfSSL_Mutex hwLock;
 #endif
-    #ifndef WC_NO_RNG
+    #ifdef WOLFTPM2_USE_WOLF_RNG
     WC_RNG rng;
     #endif
 #endif /* !WOLFTPM2_NO_WOLFCRYPT */
@@ -1649,6 +1654,16 @@ typedef struct TPM2_CTX {
 
     /* Command Buffer */
     byte cmdBuf[MAX_COMMAND_SIZE];
+
+    /* Informational Bits */
+#ifndef WOLFTPM2_NO_WOLFCRYPT
+    #ifndef SINGLE_THREADED
+    unsigned int hwLockInit:1;
+    #endif
+    #ifndef WC_NO_RNG
+    unsigned int rngInit:1;
+    #endif
+#endif
 } TPM2_CTX;
 
 
@@ -2724,6 +2739,10 @@ WOLFTPM_API const char* TPM2_GetAlgName(TPM_ALG_ID alg);
 WOLFTPM_API int TPM2_GetCurveSize(TPM_ECC_CURVE curveID);
 WOLFTPM_API int TPM2_GetTpmCurve(int curveID);
 WOLFTPM_API int TPM2_GetWolfCurve(int curve_id);
+
+#ifdef WOLFTPM2_USE_WOLF_RNG
+WOLFTPM_API int TPM2_GetWolfRng(WC_RNG** rng);
+#endif
 
 #ifdef DEBUG_WOLFTPM
 WOLFTPM_API void TPM2_PrintBin(const byte* buffer, word32 length);

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -24,6 +24,10 @@
 
 #include <wolftpm/tpm2_types.h>
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
 /* ---------------------------------------------------------------------------*/
 /* TYPES */
 /* ---------------------------------------------------------------------------*/
@@ -2724,5 +2728,8 @@ WOLFTPM_API void TPM2_PrintBin(const byte* buffer, word32 length);
 #define TPM2_PrintBin(b, l)
 #endif
 
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 
 #endif /* __TPM2_H__ */

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -2701,11 +2701,16 @@ WOLFTPM_API int TPM2_SetCommandSet(SetCommandSet_In* in);
 /* Non-standard API's */
 #define _TPM_Init TPM2_Init
 WOLFTPM_API TPM_RC TPM2_Init(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx);
+WOLFTPM_API TPM_RC TPM2_Init_ex(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx,
+    int timeoutTries);
 WOLFTPM_API TPM_RC TPM2_Cleanup(TPM2_CTX* ctx);
 
-
-/* Other API's - Not TPM Spec */
+/* Other API's - Not in TPM Specification */
+WOLFTPM_API TPM_RC TPM2_ChipStartup(TPM2_CTX* ctx, int timeoutTries);
+WOLFTPM_API TPM_RC TPM2_SetHalIoCb(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx);
 WOLFTPM_API TPM_RC TPM2_SetSessionAuth(TPMS_AUTH_COMMAND *cmd);
+
+WOLFTPM_API void      TPM2_SetActiveCtx(TPM2_CTX* ctx);
 WOLFTPM_API TPM2_CTX* TPM2_GetActiveCtx(void);
 
 WOLFTPM_API int TPM2_GetHashDigestSize(TPMI_ALG_HASH hashAlg);
@@ -2722,8 +2727,6 @@ WOLFTPM_API int TPM2_GetWolfCurve(int curve_id);
 
 #ifdef DEBUG_WOLFTPM
 WOLFTPM_API void TPM2_PrintBin(const byte* buffer, word32 length);
-
-
 #else
 #define TPM2_PrintBin(b, l)
 #endif

--- a/wolftpm/tpm2_packet.h
+++ b/wolftpm/tpm2_packet.h
@@ -24,6 +24,10 @@
 
 #include <wolftpm/tpm2.h>
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
 #define TPM2_HEADER_SIZE 10 /* expected TPM2 header size */
 
 /* For reference here is the TPM2 header (not used) */
@@ -93,5 +97,9 @@ WOLFTPM_LOCAL void TPM2_Packet_AppendSignature(TPM2_Packet* packet, TPMT_SIGNATU
 WOLFTPM_LOCAL void TPM2_Packet_ParseSignature(TPM2_Packet* packet, TPMT_SIGNATURE* sig);
 WOLFTPM_LOCAL TPM_RC TPM2_Packet_Parse(TPM_RC rc, TPM2_Packet* packet);
 WOLFTPM_LOCAL int TPM2_Packet_Finalize(TPM2_Packet* packet, TPM_ST tag, TPM_CC cc);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 
 #endif /* __TPM2_PACKET_H__ */

--- a/wolftpm/tpm2_tis.h
+++ b/wolftpm/tpm2_tis.h
@@ -25,6 +25,10 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_packet.h>
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
 /* The default locality to use */
 #ifndef WOLFTPM_LOCALITY_DEFAULT
 #define WOLFTPM_LOCALITY_DEFAULT 0
@@ -53,5 +57,9 @@ WOLFTPM_LOCAL int TPM2_TIS_CheckLocality(TPM2_CTX* ctx, int locality, byte* acce
 WOLFTPM_LOCAL int TPM2_TIS_StartupWait(TPM2_CTX* ctx, int timeout);
 WOLFTPM_LOCAL int TPM2_TIS_Write(TPM2_CTX* ctx, word32 addr, const byte* value, word32 len);
 WOLFTPM_LOCAL int TPM2_TIS_Read(TPM2_CTX* ctx, word32 addr, byte* result, word32 len);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 
 #endif /* __TPM2_TIS_H__ */

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -34,6 +34,10 @@
     #include <wolftpm/options.h>
 #endif
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
 /* ---------------------------------------------------------------------------*/
 /* TPM TYPES */
 /* ---------------------------------------------------------------------------*/
@@ -421,5 +425,8 @@ typedef int64_t  INT64;
     #define WOLFTPM2_WRAP_ECC_KEY_BITS (MAX_ECC_BYTES*8)
 #endif
 
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 
 #endif /* __TPM2_TYPES_H__ */

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -45,7 +45,9 @@
 typedef uint8_t  UINT8;
 typedef uint8_t  BYTE;
 typedef int8_t   INT8;
+#ifndef HAVE_BOOL
 typedef int      BOOL;
+#endif
 typedef uint16_t UINT16;
 typedef int16_t  INT16;
 typedef uint32_t UINT32;
@@ -176,6 +178,10 @@ typedef int64_t  INT64;
 
 #ifndef MAX_SPI_FRAMESIZE
 #define MAX_SPI_FRAMESIZE 64
+#endif
+
+#ifndef TPM_STARTUP_TEST_TRIES
+#define TPM_STARTUP_TEST_TRIES 2
 #endif
 
 #ifndef TPM_TIMEOUT_TRIES

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -63,23 +63,6 @@ typedef int64_t  INT64;
 #endif
 
 
-
-/* ---------------------------------------------------------------------------*/
-/* TPM HARDWARE TYPE */
-/* ---------------------------------------------------------------------------*/
-/* ST ST33TP TPM 2.0 */
-/* #define WOLFTPM_ST33 */
-
-/* Microchip ATTPM20 */
-/* #define WOLFTPM_MCHP */
-
-/* Infineon SLB9670 TPM 2.0 (default) */
-/* #define WOLFTPM_SLB9670 */
-#if !defined(WOLFTPM_ST33) && !defined(WOLFTPM_MCHP) && !defined(WOLFTPM_SLB9670)
-    #define WOLFTPM_SLB9670
-#endif
-
-
 /* ---------------------------------------------------------------------------*/
 /* WOLFCRYPT */
 /* ---------------------------------------------------------------------------*/
@@ -147,6 +130,30 @@ typedef int64_t  INT64;
         #endif
     #endif
 #endif /* !WOLFTPM2_NO_WOLFCRYPT */
+
+/* enable way for customer to override printf */
+#ifdef XPRINTF
+    #undef  printf
+    #define printf XPRINTF
+#endif
+
+
+
+/* ---------------------------------------------------------------------------*/
+/* TPM HARDWARE TYPE */
+/* ---------------------------------------------------------------------------*/
+/* ST ST33TP TPM 2.0 */
+/* #define WOLFTPM_ST33 */
+
+/* Microchip ATTPM20 */
+/* #define WOLFTPM_MCHP */
+
+/* Infineon SLB9670 TPM 2.0 (default) */
+/* #define WOLFTPM_SLB9670 */
+#if !defined(WOLFTPM_ST33) && !defined(WOLFTPM_MCHP) && !defined(WOLFTPM_SLB9670)
+    #define WOLFTPM_SLB9670
+#endif
+
 
 
 /* ---------------------------------------------------------------------------*/

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -45,7 +45,7 @@
 typedef uint8_t  UINT8;
 typedef uint8_t  BYTE;
 typedef int8_t   INT8;
-#ifndef HAVE_BOOL
+#if !defined(BOOL) && !defined(HAVE_BOOL)
 typedef int      BOOL;
 #endif
 typedef uint16_t UINT16;

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -22,8 +22,11 @@
 #ifndef __TPM2_WRAP_H__
 #define __TPM2_WRAP_H__
 
-
 #include <wolftpm/tpm2.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
 
 typedef struct WOLFTPM2_DEV {
     TPM2_CTX ctx;
@@ -293,5 +296,8 @@ WOLFTPM_API int wolfTPM2_ClearCryptoDevCb(WOLFTPM2_DEV* dev, int devId);
 
 #endif /* WOLF_CRYPTO_CB */
 
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 
 #endif /* __TPM2_WRAP_H__ */


### PR DESCRIPTION
* Improvements to hardware test timeout and detection.
* Fix to make sure TPM2_CTX is cleaned up after `wolfTPM2_Test`.
* Optimization to defer initialization of wolf mutex and RNG till use.
* Fix printf type warnings.
* Added C++ support.
* Added missing stdio.h for printf in examples.
* Added new API's `TPM2_SetActiveCtx`, `TPM2_ChipStartup`, `TPM2_SetHalIoCb` and `TPM2_Init_ex`.
* Allowed way to indicate `BOOL` type already defined.
* Added way to force use of TPM RNG instead of wolf using build option `WOLFTPM2_USE_HW_RNG`.