### PR TITLE
Adding more testing

### DIFF
--- a/examples/native/native_test.c
+++ b/examples/native/native_test.c
@@ -115,6 +115,7 @@ int TPM2_Native_Test(void* userCtx)
         GetRandom_Out getRand;
         GetTestResult_Out tr;
         IncrementalSelfTest_Out incSelfTest;
+        ReadClock_Out readClock;
         PCR_Read_Out pcrRead;
         CreatePrimary_Out createPri;
         Create_Out create;
@@ -344,6 +345,17 @@ int TPM2_Native_Test(void* userCtx)
         goto exit;
     }
     printf("TPM2_StirRandom: success\n");
+
+
+    /* ReadClock */
+    XMEMSET(&cmdOut.readClock, 0, sizeof(cmdOut.readClock));
+    rc = TPM2_ReadClock(&cmdOut.readClock);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_ReadClock failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("TPM2_ReadClock: success\n");
 
 
     /* PCR Read */

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -88,11 +88,18 @@ static void test_wolfTPM2_Init(void)
     int rc;
     WOLFTPM2_DEV dev;
 
-    /* Test arguments */
+    /* Test first argument, wolfTPM2 context */
     rc = wolfTPM2_Init(NULL, TPM2_IoCb, NULL);
     AssertIntNE(rc, 0);
+    /* Test second argument, TPM2 IO Callbacks */
     rc = wolfTPM2_Init(&dev, NULL, NULL);
+#ifdef WOLFTPM_LINUX_DEV
+    /* Custom IO Callbacks are not needed for Linux TIS driver */
+    AssertIntEQ(rc, 0);
+#else
+    /* IO Callbacks are required for SPIdev/I2C and must be valid */
     AssertIntNE(rc, 0);
+#endif
 
     /* Test success */
     rc = wolfTPM2_Init(&dev, TPM2_IoCb, NULL);


### PR DESCRIPTION
The idea of this PR is to add more TPM2 Native commands testing. It also includes small fix for wolfTPM2 unit testing.

I am also looking into making the testing somewhat functional, I changed the PCR Extend test to be on PCR16, so I can then use it in the PCR_Reset test, which is the first new native test. Here is an example of how the output looks for the user running the native tests:

```
TPM2_PCR_Extend success
TPM2_PCR_Read: Index 16, Count 1
TPM2_PCR_Read: Index 16, Digest Sz 32, Update Counter 129

	bb 22 75 c4 9f 28 ad 52 ca e6 d5 5e 34 a9 74 a5 | ."u..(.R...^4.t.
	8c 7a 3b a2 6f 97 6e 8e cb be 7a 53 69 18 dc 73 | .z;.o.n...zSi..s

TPM2_PCR_Reset command success
PCR Reset: PCR16 value check after reset
PCR Reset: PCR16 read successfully after reset

	00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................
	00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................

TPM2_StartAuthSession: sessionHandle 0x3000000
```

The user can clearly see the PCR was extended and then cleared, besides just testing the wolfTPM2 implementation of the TPM2 commands.

I am adding more commits to this PR, this is why I publish it as a draft for now. In next commit I am adding TPM2_ReadClock. Stay tuned :)