### PR TITLE
Added crypto callback flags for FIPS and Symmetric

### DIFF
--- a/examples/csr/csr.c
+++ b/examples/csr/csr.c
@@ -41,9 +41,9 @@ static const char* gClientCertEccFile = "./certs/tpm-ecc-cert.csr";
 /* --- BEGIN TPM2 CSR Example -- */
 /******************************************************************************/
 
- static int TPM2_CSR_Generate(WOLFTPM2_DEV* dev, int key_type, void* wolfKey,
+static int TPM2_CSR_Generate(WOLFTPM2_DEV* dev, int key_type, void* wolfKey,
     const char* outputPemFile)
- {
+{
     int rc;
     Cert req;
     const CertName myCertName = {
@@ -130,7 +130,7 @@ static const char* gClientCertEccFile = "./certs/tpm-ecc-cert.csr";
 
 exit:
     return rc;
- }
+}
 
 int TPM2_CSR_Example(void* userCtx)
 {

--- a/examples/tls/tls_client.c
+++ b/examples/tls/tls_client.c
@@ -128,6 +128,9 @@ int TPM2_TLS_Client(void* userCtx)
 #endif
     tpmCtx.checkKeyCb = myTpmCheckKey; /* detects if using "dummy" key */
     tpmCtx.storageKey = &storageKey;
+#ifdef WOLFTPM_USE_SYMMETRIC
+    tpmCtx.useSymmetricOnTPM = 1;
+#endif
     rc = wolfTPM2_SetCryptoDevCb(&dev, wolfTPM2_CryptoDevCb, &tpmCtx, &tpmDevId);
     if (rc != 0) goto exit;
 

--- a/examples/tls/tls_server.c
+++ b/examples/tls/tls_server.c
@@ -136,6 +136,9 @@ int TPM2_TLS_Server(void* userCtx)
 #endif
     tpmCtx.checkKeyCb = myTpmCheckKey; /* detects if using "dummy" key */
     tpmCtx.storageKey = &storageKey;
+#ifdef WOLFTPM_USE_SYMMETRIC
+    tpmCtx.useSymmetricOnTPM = 1;
+#endif
     rc = wolfTPM2_SetCryptoDevCb(&dev, wolfTPM2_CryptoDevCb, &tpmCtx, &tpmDevId);
     if (rc != 0) goto exit;
 

--- a/src/tpm2_tis.c
+++ b/src/tpm2_tis.c
@@ -255,6 +255,9 @@ int TPM2_TIS_StartupWait(TPM2_CTX* ctx, int timeout)
         }
         XTPM_WAIT();
     } while (rc == TPM_RC_SUCCESS && --timeout > 0);
+#ifdef WOLFTPM_DEBUG_TIMEOUT
+    printf("TIS_StartupWait: Timeout %d\n", TPM_TIMEOUT_TRIES - timeout);
+#endif
     if (timeout <= 0)
         return TPM_RC_TIMEOUT;
     return rc;
@@ -302,6 +305,9 @@ int TPM2_TIS_RequestLocality(TPM2_CTX* ctx, int timeout)
             }
             XTPM_WAIT();
         } while (rc < 0 && --timeout > 0);
+#ifdef WOLFTPM_DEBUG_TIMEOUT
+        printf("TIS_RequestLocality: Timeout %d\n", TPM_TIMEOUT_TRIES - timeout);
+#endif
         if (timeout <= 0)
             return TPM_RC_TIMEOUT;
     }
@@ -353,6 +359,9 @@ int TPM2_TIS_WaitForStatus(TPM2_CTX* ctx, byte status, byte status_mask)
             break;
         XTPM_WAIT();
     } while (rc == TPM_RC_SUCCESS && --timeout > 0);
+#ifdef WOLFTPM_DEBUG_TIMEOUT
+    printf("TIS_WaitForStatus: Timeout %d\n", TPM_TIMEOUT_TRIES - timeout);
+#endif
     if (timeout <= 0)
         return TPM_RC_TIMEOUT;
     return rc;
@@ -386,6 +395,10 @@ int TPM2_TIS_GetBurstCount(TPM2_CTX* ctx, word16* burstCount)
             break;
         XTPM_WAIT();
     } while (rc == TPM_RC_SUCCESS && --timeout > 0);
