### PR TITLE
Add Xilinx Zynqmp bare-metal SPI support

### DIFF
--- a/examples/tpm_io.c
+++ b/examples/tpm_io.c
@@ -24,7 +24,7 @@
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_tis.h>
-#include <examples/tpm_io.h>
+#include "tpm_io.h"
 
 
 /******************************************************************************/
@@ -32,7 +32,12 @@
 /******************************************************************************/
 
 /* Configuration for the SPI interface */
-/* SPI Requirement: Mode 0 (CPOL=0, CPHA=0), Speed up to 50Mhz */
+/* SPI Requirement: Mode 0 (CPOL=0, CPHA=0) */
+
+/* Use the max speed by default - see tpm2_types.h for chip specific max values */
+#ifndef TPM2_SPI_HZ
+    #define TPM2_SPI_HZ TPM2_SPI_MAX_HZ
+#endif
 
 #if defined(__linux__)
     #include <sys/ioctl.h>
@@ -60,32 +65,12 @@
             /* Microchip ATTPM20 */
             /* SPI uses CE0 */
             #define TPM2_SPI_DEV "/dev/spidev0.0"
-            /* Requires SPI wait states */
-            #ifndef WOLFTPM_CHECK_WAIT_STATE
-                #define WOLFTPM_CHECK_WAIT_STATE
-            #endif
-            #ifndef TPM2_SPI_HZ
-                /* Max: 36MHz (has issues so using 33MHz) */
-                #define TPM2_SPI_HZ 33000000
-            #endif
         #elif defined(WOLFTPM_ST33)
             /* STM ST33HTPH SPI uses CE0 */
             #define TPM2_SPI_DEV "/dev/spidev0.0"
-            /* Requires wait state support */
-            #ifndef WOLFTPM_CHECK_WAIT_STATE
-                #define WOLFTPM_CHECK_WAIT_STATE
-            #endif
-            #ifndef TPM2_SPI_HZ
-                /* Max: 33MHz */
-                #define TPM2_SPI_HZ 33000000
-            #endif
         #else
             /* OPTIGA SLB9670 and LetsTrust TPM use CE1 */
             #define TPM2_SPI_DEV "/dev/spidev0.1"
-            #ifndef TPM2_SPI_HZ
-                /* Max: 43MHz */
-                #define TPM2_SPI_HZ 43000000
-            #endif
         #endif
     #endif
 

--- a/examples/tpm_io.c
+++ b/examples/tpm_io.c
@@ -99,6 +99,18 @@
     #include <spi/spi.h>
     #include <spi/spi_gpio.h>
 
+#elif defined(__XILINX__)
+
+    #include "xspips.h"
+    static int SpiInitDone;
+    static XSpiPs SpiInstance;
+    #ifndef TPM2_SPI_CHIPSELECT
+    #define TPM2_SPI_CHIPSELECT 0x00
+    #endif
+    #ifndef TPM2_SPI_DEVID
+    #define TPM2_SPI_DEVID      XPAR_XSPIPS_1_DEVICE_ID
+    #endif
+
 #else
     /* TODO: Add your platform here for HW interface */
 
@@ -512,6 +524,184 @@
 
         return ret;
     }
