### PR TITLE
Add linux dev tpm interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Portable TPM 2.0 project designed for embedded use.
 
 * This implementation provides all TPM 2.0 API’s in compliance with the specification.
 * Wrappers provided to simplify Key Generation/Loading, RSA encrypt/decrypt, ECC sign/verify, ECDH, NV, Hashing/Hmac and AES.
-* Testing done using the STM ST33TP* SPI/I2C, Infineon OPTIGA SLB9670 and Microchip ATTPM20 TPM 2.0 modules.
-* This uses the TPM Interface Specification (TIS) to communicate over SPI.
+* Testing done using the STM ST33TP* SPI/I2C, Infineon OPTIGA SLB9670, Microchip ATTPM20 TPM 2.0 modules and Nuveton NPCT650.
+* wolfTPM uses the TPM Interface Specification (TIS) to communicate over SPI.
+* wolfTPM can also use the Linux TPM kernel interface (/dev/tpmX) to talk with any physical TPM on SPI, I2C and even LPC bus.
 * Platform support for Raspberry Pi, STM32 with CubeMX, Atmel ASF and Barebox.
 * The design allows for easy portability to different platforms:
 	* Native C code designed for embedded use.
@@ -72,6 +73,7 @@ Tested with:
 * LetsTrust: http://letstrust.de (https://buyzero.de/collections/andere-platinen/products/letstrust-hardware-tpm-trusted-platform-module). Compact Raspberry Pi TPM 2.0 board based on Infineon SLB 9670.
 * ST ST33TP* TPM 2.0 module (SPI and I2C)
 * Microchip ATTPM20
+* Nuveton NPCT650 TPM2.0
 
 #### Device Identification
 
@@ -89,6 +91,9 @@ Mfg MCHP (3), Vendor , Fw 512.20481 (0), FIPS 140-2 0, CC-EAL4 0
 
 Nations Technologies Inc. TPM 2.0 module
 Mfg NTZ (0), Vendor Z32H330, Fw 7.51 (419631892), FIPS 140-2 0, CC-EAL4 0
+
+Nuveton NPCT650 TPM2.0
+Mfg NTC (0), Vendor rlsNPCT , Fw 1.3 (65536), FIPS 140-2 0, CC-EAL4 0
 
 
 ## Building
@@ -160,6 +165,24 @@ Build wolfTPM:
 ./autogen.sh
 ./configure --enable-mchp
 make
