### PR TITLE
Add missing xor overload to TPMU_SYM_KEY_BITS

### DIFF
--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1080,6 +1080,7 @@ typedef TPM_KEY_BITS TPMI_AES_KEY_BITS;
 typedef union TPMU_SYM_KEY_BITS {
     TPMI_AES_KEY_BITS aes;
     TPM_KEY_BITS sym;
+    TPMI_ALG_HASH xor;
 } TPMU_SYM_KEY_BITS;
 
 typedef union TPMU_SYM_MODE {


### PR DESCRIPTION
I came across this while working on the Authorization Sessions.

In one of my tests I actually tried using XOR hash alg for securing the authSession and discovered there is no such overload in TPMU_SYM_KEY_BITS of wolfTPM.

It is one-liner commit, but TPMU_SYM_KEY_BITS is part of TPMT_SYM_DEF that turns into TPMT_SYM_DEF_OBJECT and is part of several other TPM types, so having this overload added will make it available in more than one place.

Like TPMS_ASYM_PARMS and TPMS_ECC_PARAMS, etc.