+
+#elif defined(__XILINX__)
+
+    #define XSpiPs_SendByte(BaseAddress, Data) \
+        XSpiPs_Out32((BaseAddress) + (u32)XSPIPS_TXD_OFFSET, (u32)(Data))
+    #define XSpiPs_RecvByte(BaseAddress) \
+        XSpiPs_In32((u32)((BaseAddress) + (u32)XSPIPS_RXD_OFFSET))
+
+    /* Modified version of XSpiPs_PolledTransfer that allows enable and CS to 
+     * be used across multiple transfers */
+    static s32 TPM2_IoCb_Xilinx_SPITransfer(XSpiPs *InstancePtr, u8 *SendBufPtr,
+        u8 *RecvBufPtr, u32 ByteCount)
+    {
+        u32 StatusReg;
+        u32 ConfigReg;
+        u32 TransCount;
+        u32 CheckTransfer;
+        u8 TempData;
+
+        /* Set up buffer pointers */
+        InstancePtr->SendBufferPtr = SendBufPtr;
+        InstancePtr->RecvBufferPtr = RecvBufPtr;
+        InstancePtr->RequestedBytes = ByteCount;
+        InstancePtr->RemainingBytes = ByteCount;
+
+        while((InstancePtr->RemainingBytes > (u32)0U) ||
+              (InstancePtr->RequestedBytes > (u32)0U))
+        {
+            TransCount = 0U;
+
+            /* Fill the TXFIFO with as many bytes as it will take (or as
+             * many as we have to send). */
+            while ((InstancePtr->RemainingBytes > (u32)0U) && 
+                ((u32)TransCount < (u32)XSPIPS_FIFO_DEPTH))
+            {
+                XSpiPs_SendByte(InstancePtr->Config.BaseAddress, 
+                    *InstancePtr->SendBufferPtr);
+                InstancePtr->SendBufferPtr += 1;
+                InstancePtr->RemainingBytes--;
+                ++TransCount;
+            }
+
+            /* If master mode and manual start mode, issue manual start
+             * command to start the transfer. */
+            if ((XSpiPs_IsManualStart(InstancePtr) == TRUE) && 
+                (XSpiPs_IsMaster(InstancePtr) == TRUE))
+            {
+                ConfigReg = XSpiPs_ReadReg(InstancePtr->Config.BaseAddress, 
+                    XSPIPS_CR_OFFSET);
+                ConfigReg |= XSPIPS_CR_MANSTRT_MASK;
+                XSpiPs_WriteReg(InstancePtr->Config.BaseAddress, 
+                    XSPIPS_CR_OFFSET, ConfigReg);
+            }
+
+            /* Wait for the transfer to finish by polling Tx fifo status. */
+            CheckTransfer = (u32)0U;
+            while (CheckTransfer == 0U) {
+                StatusReg = XSpiPs_ReadReg(InstancePtr->Config.BaseAddress, 
+                    XSPIPS_SR_OFFSET);
+                if ((StatusReg & XSPIPS_IXR_MODF_MASK) != 0U) {
+                    /* Clear the mode fail bit */
+                    XSpiPs_WriteReg(InstancePtr->Config.BaseAddress, 
+                        XSPIPS_SR_OFFSET, XSPIPS_IXR_MODF_MASK);
+                    return (s32)XST_SEND_ERROR;
+                }
+                CheckTransfer = (StatusReg & XSPIPS_IXR_TXOW_MASK);
+            }
+
+            /*
+             * A transmit has just completed. Process received data and
+             * check for more data to transmit.
+             * First get the data received as a result of the transmit
+             * that just completed. Receive data based on the
+             * count obtained while filling tx fifo. Always get the
+             * received data, but only fill the receive buffer if it
+             * points to something (the upper layer software may not
+             * care to receive data).
+             */
+            while (TransCount != (u32)0U) {
+                TempData = (u8)XSpiPs_RecvByte(InstancePtr->Config.BaseAddress);
+                if (InstancePtr->RecvBufferPtr != NULL) {
+                    *(InstancePtr->RecvBufferPtr) = TempData;
+                    InstancePtr->RecvBufferPtr += 1;
+                }
+                InstancePtr->RequestedBytes--;
+                --TransCount;
+            }
+        }
+
+        return (s32)XST_SUCCESS;
+    }
+
+    static int TPM2_IoCb_Xilinx_SPI(TPM2_CTX* ctx, const byte* txBuf,
+        byte* rxBuf, word16 xferSz, void* userCtx)
+    {
+        int ret = TPM_RC_FAILURE;
+        int status;
+        XSpiPs_Config *SpiConfig;
+    #ifdef WOLFTPM_CHECK_WAIT_STATE
+        int timeout = TPM_SPI_WAIT_RETRY;
+    #endif
+
+        if (!SpiInitDone) {
+            /* Initialize the SPI driver so that it's ready to use */
+            SpiConfig = XSpiPs_LookupConfig(TPM2_SPI_DEVID);
+            if (SpiConfig == NULL) {
+                return TPM_RC_FAILURE;
+            }
+            status = XSpiPs_CfgInitialize(&SpiInstance, SpiConfig, 
+                SpiConfig->BaseAddress);
+            if (status != XST_SUCCESS) {
+                return TPM_RC_FAILURE;
+            }
+
+            /* Set the SPI device as a master */
+            XSpiPs_SetOptions(&SpiInstance, XSPIPS_MASTER_OPTION | 
+                XSPIPS_FORCE_SSELECT_OPTION | XSPIPS_MANUAL_START_OPTION);
+            XSpiPs_SetClkPrescaler(&SpiInstance, XSPIPS_CLK_PRESCALE_8);
+
+            SpiInitDone = 1;
+        }
+
+        XSpiPs_Enable(&SpiInstance);
+        XSpiPs_SetSlaveSelect(&SpiInstance, TPM2_SPI_CHIPSELECT);
+
+    #ifdef WOLFTPM_CHECK_WAIT_STATE
+        /* Send Header */
+        status = TPM2_IoCb_Xilinx_SPITransfer(&SpiInstance, 
+            (byte*)txBuf, rxBuf, TPM_TIS_HEADER_SZ);
+        if (status != XST_SUCCESS) {
+            XSpiPs_SetSlaveSelect(&SpiInstance, 0xF); /* deselect CS (set high) */
+            XSpiPs_Disable(&SpiInstance);
+            return ret;
+        }
+
+        /* Check for wait states */
+        if ((rxBuf[TPM_TIS_HEADER_SZ-1] & TPM_TIS_READY_MASK) == 0) {
+            do {
+                /* Check for SPI ready */
+                status = TPM2_IoCb_Xilinx_SPITransfer(&SpiInstance, 
+                    (byte*)txBuf, rxBuf, 1);
+                if (status == XST_SUCCESS && rxBuf[0] & TPM_TIS_READY_MASK)
+                    break;
+            } while (ret == TPM_RC_SUCCESS && --timeout > 0);
+        #ifdef WOLFTPM_DEBUG_TIMEOUT
+            printf("SPI Ready Wait %d\n", TPM_SPI_WAIT_RETRY - timeout);
+        #endif
+            if (timeout <= 0) {
+                XSpiPs_SetSlaveSelect(&SpiInstance, 0xF); /* deselect CS (set high) */
+                XSpiPs_Disable(&SpiInstance);
+                return TPM_RC_FAILURE;
+            }
+        }
+
+        /* Send remainder of payload */
+        status = TPM2_IoCb_Xilinx_SPITransfer(&SpiInstance,
+            (byte*)&txBuf[TPM_TIS_HEADER_SZ],
+            &rxBuf[TPM_TIS_HEADER_SZ],
+            xferSz - TPM_TIS_HEADER_SZ);
+    #else
+        /* Send Entire Message - no wait states */
+        status = TPM2_IoCb_Xilinx_SPITransfer(&SpiInstance, 
+            (byte*)txBuf, rxBuf, xferSz);
+    #endif /* WOLFTPM_CHECK_WAIT_STATE */
+        if (status == XST_SUCCESS) {
+            ret = TPM_RC_SUCCESS;
+        }
+
+        XSpiPs_SetSlaveSelect(&SpiInstance, 0xF); /* deselect CS (set high) */
+        XSpiPs_Disable(&SpiInstance);
+
+        (void)userCtx;
+        (void)ctx;
+
+        return ret;
+    }
+
+
 #endif
 
 
