### PR TITLE
Added support for keeping an HMAC key loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ examples/csr/csr
 examples/tls/tls_client
 examples/pkcs7/pkcs7
 pkcs7tpmsigned.p7s
+pkcs7tpmsignedex.p7s
 examples/tls/tls_server
 examples/tls/tls_client_notpm
 tests/unit.test

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ examples/pkcs7/pkcs7
 pkcs7tpmsigned.p7s
 examples/tls/tls_server
 examples/tls/tls_client_notpm
+tests/unit.test
 
 # Generated Cert Files
 certs/ca-*.pem

--- a/certs/certreq.sh
+++ b/certs/certreq.sh
@@ -5,7 +5,7 @@ echo Run ./examples/crl/crl first to generate the CSR
 
 
 # Make sure required CA files exist and are populated
-rm ./certs/index.*
+rm -f ./certs/index.*
 touch ./certs/index.txt 
 if [ ! -f ./certs/serial ]; then
 	echo 1000 > ./certs/serial
@@ -15,13 +15,14 @@ if [ ! -f ./certs/crlnumber ]; then
 fi
 
 if [ "$1" == "clean" ]; then
-	rm ./certs/1*.pem
-	rm ./certs/ca-*.pem
-	rm ./certs/client-*.pem
-	rm ./certs/client-*.der
-	rm ./certs/server-*.pem
-	rm ./certs/server-*.der
-	rm ./certs/*.old
+	rm -f ./certs/1*.pem
+	rm -f ./certs/ca-*.pem
+	rm -f ./certs/client-*.pem
+	rm -f ./certs/client-*.der
+	rm -f ./certs/server-*.pem
+	rm -f ./certs/server-*.der
+	rm -f ./certs/*.old
+	exit 0
 fi
 
 

--- a/certs/certreq.sh
+++ b/certs/certreq.sh
@@ -22,6 +22,10 @@ if [ "$1" == "clean" ]; then
 	rm -f ./certs/server-*.pem
 	rm -f ./certs/server-*.der
 	rm -f ./certs/*.old
+
+	# cleanup the ./examples/crl/crl generated
+	rm -f ./certs/tpm-*-cert.csr
+	
 	exit 0
 fi
 

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -537,6 +537,7 @@ int TPM2_Wrapper_Test(void* userCtx)
     /*------------------------------------------------------------------------*/
     /* HASH TESTS */
     /*------------------------------------------------------------------------*/
+    XMEMSET(&hash, 0, sizeof(hash));
     rc = wolfTPM2_HashStart(&dev, &hash, TPM_ALG_SHA256,
         (const byte*)gUsageAuth, sizeof(gUsageAuth)-1);
     if (rc != 0) goto exit;
@@ -571,6 +572,8 @@ int TPM2_Wrapper_Test(void* userCtx)
     /*------------------------------------------------------------------------*/
     /* HMAC TESTS */
     /*------------------------------------------------------------------------*/
+    XMEMSET(&hmac, 0, sizeof(hmac));
+    hmac.hmacKeyKeep = 1; /* don't unload key on finish */
     rc = wolfTPM2_HmacStart(&dev, &hmac, &storageKey.handle, TPM_ALG_SHA256,
         (const byte*)hmacTestKey, (word32)XSTRLEN(hmacTestKey),
         (const byte*)gUsageAuth, sizeof(gUsageAuth)-1);
@@ -589,6 +592,15 @@ int TPM2_Wrapper_Test(void* userCtx)
         printf("HMAC SHA256 test failed, result not as expected!\n");
         goto exit;
     }
+
+    /* Can reuse the HMAC key here:
+     *   wolfTPM2_HmacStart, wolfTPM2_HmacUpdate, wolfTPM2_HmacFinish
+     */
+
+    /* Manually unload HMAC key, since hmacKeyKeep was set above */
+    /* If hmacKeyKeep == 0 then key will be unloaded in wolfTPM2_HmacFinish */
+    wolfTPM2_UnloadHandle(&dev, &hmac.key.handle);
+
     printf("HMAC SHA256 test success\n");
 
 

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -57,6 +57,10 @@ typedef struct WOLFTPM2_HASH {
 typedef struct WOLFTPM2_HMAC {
     WOLFTPM2_HASH   hash;
     WOLFTPM2_KEY    key;
+
+    /* option bits */
+    word16 hmacKeyLoaded:1;
+    word16 hmacKeyKeep:1;
 } WOLFTPM2_HMAC;
 
 #ifndef WOLFTPM2_MAX_BUFFER


### PR DESCRIPTION
Added support for keeping an HMAC key loaded on finish to allow using the same key for additional HMAC operations. ZD 5442