### PR TITLE
Fix for building wolfTPM with older wolfSSL versions

### DIFF
--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -82,6 +82,7 @@ typedef int64_t  INT64;
     #ifdef WOLF_CRYPTO_CB
         #include <wolfssl/wolfcrypt/cryptocb.h>
     #elif defined(WOLF_CRYPTO_DEV)
+        /* old name for crypto callback support */
         #include <wolfssl/wolfcrypt/cryptodev.h>
     #endif
     #ifndef WOLFCRYPT_ONLY
@@ -92,6 +93,13 @@ typedef int64_t  INT64;
 	#ifdef DEBUG_WOLFTPM
 		#include <stdio.h>
 	#endif
+
+    #include <wolfssl/version.h>
+    #if defined(LIBWOLFSSL_VERSION_HEX) && LIBWOLFSSL_VERSION_HEX < 0x03015004
+        /* The wc_HashFree was added in v3.15.4, so use stub to allow building */
+        #define wc_HashFree(h, t)
+    #endif
+
 #else
 
     #include <stdio.h>

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -97,7 +97,7 @@ typedef int64_t  INT64;
     #include <wolfssl/version.h>
     #if defined(LIBWOLFSSL_VERSION_HEX) && LIBWOLFSSL_VERSION_HEX < 0x03015004
         /* The wc_HashFree was added in v3.15.4, so use stub to allow building */
-        #define wc_HashFree(h, t)
+        #define wc_HashFree(h, t) (0)
     #endif
 
 #else


### PR DESCRIPTION
Fix for building wolfTPM with older wolfSSL versions not supporting `wc_HashFree`.

Fixes Error:

```
src/tpm2_wrap.c:738:9: error: implicit declaration of function 'wc_HashFree' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        wc_HashFree(&hash, hashType);
        ^
src/tpm2_wrap.c:738:9: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
src/tpm2_wrap.c:2555:9: error: implicit declaration of function 'wc_HashFree' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        wc_HashFree(&hash, hashType);
        ^
3 errors generated.
```