@@ -529,6 +719,8 @@ static int TPM2_IoCb_SPI(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
     ret = TPM2_IoCb_Atmel_SPI(ctx, txBuf, rxBuf, xferSz, userCtx);
 #elif defined(__BAREBOX__)
     ret = TPM2_IoCb_Barebox_SPI(ctx, txBuf, rxBuf, xferSz, userCtx);
+#elif defined(__XILINX__)
+    ret = TPM2_IoCb_Xilinx_SPI(ctx, txBuf, rxBuf, xferSz, userCtx);
 #else
 
     /* TODO: Add your platform here for HW SPI interface */

--- a/wolftpm/tpm2_tis.h
+++ b/wolftpm/tpm2_tis.h
@@ -37,11 +37,7 @@
 #define TPM_TIS_READ        0x80
 #define TPM_TIS_WRITE       0x00
 
-#ifdef WOLFTPM_ST33
-#define TPM_TIS_HEADER_SZ 5
-#else
 #define TPM_TIS_HEADER_SZ 4
-#endif
 
 #define TPM_TIS_READY_MASK 0x01
 

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -154,6 +154,35 @@ typedef int64_t  INT64;
     #define WOLFTPM_SLB9670
 #endif
 
+/* Chip Specific Settings */
+#ifdef WOLFTPM_MCHP
+    /* Microchip ATTPM20 */
+    /* Requires SPI wait states */
+    #ifndef WOLFTPM_CHECK_WAIT_STATE
+        #define WOLFTPM_CHECK_WAIT_STATE
+    #endif
+    #ifndef TPM2_SPI_MAX_HZ
+        /* Max: 36MHz (has issues so using 33MHz) */
+        #define TPM2_SPI_MAX_HZ 33000000
+    #endif
+#elif defined(WOLFTPM_ST33)
+    /* ST33TPM20 modules */
+    /* Requires wait state support */
+    #ifndef WOLFTPM_CHECK_WAIT_STATE
+        #define WOLFTPM_CHECK_WAIT_STATE
+    #endif
+    #ifndef TPM2_SPI_MAX_HZ
+        /* Max: 33MHz */
+        #define TPM2_SPI_MAX_HZ 33000000
+    #endif
+#else
+    /* OPTIGA SLB9670 */
+    #ifndef TPM2_SPI_MAX_HZ
+        /* Max: 43MHz */
+        #define TPM2_SPI_MAX_HZ 43000000
+    #endif
+#endif
+
 
 
 /* ---------------------------------------------------------------------------*/


### PR DESCRIPTION
* Add Xilinx Zynqmp bare-metal SPI support.
* Fixed obsolete workaround for ST33 and TIS header size.
* Moved the chip specific settings to `tpm2_types.h`.