### PR TITLE
Signed timestamp example (AIK and Attestation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ examples/bench/bench
 examples/csr/csr
 examples/tls/tls_client
 examples/pkcs7/pkcs7
+examples/timestamp/signed_timestamp
 pkcs7tpmsigned.p7s
 pkcs7tpmsignedex.p7s
 examples/tls/tls_server

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,7 +24,7 @@ Demonstrates calling the wolfTPM2_* wrapper API's.
 
 Demonstrates creation of Attestation Identity Keys(AIK) and the generation of TPM signed timestamp that can be later used as protected report of the current system uptime.
 
-This example demonstrates the use of authSession(authorization Sesssion) and policySession(Policy authorization) to enable the Endorsement Hierarachy necessary for creating AIK. Then, the AIK is used to issue a TPM2_GetTime command using the wolfTPM2 native API. This provides us with TPM generated and signed timestamp that can be used as a system report of its uptime.
+This example demonstrates the use of authSession(authorization Session) and policySession(Policy authorization) to enable the Endorsement Hierarchy necessary for creating AIK. Then, the AIK is used to issue a TPM2_GetTime command using the wolfTPM2 native API. This provides us with TPM generated and signed timestamp that can be used as a system report of its uptime.
 
 `./examples/timestamp/signed_timestamp`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,15 @@ Demonstrates calling the wolfTPM2_* wrapper API's.
 `./examples/wrap/wrap_test`
 
 
+## Attestation Use Case (TPM signed timestamp)
+
+Demonstrates creation of Attestation Identity Keys(AIK) and the generation of TPM signed timestamp that can be later used as protected report of the current system uptime.
+
+This example demonstrates the use of authSession(authorization Sesssion) and policySession(Policy authorization) to enable the Endorsement Hierarachy necessary for creating AIK. Then, the AIK is used to issue a TPM2_GetTime command using the wolfTPM2 native API. This provides us with TPM generated and signed timestamp that can be used as a system report of its uptime.
+
+`./examples/timestamp/signed_timestamp`
+
+
 ## CSR
 
 Generates a Certificate Signing Request for building a certificate based on a TPM key pair.

--- a/examples/include.am
+++ b/examples/include.am
@@ -7,6 +7,7 @@ include examples/bench/include.am
 include examples/tls/include.am
 include examples/csr/include.am
 include examples/pkcs7/include.am
+include examples/timestamp/include.am
 
 dist_example_DATA+= examples/README.md \
                     examples/tpm_io.c \

--- a/examples/timestamp/include.am
+++ b/examples/timestamp/include.am
@@ -1,0 +1,14 @@
+# vim:ft=automake
+# All paths should be given relative to the root
+
+if BUILD_EXAMPLES
+noinst_PROGRAMS += examples/timestamp/signed_timestamp
+noinst_HEADERS  += examples/timestamp/signed_timestamp.h
+examples_timestamp_signed_timestamp_SOURCES      = examples/timestamp/signed_timestamp.c \
+									       examples/tpm_io.c
+examples_timestamp_signed_timestamp_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
+examples_timestamp_signed_timestamp_DEPENDENCIES = src/libwolftpm.la
+endif
+
+dist_example_DATA+= examples/timestamp/signed_timestamp.c
+DISTCLEANFILES+= examples/timestamp/.libs/signed_timestamp

--- a/examples/timestamp/signed_timestamp.c
+++ b/examples/timestamp/signed_timestamp.c
@@ -325,7 +325,7 @@ int TPM2_Timestamp_Test(void* userCtx)
     /* Print result in human friendly way */
     attestedTime = (TPMS_TIME_ATTEST_INFO*)cmdOut.getTime.timeInfo.attestationData;
     printf("TPM2_GetTime: TPMS_TIME_ATTEST_INFO with signature attests:\n");
-    printf("* TPM Uptime (in ms) since power-up = %lu\n", attestedTime->time.clockInfo.clock);
+    printf("* TPM Uptime (in ms) since power-up = %lu\n", (unsigned long)attestedTime->time.clockInfo.clock);
 
 exit:
 

--- a/examples/timestamp/signed_timestamp.c
+++ b/examples/timestamp/signed_timestamp.c
@@ -1,0 +1,326 @@
+/* signed_timestamp.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/* This example shows how to use extended authorization sessions (TPM2.0) and
+ * generate a signed timestamp from the TPM using a Attestation Identity Key.
+ */
+
+#include <wolftpm/tpm2.h>
+
+#include <examples/timestamp/signed_timestamp.h>
+#include <examples/tpm_io.h>
+#include <examples/tpm_test.h>
+
+#include <stdio.h>
+
+
+/******************************************************************************/
+/* --- BEGIN TPM Timestamp Test -- */
+/******************************************************************************/
+
+typedef struct tpmKey {
+    TPM_HANDLE          handle;
+    TPM2B_AUTH          auth;
+    TPM2B_PRIVATE       priv;
+    TPM2B_PUBLIC        pub;
+    TPM2B_NAME          name;
+} TpmKey; /* Type used to store the output from Key generation */
+
+
+int TPM2_Timestamp_Test(void* userCtx)
+{
+    int rc;
+    TPM2_CTX tpm2Ctx;
+
+    union {
+        GetTime_In getTime;
+        /* For creating keys */
+        CreatePrimary_In createPri;
+        Create_In create;
+        /* For managing TPM session */
+        StartAuthSession_In authSes;
+        PolicySecret_In policySecret;
+        /* Loading a key and removing objects */
+        Load_In load;
+        FlushContext_In flushCtx;
+        byte maxInput[MAX_COMMAND_SIZE];
+    } cmdIn;
+    union {
+        ReadClock_Out readClock;
+        GetTime_Out getTime;
+        /* Output from creating keys */
+        CreatePrimary_Out createPri;
+        Create_Out create;
+        /* Output from session operations */
+        StartAuthSession_Out authSes;
+        PolicySecret_Out policySecret;
+        /* Output from loading a key into the TPM */
+        Load_Out load;
+        byte maxOutput[MAX_RESPONSE_SIZE];
+    } cmdOut;
+
+    TPM_HANDLE sessionHandle = TPM_RH_NULL;
+
+    TpmKey endorse = { .handle = TPM_RH_NULL }; /* EK  */
+    TpmKey rsaKey = { .handle = TPM_RH_NULL };  /* AIK */
+
+    const char usageAuth[] = "ThisIsASecretUsageAuth";
+    const char keyCreationNonce[] = "RandomServerPickedCreationNonce";
+
+    TPMS_AUTH_COMMAND session[MAX_SESSION_NUM];
+
+
+    printf("TPM2 Demo of generating signed timestamp from the TPM\n");
+    rc = TPM2_Init(&tpm2Ctx, TPM2_IoCb, userCtx);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_Init failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+
+
+    /* Define the default session auth that has NULL password */
+    XMEMSET(session, 0, sizeof(session));
+    session[0].sessionHandle = TPM_RS_PW;
+    session[0].auth.size = 0; /* NULL Password */
+    TPM2_SetSessionAuth(session);
+
+
+    /* ReadClock for quick test of the TPM communication */
+    XMEMSET(&cmdOut.readClock, 0, sizeof(cmdOut.readClock));
+    rc = TPM2_ReadClock(&cmdOut.readClock);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_ReadClock failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("TPM2_ReadClock: success\n");
+
+
+    /* Create Primary (Endorsement Key) */
+    XMEMSET(&cmdIn.createPri, 0, sizeof(cmdIn.createPri));
+    cmdIn.createPri.primaryHandle = TPM_RH_ENDORSEMENT;
+    /* Policy for creating the EK */
+    cmdIn.createPri.inPublic.publicArea.authPolicy.size =
+        sizeof(TPM_20_EK_AUTH_POLICY);
+    XMEMCPY(cmdIn.createPri.inPublic.publicArea.authPolicy.buffer,
+        TPM_20_EK_AUTH_POLICY,
+        cmdIn.createPri.inPublic.publicArea.authPolicy.size);
+    /* Parameters of the EK */
+    cmdIn.createPri.inPublic.publicArea.type = TPM_ALG_RSA;
+    cmdIn.createPri.inPublic.publicArea.unique.rsa.size = MAX_RSA_KEY_BITS / 8;
+    cmdIn.createPri.inPublic.publicArea.nameAlg = TPM_ALG_SHA256;
+    cmdIn.createPri.inPublic.publicArea.objectAttributes = (
+        TPMA_OBJECT_fixedTPM | TPMA_OBJECT_fixedParent |
+        TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_adminWithPolicy |
+        TPMA_OBJECT_restricted | TPMA_OBJECT_decrypt);
+    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.keyBits = MAX_RSA_KEY_BITS;
+    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.exponent = 0;
+    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.scheme.scheme = TPM_ALG_NULL;
+    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_AES;
+    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 128;
+    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.symmetric.mode.aes = TPM_ALG_CFB;
+    /* Ready to create the EK */
+    rc = TPM2_CreatePrimary(&cmdIn.createPri, &cmdOut.createPri);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_CreatePrimary: Endorsement failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+    /* Store the EK */
+    endorse.handle = cmdOut.createPri.objectHandle;
+    endorse.auth = cmdIn.createPri.inPublic.publicArea.authPolicy;
+    endorse.pub = cmdOut.createPri.outPublic;
+    endorse.name = cmdOut.createPri.name;
+    printf("TPM2_CreatePrimary: Endorsement 0x%x (%d bytes)\n",
+        (word32)endorse.handle, endorse.pub.size);
+
+
+    /* Start Auth Session */
+    XMEMSET(&cmdIn.authSes, 0, sizeof(cmdIn.authSes));
+    cmdIn.authSes.sessionType = TPM_SE_POLICY;
+    cmdIn.authSes.tpmKey = TPM_RH_NULL;
+    cmdIn.authSes.bind = TPM_RH_NULL;
+    cmdIn.authSes.symmetric.algorithm = TPM_ALG_NULL;
+    cmdIn.authSes.authHash = TPM_ALG_SHA256;
+    cmdIn.authSes.nonceCaller.size = TPM_SHA256_DIGEST_SIZE;
+    rc = TPM2_GetNonce(cmdIn.authSes.nonceCaller.buffer,
+                       cmdIn.authSes.nonceCaller.size);
+    if (rc < 0) {
+        printf("TPM2_GetNonce failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    rc = TPM2_StartAuthSession(&cmdIn.authSes, &cmdOut.authSes);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_StartAuthSession failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    sessionHandle = cmdOut.authSes.sessionHandle;
+    printf("TPM2_StartAuthSession: sessionHandle 0x%x\n", (word32)sessionHandle);
+
+
+    /* Set PolicySecret for our session to enable use of the Endoresment Hierarchy */
+    XMEMSET(&cmdIn.policySecret, 0, sizeof(cmdIn.policySecret));
+    cmdIn.policySecret.authHandle = TPM_RH_ENDORSEMENT;
+    cmdIn.policySecret.policySession = sessionHandle;
+    rc = TPM2_PolicySecret(&cmdIn.policySecret, &cmdOut.policySecret);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("policySecret failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("TPM2_policySecret success\n"); /* No use of the output */
+
+
+    /* At this stage, the EK is created and NULL password has alredy been set
+     * The EH is enabled through policySecret over the active TPM session and
+     * the creation of Attestation Identity Key under the EH can take place.
+     */
+
+
+    /* Create an RSA key for Attestation purposes */
+    XMEMSET(&cmdIn.create, 0, sizeof(cmdIn.create));
+    cmdIn.create.parentHandle = endorse.handle;
+    /* Set auth required for using the AIK later */
+    cmdIn.create.inSensitive.sensitive.userAuth.size = sizeof(usageAuth)-1;
+    XMEMCPY(cmdIn.create.inSensitive.sensitive.userAuth.buffer, usageAuth,
+        cmdIn.create.inSensitive.sensitive.userAuth.size);
+    /* AIK parameters */
+    cmdIn.create.inPublic.publicArea.type = TPM_ALG_RSA;
+    cmdIn.create.inPublic.publicArea.unique.rsa.size = MAX_RSA_KEY_BITS / 8;
+    cmdIn.create.inPublic.publicArea.nameAlg = TPM_ALG_SHA256;
+    cmdIn.create.inPublic.publicArea.objectAttributes = (
+        TPMA_OBJECT_fixedTPM | TPMA_OBJECT_fixedParent | TPMA_OBJECT_restricted |
+        TPMA_OBJECT_sensitiveDataOrigin |
+        TPMA_OBJECT_userWithAuth | TPMA_OBJECT_sign | TPMA_OBJECT_noDA);
+    cmdIn.create.inPublic.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_NULL;
+    cmdIn.create.inPublic.publicArea.parameters.rsaDetail.scheme.scheme = TPM_ALG_RSASSA;
+    cmdIn.create.inPublic.publicArea.parameters.rsaDetail.scheme.details.anySig.hashAlg = TPM_ALG_SHA256;
+    cmdIn.create.inPublic.publicArea.parameters.rsaDetail.keyBits = MAX_RSA_KEY_BITS;
+    cmdIn.create.outsideInfo.size = sizeof(keyCreationNonce)-1;
+    XMEMCPY(cmdIn.create.outsideInfo.buffer, keyCreationNonce,
+        cmdIn.create.outsideInfo.size);
+    /* Create the AIK */
+    rc = TPM2_Create(&cmdIn.create, &cmdOut.create);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_Create RSA failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("TPM2_Create: New RSA Key: pub %d, priv %d\n",
+        cmdOut.create.outPublic.size,
+        cmdOut.create.outPrivate.size);
+    /* Store the AIK */
+    rsaKey.pub = cmdOut.create.outPublic;
+    rsaKey.priv = cmdOut.create.outPrivate;
+
+
+    /* Load new key */
+    XMEMSET(&cmdIn.load, 0, sizeof(cmdIn.load));
+    cmdIn.load.parentHandle = endorse.handle;
+    cmdIn.load.inPrivate = rsaKey.priv;
+    cmdIn.load.inPublic = rsaKey.pub;
+    rc = TPM2_Load(&cmdIn.load, &cmdOut.load);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_Load RSA key failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    rsaKey.handle = cmdOut.load.objectHandle;
+    printf("TPM2_Load RSA Key Handle 0x%x\n", (word32)rsaKey.handle);
+
+
+    /* set auth for using the AIK */
+    session[1].sessionHandle = TPM_RS_PW;
+    session[1].auth.size = sizeof(usageAuth)-1;
+    XMEMCPY(session[1].auth.buffer, usageAuth, session[1].auth.size);
+
+
+    /* At this stage: The EK is created, AIK is created and loaded,
+     * Endorsement Hierarchy is enabled through policySecret,
+     * the use of the loaded AIK is enabled through its usageAuth.
+     * Invoking attestation of the TPM time structure can take place.
+     */
+
+    /* GetTime */
+    XMEMSET(&cmdIn.getTime, 0, sizeof(cmdIn.getTime));
+    XMEMSET(&cmdOut.getTime, 0, sizeof(cmdOut.getTime));
+    cmdIn.getTime.privacyAdminHandle = TPM_RH_ENDORSEMENT;
+    /* TPM_RH_NULL is a valid handle for NULL signature */
+    cmdIn.getTime.signHandle = rsaKey.handle;
+    /* TPM_ALG_NULL is a valid hanle for  NULL signature */
+    cmdIn.getTime.inScheme.scheme = TPM_ALG_RSASSA;
+    cmdIn.getTime.inScheme.details.rsassa.hashAlg = TPM_ALG_SHA256;
+    cmdIn.getTime.qualifyingData.size = 0; /* optional */
+    rc = TPM2_GetTime(&cmdIn.getTime, &cmdOut.getTime);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_GetTime failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("TPM2_GetTime: success\n");
+
+
+exit:
+
+    /* Close session */
+    if (sessionHandle != TPM_RH_NULL) {
+        cmdIn.flushCtx.flushHandle = sessionHandle;
+        TPM2_FlushContext(&cmdIn.flushCtx);
+    }
+
+    /* Close object handle */
+    if (rsaKey.handle != TPM_RH_NULL) {
+        cmdIn.flushCtx.flushHandle = rsaKey.handle;
+        TPM2_FlushContext(&cmdIn.flushCtx);
+    }
+
+    /* Cleanup key handles */
+    if (endorse.handle != TPM_RH_NULL) {
+        cmdIn.flushCtx.flushHandle = endorse.handle;
+        TPM2_FlushContext(&cmdIn.flushCtx);
+    }
+
+    TPM2_Cleanup(&tpm2Ctx);
+
+#ifdef TPM2_SPI_DEV
+    /* close handle */
+    if (gSpiDev >= 0)
+        close(gSpiDev);
+#endif
+
+    return rc;
+}
+
+/******************************************************************************/
+/* --- END TPM Timestamp Test -- */
+/******************************************************************************/
+
+
+#ifndef NO_MAIN_DRIVER
+int main(void)
+{
+    int rc;
+
+    rc = TPM2_Timestamp_Test(NULL);
+
+    return rc;
+}
+#endif

--- a/examples/timestamp/signed_timestamp.c
+++ b/examples/timestamp/signed_timestamp.c
@@ -49,6 +49,7 @@ int TPM2_Timestamp_Test(void* userCtx)
 {
     int rc;
     TPM2_CTX tpm2Ctx;
+    TPMS_TIME_ATTEST_INFO* attestedTime = NULL;
 
     union {
         GetTime_In getTime;
@@ -321,7 +322,10 @@ int TPM2_Timestamp_Test(void* userCtx)
         goto exit;
     }
     printf("TPM2_GetTime: success\n");
-
+    /* Print result in human friendly way */
+    attestedTime = (TPMS_TIME_ATTEST_INFO*)cmdOut.getTime.timeInfo.attestationData;
+    printf("TPM2_GetTime: TPMS_TIME_ATTEST_INFO with signature attests:\n");
+    printf("* TPM Uptime (in ms) since power-up = %lu\n", attestedTime->time.clockInfo.clock);
 
 exit:
 

--- a/examples/timestamp/signed_timestamp.c
+++ b/examples/timestamp/signed_timestamp.c
@@ -215,7 +215,7 @@ int TPM2_Timestamp_Test(void* userCtx)
     printf("TPM2_StartAuthSession: sessionHandle 0x%x\n", (word32)sessionHandle);
 
 
-    /* Set PolicySecret for our session to enable use of the Endoresment Hierarchy */
+    /* Set PolicySecret for our session to enable use of the Endorsement Hierarchy */
     XMEMSET(&cmdIn.policySecret, 0, sizeof(cmdIn.policySecret));
     cmdIn.policySecret.authHandle = TPM_RH_ENDORSEMENT;
     cmdIn.policySecret.policySession = sessionHandle;
@@ -227,7 +227,7 @@ int TPM2_Timestamp_Test(void* userCtx)
     printf("TPM2_policySecret success\n"); /* No use of the output */
 
 
-    /* At this stage, the EK is created and NULL password has alredy been set
+    /* At this stage, the EK is created and NULL password has already been set
      * The EH is enabled through policySecret over the active TPM session and
      * the creation of Attestation Identity Key under the EH can take place.
      */
@@ -311,7 +311,7 @@ int TPM2_Timestamp_Test(void* userCtx)
     cmdIn.getTime.privacyAdminHandle = TPM_RH_ENDORSEMENT;
     /* TPM_RH_NULL is a valid handle for NULL signature */
     cmdIn.getTime.signHandle = rsaKey.handle;
-    /* TPM_ALG_NULL is a valid hanle for  NULL signature */
+    /* TPM_ALG_NULL is a valid handle for  NULL signature */
     cmdIn.getTime.inScheme.scheme = TPM_ALG_RSASSA;
     cmdIn.getTime.inScheme.details.rsassa.hashAlg = TPM_ALG_SHA256;
     cmdIn.getTime.qualifyingData.size = 0; /* optional */
@@ -325,7 +325,8 @@ int TPM2_Timestamp_Test(void* userCtx)
     /* Print result in human friendly way */
     attestedTime = (TPMS_TIME_ATTEST_INFO*)cmdOut.getTime.timeInfo.attestationData;
     printf("TPM2_GetTime: TPMS_TIME_ATTEST_INFO with signature attests:\n");
-    printf("* TPM Uptime (in ms) since power-up = %lu\n", (unsigned long)attestedTime->time.clockInfo.clock);
+    printf("* TPM Uptime (in ms) since power-up = %lu\n", 
+        (unsigned long)attestedTime->time.clockInfo.clock);
 
 exit:
 
@@ -335,19 +336,15 @@ exit:
         TPM2_FlushContext(&cmdIn.flushCtx);
     }
 
-    /* Close object handle */
+    /* Close key handles */
     if (rsaKey.handle != TPM_RH_NULL) {
         cmdIn.flushCtx.flushHandle = rsaKey.handle;
         TPM2_FlushContext(&cmdIn.flushCtx);
     }
-
-    /* Cleanup key handles */
     if (endorse.handle != TPM_RH_NULL) {
         cmdIn.flushCtx.flushHandle = endorse.handle;
         TPM2_FlushContext(&cmdIn.flushCtx);
     }
-
-    /* Cleanup key handles */
     if (storage.handle != TPM_RH_NULL) {
         cmdIn.flushCtx.flushHandle = storage.handle;
         TPM2_FlushContext(&cmdIn.flushCtx);

--- a/examples/timestamp/signed_timestamp.c
+++ b/examples/timestamp/signed_timestamp.c
@@ -345,7 +345,7 @@ exit:
 
     /* Cleanup key handles */
     if (storage.handle != TPM_RH_NULL) {
-        cmdIn.flushCtx.flushHandle = endorse.handle;
+        cmdIn.flushCtx.flushHandle = storage.handle;
         TPM2_FlushContext(&cmdIn.flushCtx);
     }
 

--- a/examples/timestamp/signed_timestamp.h
+++ b/examples/timestamp/signed_timestamp.h
@@ -1,0 +1,35 @@
+/* signed_timestamp.h
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef _SIGNED_TIMESTAMP_H_
+#define _SIGNED_TIMESTAMP_H_
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+int TPM2_Timestamp_Test(void* userCtx);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* _SIGNED_TIMESTAMP_H_ */


### PR DESCRIPTION
This is the first step toward enabling wolfTPM to be used for System Integrity and Attestation.

The work here is continuation of #93 but stands on its own as it solves a very interesting problem.

This example creates EK, then sets up a TPM AuthSession for using the Endorsement Hierarchy(EH) under which an Attestation Identity Key(AIK) is to be created. Using this AIK we can attest the TPM time structure. A future use would be using another AIK to generate a quote of the system state.

Currently, the AIK creation fails with strange error for authPolicy or authValue unavailable. This is odd, because we are using PolicySecret to enable the use of the EH, in accordance with the TCG spec and turns out we do it the same way the Intel stack does in their [tpm2_createak](https://github.com/tpm2-software/tpm2-tools/blob/master/tools/tpm2_createak.c#L228) tool.

```
TPM2 Demo of generating signed timestamp from the TPM
TPM2_ReadClock: success
TPM2_CreatePrimary: Endorsement 0x80000000 (314 bytes)
TPM2_StartAuthSession: sessionHandle 0x3000000
TPM2_policySecret success
TPM2_Create RSA failed 0x12f: TPM_RC_AUTH_UNAVAILABLE: The authValue or authPolicy is not available for selected entity
```

So, this example is pivotal for making Authorization Session for EK work with wolfTPM(#95), creating the special type of AIK keys and have the first ever use of wolfTPM for attestation. I am sure there is some tiny detail missing to have this fully working.

Note: I have an alternative version using EK with password authentication (in violation of the TCG spec) and then I am able to create AIK. But the TPM2_GetTime fails with badAuth (probably because of the violation). Still, this was a good test to determine that the params for AIK create are good and the TPM2_Create( AIK ) can succeed. Creating AIK under EH is where things hit an odd error.

In nutshell, it only remains to figure out why  TPM2_Create ( AIK ) is not satisfied by policySecret that  succeeds.