+```
+
+### Building for "/dev/tpmX"
+
+This build option allows you to talk to any TPM vendor supported by the Linux TIS kernel driver
+
+Build wolfTPM:
+
+```
+./autogen.sh
+./configure --enable-devtpm
+make
+```
+
+Note: When using a TPM device through the Linux kernel driver make sure sufficient permissions are given to the application that uses wolfTPM, because the "/dev/tpmX" typically has read-write permissions only for the "tss" user group. Either run wolfTPM examples and your application using sudo or add your user to the "tss" group like this:
+
+```
+sudo adduser yourusername tss
 ```
 
 ## Running Examples

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Portable TPM 2.0 project designed for embedded use.
 
 * This implementation provides all TPM 2.0 API’s in compliance with the specification.
 * Wrappers provided to simplify Key Generation/Loading, RSA encrypt/decrypt, ECC sign/verify, ECDH, NV, Hashing/Hmac and AES.
-* Testing done using the STM ST33TP* SPI/I2C, Infineon OPTIGA SLB9670, Microchip ATTPM20 TPM 2.0 modules and Nuveton NPCT650.
+* Testing done using the STM ST33TP* SPI/I2C, Infineon OPTIGA SLB9670, Microchip ATTPM20 TPM 2.0 modules and Nuvoton NPCT650.
 * wolfTPM uses the TPM Interface Specification (TIS) to communicate over SPI.
 * wolfTPM can also use the Linux TPM kernel interface (/dev/tpmX) to talk with any physical TPM on SPI, I2C and even LPC bus.
 * Platform support for Raspberry Pi, STM32 with CubeMX, Atmel ASF and Barebox.
@@ -73,7 +73,7 @@ Tested with:
 * LetsTrust: http://letstrust.de (https://buyzero.de/collections/andere-platinen/products/letstrust-hardware-tpm-trusted-platform-module). Compact Raspberry Pi TPM 2.0 board based on Infineon SLB 9670.
 * ST ST33TP* TPM 2.0 module (SPI and I2C)
 * Microchip ATTPM20
-* Nuveton NPCT650 TPM2.0
+* Nuvoton NPCT650 TPM2.0
 
 #### Device Identification
 
@@ -92,7 +92,7 @@ Mfg MCHP (3), Vendor , Fw 512.20481 (0), FIPS 140-2 0, CC-EAL4 0
 Nations Technologies Inc. TPM 2.0 module
 Mfg NTZ (0), Vendor Z32H330, Fw 7.51 (419631892), FIPS 140-2 0, CC-EAL4 0
 
-Nuveton NPCT650 TPM2.0
+Nuvoton NPCT650 TPM2.0
 Mfg NTC (0), Vendor rlsNPCT , Fw 1.3 (65536), FIPS 140-2 0, CC-EAL4 0
 
 

--- a/README.md
+++ b/README.md
@@ -553,7 +553,6 @@ Connection: close
 ## Todo
 * Add support for encrypting / decrypting parameters.
 * Add support for SensitiveToPrivate inner and outer.
-* Add `spi_tis_dev` support for Raspberry Pi.
 * Add runtime support for detecting module type ST33, SLB9670 or ATTPM20.
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -162,6 +162,19 @@ then
 fi
 
 
+# Linux kernel TPM device Support
+AC_ARG_ENABLE([devtpm],
+    [AS_HELP_STRING([--enable-devtpm],[Enable use of TPM through the Linux kernel driver (default: disabled)])],
+    [ ENABLED_DEVTPM=$enableval ],
+    [ ENABLED_DEVTPM=no ]
+    )
+
+if test "x$ENABLED_DEVTPM" = "xyes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_LINUX_DEV"
+fi
+
+
 # STM ST33 Support
 AC_ARG_ENABLE([st33],
     [AS_HELP_STRING([--enable-st33],[Enable ST33 TPM Support (default: disabled)])],

--- a/configure.ac
+++ b/configure.ac
@@ -242,6 +242,7 @@ AM_CONDITIONAL([BUILD_ADVIO], [test "x$ENABLED_ADVIO" = "xyes"])
 AM_CONDITIONAL([BUILD_ST33], [test "x$ENABLED_ST33" = "xyes"])
 AM_CONDITIONAL([BUILD_MCHP], [test "x$ENABLED_MCHP" = "xyes"])
 AM_CONDITIONAL([BUILD_INFINEON], [test "x$ENABLED_INFINEON" = "xyes"])
+AM_CONDITIONAL([BUILD_DEVTPM], [test "x$ENABLED_DEVTPM" = "xyes"])
 
 
 
@@ -359,3 +360,4 @@ echo "   * Infineon SLB9670           $ENABLED_INFINEON"
 echo "   * STM ST33:                  $ENABLED_ST33"
 echo "   * Microchip ATTPM20:         $ENABLED_MCHP"
 echo "   * I2C:                       $ENABLED_I2C"
+echo "   * Linux kernel TPM device:   $ENABLED_DEVTPM"

--- a/src/include.am
+++ b/src/include.am
@@ -8,8 +8,12 @@ src_libwolftpm_la_SOURCES      = \
                                 src/tpm2.c \
                                 src/tpm2_packet.c \
                                 src/tpm2_tis.c \
-                                src/tpm2_wrap.c \
-                                src/tpm2_linux.c
+                                src/tpm2_wrap.c
+
+if BUILD_DEVTPM
+src_libwolftpm_la_SOURCES      += src/tpm2_linux.c
+endif
+
 src_libwolftpm_la_CFLAGS       = -DBUILDING_WOLFTPM $(AM_CFLAGS)
 src_libwolftpm_la_CPPFLAGS     = -DBUILDING_WOLFTPM $(AM_CPPFLAGS)
 src_libwolftpm_la_LDFLAGS      = ${AM_LDFLAGS} -no-undefined -version-info ${WOLFTPM_LIBRARY_VERSION} 

--- a/src/include.am
+++ b/src/include.am
@@ -5,10 +5,10 @@
 
 lib_LTLIBRARIES+=  src/libwolftpm.la
 src_libwolftpm_la_SOURCES      = \
-								src/tpm2.c \
-								src/tpm2_packet.c \
-								src/tpm2_tis.c \
-								src/tpm2_wrap.c \
+                                src/tpm2.c \
+                                src/tpm2_packet.c \
+                                src/tpm2_tis.c \
+                                src/tpm2_wrap.c \
                                 src/tpm2_linux.c
 src_libwolftpm_la_CFLAGS       = -DBUILDING_WOLFTPM $(AM_CFLAGS)
 src_libwolftpm_la_CPPFLAGS     = -DBUILDING_WOLFTPM $(AM_CPPFLAGS)

--- a/src/include.am
+++ b/src/include.am
@@ -8,7 +8,8 @@ src_libwolftpm_la_SOURCES      = \
 								src/tpm2.c \
 								src/tpm2_packet.c \
 								src/tpm2_tis.c \
-								src/tpm2_wrap.c 
+								src/tpm2_wrap.c \
+                                src/tpm2_linux.c
 src_libwolftpm_la_CFLAGS       = -DBUILDING_WOLFTPM $(AM_CFLAGS)
 src_libwolftpm_la_CPPFLAGS     = -DBUILDING_WOLFTPM $(AM_CPPFLAGS)
 src_libwolftpm_la_LDFLAGS      = ${AM_LDFLAGS} -no-undefined -version-info ${WOLFTPM_LIBRARY_VERSION} 

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -167,7 +167,11 @@ static TPM_RC TPM2_SendCommandAuth(TPM2_CTX* ctx, TPM2_Packet* packet,
     }
 
     /* submit command and wait for response */
+#ifdef WOLFTPM_LINUX_DEV
+    rc = (TPM_RC)TPM2_LINUX_SendCommand(ctx, cmd, cmdSz);
+#else
     rc = (TPM_RC)TPM2_TIS_SendCommand(ctx, cmd, cmdSz);
+#endif
 
     /* parse response */
     rc = TPM2_Packet_Parse(rc, packet);

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -23,6 +23,7 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_packet.h>
 #include <wolftpm/tpm2_tis.h>
+#include <wolftpm/tpm2_linux.h>
 
 /******************************************************************************/
 /* --- Local Variables -- */
@@ -232,7 +233,11 @@ static TPM_RC TPM2_SendCommand(TPM2_CTX* ctx, TPM2_Packet* packet)
         return BAD_FUNC_ARG;
 
     /* submit command and wait for response */
+#ifndef WOLFTPM_LINUX_DEV
     rc = (TPM_RC)TPM2_TIS_SendCommand(ctx, packet->buf, packet->pos);
+#else
+    rc = (TPM_RC)TPM2_LINUX_SendCommand(ctx, packet->buf, packet->pos);
+#endif
 
     return TPM2_Packet_Parse(rc, packet);
 }
@@ -248,6 +253,20 @@ static TPM_ST TPM2_GetTag(TPM2_CTX* ctx)
     return st;
 }
 
+#ifndef WOLFTPM2_NO_WOLFCRYPT
+static inline void TPM2_WolfCrypt_Init(void)
+{
+    /* track reference count for wolfCrypt initialization */
+    if (gWolfCryptRefCount == 0) {
+    #ifdef DEBUG_WOLFSSL
+        wolfSSL_Debugging_ON();
+    #endif
+
+        wolfCrypt_Init();
+    }
+    gWolfCryptRefCount++;
+}
+#endif
 
 /******************************************************************************/
 /* --- Public Functions -- */
@@ -342,16 +361,8 @@ TPM_RC TPM2_Init_ex(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx,
     XMEMSET(ctx, 0, sizeof(TPM2_CTX));
 
 #ifndef WOLFTPM2_NO_WOLFCRYPT
-    /* track reference count for wolfCrypt initialization */
-    if (gWolfCryptRefCount == 0) {
-    #ifdef DEBUG_WOLFSSL
-        wolfSSL_Debugging_ON();
-    #endif
-
-        wolfCrypt_Init();
-    }
-    gWolfCryptRefCount++;
-#endif /* !WOLFTPM2_NO_WOLFCRYPT */
+    TPM2_WolfCrypt_Init();
+#endif
 
     /* Setup HAL IO Callback */
     rc = TPM2_SetHalIoCb(ctx, ioCb, userCtx);
@@ -369,6 +380,29 @@ TPM_RC TPM2_Init_ex(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx,
         /* use existing locality */
         ctx->locality = WOLFTPM_LOCALITY_DEFAULT;
     }
+
+    return rc;
+}
+
+TPM_RC TPM2_Init_minimal(TPM2_CTX* ctx)
+{
+    TPM_RC rc = TPM_RC_SUCCESS;
+
+    if (ctx == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    XMEMSET(ctx, 0, sizeof(TPM2_CTX));
+
+#ifndef WOLFTPM2_NO_WOLFCRYPT
+    TPM2_WolfCrypt_Init();
+#endif
+
+    /* Set the active TPM global */
+    TPM2_SetActiveCtx(ctx);
+
+    /* Use existing locality */
+    ctx->locality = WOLFTPM_LOCALITY_DEFAULT;
 
     return rc;
 }

--- a/src/tpm2_linux.c
+++ b/src/tpm2_linux.c
@@ -94,12 +94,14 @@ int TPM2_LINUX_SendCommand(TPM2_CTX* ctx, byte* cmd, word16 cmdSz)
                 printf("Failed to get a response from fd %d, got errno %d ="
                     "%s\n", fd, errno, strerror(errno));
             }
-        }
-        else {
-        printf("Failed to send the TPM command to fd %d, got errno %d ="
-            "%s\n", fd, errno, strerror(errno));
         #endif
         }
+        #ifdef WOLFTPM_DEBUG_VERBOSE
+        else {
+            printf("Failed to send the TPM command to fd %d, got errno %d ="
+                "%s\n", fd, errno, strerror(errno));
+        }
+        #endif
 
         close(fd);
     }

--- a/src/tpm2_linux.c
+++ b/src/tpm2_linux.c
@@ -1,0 +1,116 @@
+/* tpm2_linux.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+#include <wolftpm/tpm2_linux.h>
+#include <wolftpm/tpm2_packet.h>
+#include <wolftpm/tpm2_wrap.h> /* Needed only for WOLFTPM2_MAX_BUFFER */
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <poll.h>
+#include <errno.h>
+#include <string.h>
+
+
+#define TPM2_LINUX_DEV "/dev/tpm0"
+#define TPM2_LINUX_DEV_POLL_TIMEOUT -1 /* Infinite time for poll events */
+#define TPM2_LINUX_DEV_RSP_SIZE WOLFTPM2_MAX_BUFFER
+/* Linux kernels older than v4.20 (before December 2018) do not support
+ * partial reads. The only way to receive a complete response is to read
+ * the maximum allowed TPM response from the kernel, which is 4K. And most
+ * of the ARM systems use older kernels, such as the RPI that uses v4.12
+ *
+ * The caller knows what the expected outcome of the operation is. Therefore,
+ * the response size is limited only by the WOLFTPM2_MAX_BUFFER used to limit
+ * the WOLFTPM2_BUFFER in wolfTPM wrappers */
+
+
+/* Talk to a TPM device exposed by the Linux tpm_tis driver */
+int TPM2_LINUX_SendCommand(TPM2_CTX* ctx, byte* cmd, word16 cmdSz)
+{
+    int rc = TPM_RC_FAILURE;
+    int fd, rspSz;
+    int rc_poll, nfds= 1; /* Polling single TPM dev file */
+    struct pollfd fds;
+
+#ifdef DEBUG_WOLFTPM /* TODO: Change to WOLFTPM_DEBUG_VERBOSE */
+    printf("Command size: %d\n", cmdSz);
+    TPM2_PrintBin(cmd, cmdSz);
+#endif
+
+    fd = open(TPM2_LINUX_DEV, O_RDWR | O_NONBLOCK);
+    if (fd > 0) {
+        /* Send the TPM command */
+        if (write(fd, cmd, cmdSz) == cmdSz) {
+            fds.fd = fd;
+            fds.events = POLLIN;
+            /* Wait for response to be available */
+            rc_poll = poll(&fds, nfds, TPM2_LINUX_DEV_POLL_TIMEOUT);
+            if (rc_poll > 0 && fds.revents == POLLIN) {
+                rspSz = read(fd, cmd, TPM2_LINUX_DEV_RSP_SIZE);
+                if (rspSz > 0) {
+                    UINT32 tmpSz;
+                    XMEMCPY(&tmpSz, &cmd[2], sizeof(UINT32));
+                    rspSz = TPM2_Packet_SwapU32(tmpSz);
+                    /* Enough bytes for a TPM response? */
+                    if (rspSz >= TPM2_HEADER_SIZE) {
+                        rc = TPM_RC_SUCCESS;
+                    }
+                #ifdef DEBUG_WOLFTPM
+                    else
+                    {
+                        printf("Response size is %d bytes, not enough to "
+                            "hold TPM response.\n", rspSz);
+                    }
+                }
+                else if (rspSz == 0) {
+                    printf("Received EOF instead of TPM response.\n");
+                }
+                else {
+                    printf("Failed to read from TPM device %d, got errno %d"
+                        " = %s\n", fd, errno, strerror(errno));
+                #endif
+                }
+            }
+        #ifdef DEBUG_WOLFTPM /* TODO: Change to WOLFTPM_DEBUG_TIMEOUT */
+            else {
+                printf("Failed to get a response from fd %d, got errno %d ="
+                    "%s\n", fd, errno, strerror(errno));
+            }
+        #endif
+        }
+
+        close(fd);
+    }
+
+#ifdef DEBUG_WOLFTPM /* TODO: Change to WOLFTPM_DEBUG_VERBOSE */
+    if (rspSz > 0) {
+        printf("Response size: %d\n", rspSz);
+        TPM2_PrintBin(cmd, rspSz);
+    }
+#endif
+
+    (void)ctx;
+
+    return rc;
+}

--- a/src/tpm2_linux.c
+++ b/src/tpm2_linux.c
@@ -73,29 +73,21 @@ int TPM2_LINUX_SendCommand(TPM2_CTX* ctx, byte* cmd, word16 cmdSz)
             rc_poll = poll(&fds, nfds, TPM2_LINUX_DEV_POLL_TIMEOUT);
             if (rc_poll > 0 && fds.revents == POLLIN) {
                 rspSz = read(fd, cmd, TPM2_LINUX_DEV_RSP_SIZE);
-                if (rspSz > 0) {
-                    UINT32 tmpSz;
-                    XMEMCPY(&tmpSz, &cmd[2], sizeof(UINT32));
-                    rspSz = TPM2_Packet_SwapU32(tmpSz);
-                    /* Enough bytes for a TPM response? */
-                    if (rspSz >= TPM2_HEADER_SIZE) {
-                        rc = TPM_RC_SUCCESS;
-                    }
-                #ifdef DEBUG_WOLFTPM
-                    else
-                    {
-                        printf("Response size is %ld bytes, not enough to "
-                            "hold TPM response.\n", rspSz);
-                    }
+                /* The caller parses the TPM_Packet for correctness */
+                if (rspSz >= TPM2_HEADER_SIZE) {
+                    /* Enough bytes for a TPM response */
+                    rc = TPM_RC_SUCCESS;
                 }
+                #ifdef DEBUG_WOLFTPM
                 else if (rspSz == 0) {
                     printf("Received EOF instead of TPM response.\n");
                 }
-                else {
+                else
+                {
                     printf("Failed to read from TPM device %d, got errno %d"
                         " = %s\n", fd, errno, strerror(errno));
-                #endif
                 }
+                #endif
             }
         #ifdef WOLFTPM_DEBUG_VERBOSE
             else {
@@ -122,7 +114,7 @@ int TPM2_LINUX_SendCommand(TPM2_CTX* ctx, byte* cmd, word16 cmdSz)
 
 #ifdef WOLFTPM_DEBUG_VERBOSE
     if (rspSz > 0) {
-        printf("Response size: %ld\n", rspSz);
+        printf("Response size: %d\n", (int)rspSz);
         TPM2_PrintBin(cmd, rspSz);
     }
 #endif

--- a/wolftpm/include.am
+++ b/wolftpm/include.am
@@ -8,6 +8,7 @@ nobase_include_HEADERS+= \
                          wolftpm/tpm2_tis.h \
                          wolftpm/tpm2_types.h \
                          wolftpm/tpm2_wrap.h \
+                         wolftpm/tpm2_linux.h \
                          wolftpm/version.h \
                          wolftpm/visibility.h \
                          wolftpm/options.h

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -2738,6 +2738,7 @@ WOLFTPM_API int TPM2_SetMode(SetMode_In* in);
 WOLFTPM_API TPM_RC TPM2_Init(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx);
 WOLFTPM_API TPM_RC TPM2_Init_ex(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx,
     int timeoutTries);
+WOLFTPM_API TPM_RC TPM2_Init_minimal(TPM2_CTX* ctx);
 WOLFTPM_API TPM_RC TPM2_Cleanup(TPM2_CTX* ctx);
 
 /* Other API's - Not in TPM Specification */

--- a/wolftpm/tpm2_linux.h
+++ b/wolftpm/tpm2_linux.h
@@ -1,0 +1,38 @@
+/* tpm2_linux.h
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef _TPM2_LINUX_H_
+#define _TPM2_LINUX_H_
+
+#include <wolftpm/tpm2.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+/* TPM2 IO for using TPM through the Linux kernel driver */
+int TPM2_LINUX_SendCommand(TPM2_CTX* ctx, byte* cmd, word16 cmdSz);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* _TPM2_LINUX_H_ */

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -229,7 +229,11 @@ typedef int64_t  INT64;
 #endif
 
 #ifndef TPM_TIMEOUT_TRIES
-#define TPM_TIMEOUT_TRIES 1000000
+    #ifdef WOLFTPM_LINUX_DEV
+    #define TPM_TIMEOUT_TRIES 0
+    #else
+    #define TPM_TIMEOUT_TRIES 1000000
+    #endif
 #endif
 
 #ifndef TPM_SPI_WAIT_RETRY


### PR DESCRIPTION
This PR adds the ability to talk to a TPM using the Linux TIS kernel driver. This means, talking to any TPM that supports the TCG TIS protocol, regardless if on I2C, SPI or even LPC bus. The Linux kernel abstracts the physical interface and provides TIS interface using char device at /dev/tpmX

All native tests pass, but one: the PCR Extend command test.

The code is tested against:
* Infineon TPM2.0 Iridium 9670 on RPI4 (SW: latest Raspbian/ Kernel 4.12)
* Nuvoton TPM2.0 npct650 on x86 test machine (SW: Ubuntu 19.10 / Kernel 5.3)

One thing that I would want to also add are unit tests.

This is my first try to add functionality to wolfTPM, so all feedback is highly welcomed :)