+
+#ifdef WOLFTPM_DEBUG_TIMEOUT
+    printf("TIS_GetBurstCount: Timeout %d\n", TPM_TIMEOUT_TRIES - timeout);
+#endif
 
     if (*burstCount > MAX_SPI_FRAMESIZE)
         *burstCount = MAX_SPI_FRAMESIZE;

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -3100,6 +3100,12 @@ int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
                     wolfTPM2_UnloadHandle(tlsCtx->dev, &tlsCtx->ecdhKey->handle);
                 }
             }
+            else if (rc & TPM_RC_CURVE) {
+                /* if the curve is not supported on TPM, then fall-back to software */
+                rc = exit_rc;
+                /* Make sure ECDHE key indicates nothing loaded */
+                tlsCtx->ecdhKey->handle.hndl = TPM_RH_NULL;
+            }
         #endif /* WOLFTPM2_USE_SW_ECDHE */
         }
         else if (info->pk.type == WC_PK_TYPE_ECDSA_SIGN) {
@@ -3158,7 +3164,8 @@ int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
             TPM2B_ECC_POINT pubPoint;
 
             /* Make sure an ECDH key has been set */
-            if (tlsCtx->ecdhKey == NULL || tlsCtx->eccKey == NULL) {
+            if (tlsCtx->ecdhKey == NULL || tlsCtx->eccKey == NULL ||
+            		tlsCtx->ecdhKey->handle.hndl == TPM_RH_NULL) {
                 return exit_rc;
             }
 

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -2536,7 +2536,10 @@ int wolfTPM2_SetCommand(WOLFTPM2_DEV* dev, TPM_CC commandCode, int enableFlag)
 #ifdef WOLFTPM_ST33
     SetCommandSet_In in;
 
-    /* Enable TPM2_EncryptDecrypt2 command */
+    /* clear auth */
+    XMEMSET(&dev->session[0].auth, 0, sizeof(dev->session[0].auth));
+
+    /* Enable commands (like TPM2_EncryptDecrypt2) */
     XMEMSET(&in, 0, sizeof(in));
     in.authHandle = TPM_RH_PLATFORM;
     in.commandCode = commandCode;

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -2711,6 +2711,26 @@ typedef struct {
     UINT32 lockFlag;
 } SetCommandSet_In;
 WOLFTPM_API int TPM2_SetCommandSet(SetCommandSet_In* in);
+
+enum {
+    TPMLib_2 = 0x01,
+    TPMFips = 0x02,
+    TPMLowPowerOff = 0x00,
+    TPMLowPowerByRegister = 0x04,
+    TPMLowPowerByGpio = 0x08,
+    TPMLowPowerAuto = 0x0C,
+};
+typedef struct TPM_MODE_SET {
+    BYTE CmdToLowPower;
+    BYTE BootToLowPower;
+    BYTE modeLock;
+    BYTE mode;
+} TPM_MODE_SET;
+typedef struct {
+    TPMI_RH_HIERARCHY authHandle;
+    TPM_MODE_SET modeSet;
+} SetMode_In;
+WOLFTPM_API int TPM2_SetMode(SetMode_In* in);
 #endif /* WOLFTPM_ST33 */
 
 /* Non-standard API's */

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -289,6 +289,10 @@ typedef struct TpmCryptoDevCtx {
 #endif
     CheckWolfKeyCallbackFunc checkKeyCb;
     WOLFTPM2_KEY* storageKey;
+#ifdef WOLFTPM_USE_SYMMETRIC
+    unsigned short useSymmetricOnTPM:1; /* if set indicates desire to use symmetric algorithms on TPM */
+#endif
+    unsigned short useFIPSMode:1; /* if set requires FIPS mode on TPM and no fallback to software algos */
 } TpmCryptoDevCtx;
 
 WOLFTPM_API int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx);


### PR DESCRIPTION
Added TPM crypto callback flags for FIPS mode and Use Symmetric.

`useSymmetricOnTPM`: Tells wolfTPM crypto callback to use symmetric AES/SHA1/SHA2 on the TPM module.
`useFIPSMode`: Tell wolfTPM crypto callback to fail if any algorithm isn't supported, thus not allowing any software crypto for FIPS mode.

* Added support for ST33 `TPM2_SetMode` command for disabling power saving.
* Added `WOLFTPM_DEBUG_TIMEOUT` macro for debugging the timeout checking.
* Fix for `wolfTPM2_SetCommand` to ensure auth is cleared.