### PR TITLE
For for ECC verify software fallback if curve not supported

### DIFF
--- a/examples/csr/csr.c
+++ b/examples/csr/csr.c
@@ -34,8 +34,12 @@
 
 #include <stdio.h>
 
+#ifndef NO_RSA
 static const char* gClientCertRsaFile = "./certs/tpm-rsa-cert.csr";
+#endif
+#ifdef HAVE_ECC
 static const char* gClientCertEccFile = "./certs/tpm-ecc-cert.csr";
+#endif
 
 /******************************************************************************/
 /* --- BEGIN TPM2 CSR Example -- */

--- a/examples/pkcs7/pkcs7.c
+++ b/examples/pkcs7/pkcs7.c
@@ -316,7 +316,9 @@ int TPM2_PKCS7_Example(void* userCtx)
 
     /* Setup the wolf crypto device callback */
     XMEMSET(&tpmCtx, 0, sizeof(tpmCtx));
+#ifndef NO_RSA
     tpmCtx.rsaKey = &rsaKey;
+#endif
     rc = wolfTPM2_SetCryptoDevCb(&dev, wolfTPM2_CryptoDevCb, &tpmCtx, &tpmDevId);
     if (rc < 0) goto exit;
 

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -3467,6 +3467,10 @@ int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
 
                     wolfTPM2_UnloadHandle(tlsCtx->dev, &eccPub.handle);
                 }
+                else if (rc & TPM_RC_CURVE) {
+                    /* if the curve is not supported on TPM, then fall-back to software */
+                    rc = exit_rc;
+                }
             }
         }
         else if (info->pk.type == WC_PK_TYPE_ECDH) {


### PR DESCRIPTION
* Fix for ECC verify in crypto callback to try software if the curve is not supported (`TPM_RC_CURVE`) by the TPM hardware.
* Fixes for building without wolfCrypt RSA (when `NO_RSA` is defined).

ZD 9855