### PR TITLE
Attestation key wrappers

### DIFF
--- a/examples/timestamp/signed_timestamp.c
+++ b/examples/timestamp/signed_timestamp.c
@@ -77,6 +77,7 @@ int TPM2_Timestamp_Test(void* userCtx)
         printf("wolfTPM2_Init failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
         goto exit;
     }
+    printf("wolfTPM2_Init: success\n");
 
 
     /* Define the default session auth that has NULL password */
@@ -100,11 +101,11 @@ int TPM2_Timestamp_Test(void* userCtx)
     /* Create Endorsement Key, also called EK */
     rc = wolfTPM2_CreateEK(&dev, &endorse, TPM_ALG_RSA);
     if (rc != TPM_RC_SUCCESS) {
-        printf("TPM2_CreateEK: Endorsement failed 0x%x: %s\n",
+        printf("wolfTPM2_CreateEK: Endorsement failed 0x%x: %s\n",
             rc, TPM2_GetRCString(rc));
         goto exit;
     }
-    printf("TPM2_CreateEK: Endorsement 0x%x (%d bytes)\n",
+    printf("wolfTPM2_CreateEK: Endorsement 0x%x (%d bytes)\n",
         (word32)endorse.handle.hndl, endorse.pub.size);
 
 
@@ -112,11 +113,11 @@ int TPM2_Timestamp_Test(void* userCtx)
     rc = wolfTPM2_CreateSRK(&dev, &storage, TPM_ALG_RSA, storagePwd,
         sizeof(storagePwd)-1);
     if (rc != TPM_RC_SUCCESS) {
-        printf("TPM2_CreatePrimary: Storage failed 0x%x: %s\n", rc,
+        printf("wolfTPM2_CreateSRK: Storage failed 0x%x: %s\n", rc,
             TPM2_GetRCString(rc));
         goto exit;
     }
-    printf("TPM2_CreatePrimary: Storage 0x%x (%d bytes)\n",
+    printf("wolfTPM2_CreateSRK: Storage 0x%x (%d bytes)\n",
         (word32)storage.handle.hndl, storage.pub.size);
 
 
@@ -172,10 +173,12 @@ int TPM2_Timestamp_Test(void* userCtx)
     rc = wolfTPM2_CreateAndLoadAIK(&dev, &rsaKey, TPM_ALG_RSA, &storage,
         usageAuth, sizeof(usageAuth)-1);
     if (rc != TPM_RC_SUCCESS) {
-        printf("TPM2_Create RSA failed 0x%x: %s\n", rc,
+        printf("wolfTPM2_CreateAndLoadAIK failed 0x%x: %s\n", rc,
             TPM2_GetRCString(rc));
         goto exit;
     }
+    printf("wolfTPM2_CreateAndLoadAIK: AIK 0x%x (%d bytes)\n",
+        (word32)rsaKey.handle.hndl, rsaKey.pub.size);
 
 
     /* set NULL password auth for using EK */
@@ -196,15 +199,15 @@ int TPM2_Timestamp_Test(void* userCtx)
     /* Get signed by the TPM timestamp usign the AIK key */
     rc = wolfTPM2_GetTime(&rsaKey, &cmdOut.getTime);
     if (rc != TPM_RC_SUCCESS) {
-        printf("TPM2_GetTime failed 0x%x: %s\n", rc,
+        printf("wolfTPM2_GetTime failed 0x%x: %s\n", rc,
             TPM2_GetRCString(rc));
         goto exit;
     }
-    printf("TPM2_GetTime: success\n");
+    printf("wolfTPM2_GetTime: success\n");
     /* Print result in human friendly way */
     attestedTime = (TPMS_TIME_ATTEST_INFO*)cmdOut.getTime.timeInfo.attestationData;
-    printf("TPM2_GetTime: TPMS_TIME_ATTEST_INFO with signature attests:\n");
-    printf("* TPM Uptime (in ms) since power-up = %lu\n", 
+    printf("TPMS_TIME_ATTEST_INFO with signature attests:\n");
+    printf("\tTPM Uptime (in ms) since power-up = %lu\n",
         (unsigned long)attestedTime->time.clockInfo.clock);
 
 exit:

--- a/examples/timestamp/signed_timestamp.c
+++ b/examples/timestamp/signed_timestamp.c
@@ -61,15 +61,18 @@ int TPM2_Timestamp_Test(void* userCtx)
 
     TPM_HANDLE sessionHandle = TPM_RH_NULL;
 
-    WOLFTPM2_KEY endorse = { .handle.hndl = TPM_RH_NULL }; /* EK  */
-    WOLFTPM2_KEY storage = { .handle.hndl = TPM_RH_NULL }; /* SRK */
-    WOLFTPM2_KEY rsaKey = { .handle.hndl = TPM_RH_NULL };  /* AIK */
+    WOLFTPM2_KEY endorse; /* EK  */
+    WOLFTPM2_KEY storage; /* SRK */
+    WOLFTPM2_KEY rsaKey;  /* AIK */
 
     const byte storagePwd[] = "WolfTPMpassword";
     const byte usageAuth[] = "ThisIsASecretUsageAuth";
 
     TPMS_AUTH_COMMAND session[MAX_SESSION_NUM];
 
+    XMEMSET(&endorse, 0, sizeof(endorse));
+    XMEMSET(&storage, 0, sizeof(storage));
+    XMEMSET(&rsaKey, 0, sizeof(rsaKey));
 
     printf("TPM2 Demo of generating signed timestamp from the TPM\n");
     rc = wolfTPM2_Init(&dev, TPM2_IoCb, userCtx);
@@ -219,18 +222,9 @@ exit:
     }
 
     /* Close key handles */
-    if (rsaKey.handle.hndl != TPM_RH_NULL) {
-        cmdIn.flushCtx.flushHandle = rsaKey.handle.hndl;
-        TPM2_FlushContext(&cmdIn.flushCtx);
-    }
-    if (endorse.handle.hndl != TPM_RH_NULL) {
-        cmdIn.flushCtx.flushHandle = endorse.handle.hndl;
-        TPM2_FlushContext(&cmdIn.flushCtx);
-    }
-    if (storage.handle.hndl != TPM_RH_NULL) {
-        cmdIn.flushCtx.flushHandle = storage.handle.hndl;
-        TPM2_FlushContext(&cmdIn.flushCtx);
-    }
+    wolfTPM2_UnloadHandle(&dev, &rsaKey.handle);
+    wolfTPM2_UnloadHandle(&dev, &storage.handle);
+    wolfTPM2_UnloadHandle(&dev, &endorse.handle);
 
     wolfTPM2_Cleanup(&dev);
     return rc;

--- a/examples/timestamp/signed_timestamp.c
+++ b/examples/timestamp/signed_timestamp.c
@@ -23,7 +23,7 @@
  * generate a signed timestamp from the TPM using a Attestation Identity Key.
  */
 
-#include <wolftpm/tpm2.h>
+#include <wolftpm/tpm2_wrap.h>
 
 #include <examples/timestamp/signed_timestamp.h>
 #include <examples/tpm_io.h>
@@ -36,65 +36,46 @@
 /* --- BEGIN TPM Timestamp Test -- */
 /******************************************************************************/
 
-typedef struct tpmKey {
-    TPM_HANDLE          handle;
-    TPM2B_AUTH          auth;
-    TPM2B_PRIVATE       priv;
-    TPM2B_PUBLIC        pub;
-    TPM2B_NAME          name;
-} TpmKey; /* Type used to store the output from Key generation */
-
-
 int TPM2_Timestamp_Test(void* userCtx)
 {
     int rc;
-    TPM2_CTX tpm2Ctx;
+    WOLFTPM2_DEV dev;
     TPMS_TIME_ATTEST_INFO* attestedTime = NULL;
 
     union {
         GetTime_In getTime;
-        /* For creating keys */
-        CreatePrimary_In createPri;
-        Create_In create;
         /* For managing TPM session */
         StartAuthSession_In authSes;
         PolicySecret_In policySecret;
-        /* Loading a key and removing objects */
-        Load_In load;
+        /* For removing keys after use */
         FlushContext_In flushCtx;
         byte maxInput[MAX_COMMAND_SIZE];
     } cmdIn;
     union {
         ReadClock_Out readClock;
         GetTime_Out getTime;
-        /* Output from creating keys */
-        CreatePrimary_Out createPri;
-        Create_Out create;
         /* Output from session operations */
         StartAuthSession_Out authSes;
         PolicySecret_Out policySecret;
-        /* Output from loading a key into the TPM */
-        Load_Out load;
         byte maxOutput[MAX_RESPONSE_SIZE];
     } cmdOut;
 
     TPM_HANDLE sessionHandle = TPM_RH_NULL;
 
-    TpmKey endorse = { .handle = TPM_RH_NULL }; /* EK  */
-    TpmKey storage = { .handle = TPM_RH_NULL }; /* SRK */
-    TpmKey rsaKey = { .handle = TPM_RH_NULL };  /* AIK */
+    WOLFTPM2_KEY endorse = { .handle.hndl = TPM_RH_NULL }; /* EK  */
+    WOLFTPM2_KEY storage = { .handle.hndl = TPM_RH_NULL }; /* SRK */
+    WOLFTPM2_KEY rsaKey = { .handle.hndl = TPM_RH_NULL };  /* AIK */
 
-    const char storagePwd[] = "WolfTPMpassword";
-    const char usageAuth[] = "ThisIsASecretUsageAuth";
-    const char keyCreationNonce[] = "RandomServerPickedCreationNonce";
+    const byte storagePwd[] = "WolfTPMpassword";
+    const byte usageAuth[] = "ThisIsASecretUsageAuth";
 
     TPMS_AUTH_COMMAND session[MAX_SESSION_NUM];
 
 
     printf("TPM2 Demo of generating signed timestamp from the TPM\n");
-    rc = TPM2_Init(&tpm2Ctx, TPM2_IoCb, userCtx);
-    if (rc != TPM_RC_SUCCESS) {
-        printf("TPM2_Init failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+    rc = wolfTPM2_Init(&dev, TPM2_IoCb, userCtx);
+    if (rc != 0) {
+        printf("wolfTPM2_Init failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
         goto exit;
     }
 
@@ -117,77 +98,27 @@ int TPM2_Timestamp_Test(void* userCtx)
     printf("TPM2_ReadClock: success\n");
 
 
-    /* Create Primary (Endorsement Key, also called EK) */
-    XMEMSET(&cmdIn.createPri, 0, sizeof(cmdIn.createPri));
-    cmdIn.createPri.primaryHandle = TPM_RH_ENDORSEMENT;
-    /* Policy for creating the EK */
-    cmdIn.createPri.inPublic.publicArea.authPolicy.size =
-        sizeof(TPM_20_EK_AUTH_POLICY);
-    XMEMCPY(cmdIn.createPri.inPublic.publicArea.authPolicy.buffer,
-        TPM_20_EK_AUTH_POLICY,
-        cmdIn.createPri.inPublic.publicArea.authPolicy.size);
-    /* Parameters of the EK */
-    cmdIn.createPri.inPublic.publicArea.type = TPM_ALG_RSA;
-    cmdIn.createPri.inPublic.publicArea.unique.rsa.size = MAX_RSA_KEY_BITS / 8;
-    cmdIn.createPri.inPublic.publicArea.nameAlg = TPM_ALG_SHA256;
-    cmdIn.createPri.inPublic.publicArea.objectAttributes = (
-        TPMA_OBJECT_fixedTPM | TPMA_OBJECT_fixedParent |
-        TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_adminWithPolicy |
-        TPMA_OBJECT_restricted | TPMA_OBJECT_decrypt);
-    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.keyBits = MAX_RSA_KEY_BITS;
-    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.exponent = 0;
-    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.scheme.scheme = TPM_ALG_NULL;
-    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_AES;
-    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 128;
-    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.symmetric.mode.aes = TPM_ALG_CFB;
-    /* Ready to create the EK */
-    rc = TPM2_CreatePrimary(&cmdIn.createPri, &cmdOut.createPri);
+    /* Create Endorsement Key, also called EK */
+    rc = wolfTPM2_CreateEK(&dev, &endorse, TPM_ALG_RSA);
     if (rc != TPM_RC_SUCCESS) {
-        printf("TPM2_CreatePrimary: Endorsement failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        printf("TPM2_CreateEK: Endorsement failed 0x%x: %s\n",
+            rc, TPM2_GetRCString(rc));
         goto exit;
     }
-    /* Store the EK */
-    endorse.handle = cmdOut.createPri.objectHandle;
-    endorse.auth = cmdIn.createPri.inPublic.publicArea.authPolicy;
-    endorse.pub = cmdOut.createPri.outPublic;
-    endorse.name = cmdOut.createPri.name;
-    printf("TPM2_CreatePrimary: Endorsement 0x%x (%d bytes)\n",
-        (word32)endorse.handle, endorse.pub.size);
+    printf("TPM2_CreateEK: Endorsement 0x%x (%d bytes)\n",
+        (word32)endorse.handle.hndl, endorse.pub.size);
 
 
-    /* Create Primary (Storage Key, also called SRK) */
-    XMEMSET(&cmdIn.createPri, 0, sizeof(cmdIn.createPri));
-    cmdIn.createPri.primaryHandle = TPM_RH_OWNER;
-    /* Set auth required for using SRK */
-    cmdIn.createPri.inSensitive.sensitive.userAuth.size = sizeof(storagePwd)-1;
-    XMEMCPY(cmdIn.createPri.inSensitive.sensitive.userAuth.buffer,
-        storagePwd, cmdIn.createPri.inSensitive.sensitive.userAuth.size);
-    /* Parameters for the SRK */
-    cmdIn.createPri.inPublic.publicArea.type = TPM_ALG_RSA;
-    cmdIn.createPri.inPublic.publicArea.unique.rsa.size = MAX_RSA_KEY_BITS / 8;
-    cmdIn.createPri.inPublic.publicArea.nameAlg = TPM_ALG_SHA256;
-    cmdIn.createPri.inPublic.publicArea.objectAttributes = (
-        TPMA_OBJECT_fixedTPM | TPMA_OBJECT_fixedParent |
-        TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
-        TPMA_OBJECT_restricted | TPMA_OBJECT_decrypt | TPMA_OBJECT_noDA);
-    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.keyBits = MAX_RSA_KEY_BITS;
-    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.exponent = 0;
-    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.scheme.scheme = TPM_ALG_NULL;
-    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_AES;
-    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 128;
-    cmdIn.createPri.inPublic.publicArea.parameters.rsaDetail.symmetric.mode.aes = TPM_ALG_CFB;
-    /* Create the SRK */
-    rc = TPM2_CreatePrimary(&cmdIn.createPri, &cmdOut.createPri);
+    /* Create Storage Key, also called SRK */
+    rc = wolfTPM2_CreateSRK(&dev, &storage, TPM_ALG_RSA, storagePwd,
+        sizeof(storagePwd)-1);
     if (rc != TPM_RC_SUCCESS) {
         printf("TPM2_CreatePrimary: Storage failed 0x%x: %s\n", rc,
             TPM2_GetRCString(rc));
         goto exit;
     }
-    storage.handle = cmdOut.createPri.objectHandle;
-    storage.pub = cmdOut.createPri.outPublic;
-    storage.name = cmdOut.createPri.name;
     printf("TPM2_CreatePrimary: Storage 0x%x (%d bytes)\n",
-        (word32)storage.handle, storage.pub.size);
+        (word32)storage.handle.hndl, storage.pub.size);
 
 
     /* Start Auth Session */
@@ -239,55 +170,13 @@ int TPM2_Timestamp_Test(void* userCtx)
 
 
     /* Create an RSA key for Attestation purposes */
-    XMEMSET(&cmdIn.create, 0, sizeof(cmdIn.create));
-    cmdIn.create.parentHandle = storage.handle;
-    /* Set auth required for using the AIK later */
-    cmdIn.create.inSensitive.sensitive.userAuth.size = sizeof(usageAuth)-1;
-    XMEMCPY(cmdIn.create.inSensitive.sensitive.userAuth.buffer, usageAuth,
-        cmdIn.create.inSensitive.sensitive.userAuth.size);
-    /* AIK parameters */
-    cmdIn.create.inPublic.publicArea.type = TPM_ALG_RSA;
-    cmdIn.create.inPublic.publicArea.unique.rsa.size = MAX_RSA_KEY_BITS / 8;
-    cmdIn.create.inPublic.publicArea.nameAlg = TPM_ALG_SHA256;
-    cmdIn.create.inPublic.publicArea.objectAttributes = (
-        TPMA_OBJECT_fixedTPM | TPMA_OBJECT_fixedParent | TPMA_OBJECT_restricted |
-        TPMA_OBJECT_sensitiveDataOrigin |
-        TPMA_OBJECT_userWithAuth | TPMA_OBJECT_sign | TPMA_OBJECT_noDA);
-    cmdIn.create.inPublic.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_NULL;
-    cmdIn.create.inPublic.publicArea.parameters.rsaDetail.scheme.scheme = TPM_ALG_RSASSA;
-    cmdIn.create.inPublic.publicArea.parameters.rsaDetail.scheme.details.anySig.hashAlg = TPM_ALG_SHA256;
-    cmdIn.create.inPublic.publicArea.parameters.rsaDetail.keyBits = MAX_RSA_KEY_BITS;
-    cmdIn.create.outsideInfo.size = sizeof(keyCreationNonce)-1;
-    XMEMCPY(cmdIn.create.outsideInfo.buffer, keyCreationNonce,
-        cmdIn.create.outsideInfo.size);
-    /* Create the AIK */
-    rc = TPM2_Create(&cmdIn.create, &cmdOut.create);
+    rc = wolfTPM2_CreateAndLoadAIK(&dev, &rsaKey, TPM_ALG_RSA, &storage,
+        usageAuth, sizeof(usageAuth)-1);
     if (rc != TPM_RC_SUCCESS) {
         printf("TPM2_Create RSA failed 0x%x: %s\n", rc,
             TPM2_GetRCString(rc));
         goto exit;
     }
-    printf("TPM2_Create: New RSA Key: pub %d, priv %d\n",
-        cmdOut.create.outPublic.size,
-        cmdOut.create.outPrivate.size);
-    /* Store the AIK */
-    rsaKey.pub = cmdOut.create.outPublic;
-    rsaKey.priv = cmdOut.create.outPrivate;
-
-
-    /* Load new key */
-    XMEMSET(&cmdIn.load, 0, sizeof(cmdIn.load));
-    cmdIn.load.parentHandle = storage.handle;
-    cmdIn.load.inPrivate = rsaKey.priv;
-    cmdIn.load.inPublic = rsaKey.pub;
-    rc = TPM2_Load(&cmdIn.load, &cmdOut.load);
-    if (rc != TPM_RC_SUCCESS) {
-        printf("TPM2_Load RSA key failed 0x%x: %s\n", rc,
-            TPM2_GetRCString(rc));
-        goto exit;
-    }
-    rsaKey.handle = cmdOut.load.objectHandle;
-    printf("TPM2_Load RSA Key Handle 0x%x\n", (word32)rsaKey.handle);
 
 
     /* set NULL password auth for using EK */
@@ -310,7 +199,7 @@ int TPM2_Timestamp_Test(void* userCtx)
     XMEMSET(&cmdOut.getTime, 0, sizeof(cmdOut.getTime));
     cmdIn.getTime.privacyAdminHandle = TPM_RH_ENDORSEMENT;
     /* TPM_RH_NULL is a valid handle for NULL signature */
-    cmdIn.getTime.signHandle = rsaKey.handle;
+    cmdIn.getTime.signHandle = rsaKey.handle.hndl;
     /* TPM_ALG_NULL is a valid handle for  NULL signature */
     cmdIn.getTime.inScheme.scheme = TPM_ALG_RSASSA;
     cmdIn.getTime.inScheme.details.rsassa.hashAlg = TPM_ALG_SHA256;
@@ -337,27 +226,20 @@ exit:
     }
 
     /* Close key handles */
-    if (rsaKey.handle != TPM_RH_NULL) {
-        cmdIn.flushCtx.flushHandle = rsaKey.handle;
+    if (rsaKey.handle.hndl != TPM_RH_NULL) {
+        cmdIn.flushCtx.flushHandle = rsaKey.handle.hndl;
         TPM2_FlushContext(&cmdIn.flushCtx);
     }
-    if (endorse.handle != TPM_RH_NULL) {
-        cmdIn.flushCtx.flushHandle = endorse.handle;
+    if (endorse.handle.hndl != TPM_RH_NULL) {
+        cmdIn.flushCtx.flushHandle = endorse.handle.hndl;
         TPM2_FlushContext(&cmdIn.flushCtx);
     }
-    if (storage.handle != TPM_RH_NULL) {
-        cmdIn.flushCtx.flushHandle = storage.handle;
+    if (storage.handle.hndl != TPM_RH_NULL) {
+        cmdIn.flushCtx.flushHandle = storage.handle.hndl;
         TPM2_FlushContext(&cmdIn.flushCtx);
     }
 
-    TPM2_Cleanup(&tpm2Ctx);
-
-#ifdef TPM2_SPI_DEV
-    /* close handle */
-    if (gSpiDev >= 0)
-        close(gSpiDev);
-#endif
-
+    wolfTPM2_Cleanup(&dev);
     return rc;
 }
 

--- a/examples/timestamp/signed_timestamp.c
+++ b/examples/timestamp/signed_timestamp.c
@@ -43,7 +43,6 @@ int TPM2_Timestamp_Test(void* userCtx)
     TPMS_TIME_ATTEST_INFO* attestedTime = NULL;
 
     union {
-        GetTime_In getTime;
         /* For managing TPM session */
         StartAuthSession_In authSes;
         PolicySecret_In policySecret;
@@ -194,17 +193,8 @@ int TPM2_Timestamp_Test(void* userCtx)
      * Invoking attestation of the TPM time structure can take place.
      */
 
-    /* GetTime */
-    XMEMSET(&cmdIn.getTime, 0, sizeof(cmdIn.getTime));
-    XMEMSET(&cmdOut.getTime, 0, sizeof(cmdOut.getTime));
-    cmdIn.getTime.privacyAdminHandle = TPM_RH_ENDORSEMENT;
-    /* TPM_RH_NULL is a valid handle for NULL signature */
-    cmdIn.getTime.signHandle = rsaKey.handle.hndl;
-    /* TPM_ALG_NULL is a valid handle for  NULL signature */
-    cmdIn.getTime.inScheme.scheme = TPM_ALG_RSASSA;
-    cmdIn.getTime.inScheme.details.rsassa.hashAlg = TPM_ALG_SHA256;
-    cmdIn.getTime.qualifyingData.size = 0; /* optional */
-    rc = TPM2_GetTime(&cmdIn.getTime, &cmdOut.getTime);
+    /* Get signed by the TPM timestamp usign the AIK key */
+    rc = wolfTPM2_GetTime(&rsaKey, &cmdOut.getTime);
     if (rc != TPM_RC_SUCCESS) {
         printf("TPM2_GetTime failed 0x%x: %s\n", rc,
             TPM2_GetRCString(rc));

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -3366,6 +3366,38 @@ int wolfTPM2_CreateAndLoadAIK(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* aikKey,
     return rc;
 }
 
+int wolfTPM2_GetTime(WOLFTPM2_KEY* aikKey, GetTime_Out* out)
+{
+    int rc;
+    GetTime_In getTimeCmd;
+    GetTime_Out getTimeOut;
+
+    if(out == NULL) return BAD_FUNC_ARG;
+
+    /* GetTime */
+    XMEMSET(&getTimeCmd, 0, sizeof(getTimeCmd));
+    XMEMSET(&getTimeOut, 0, sizeof(getTimeOut));
+    getTimeCmd.privacyAdminHandle = TPM_RH_ENDORSEMENT;
+    /* TPM_RH_NULL is a valid handle for NULL signature */
+    getTimeCmd.signHandle = aikKey->handle.hndl;
+    /* TPM_ALG_NULL is a valid handle for  NULL signature */
+    getTimeCmd.inScheme.scheme = TPM_ALG_RSASSA;
+    getTimeCmd.inScheme.details.rsassa.hashAlg = TPM_ALG_SHA256;
+    getTimeCmd.qualifyingData.size = 0; /* optional */
+    rc = TPM2_GetTime(&getTimeCmd, &getTimeOut);
+    if (rc != TPM_RC_SUCCESS) {
+    #ifdef DEBUG_WOLFTPM
+        printf("TPM2_GetTime failed 0x%x: %s\n", rc, wolfTPM2_GetRCString(rc));
+    #endif
+    }
+
+    /* TODO: Decide what to return. For now, the output structure of GetTime */
+    out = &getTimeOut;
+
+    return rc;
+}
+
+
 /******************************************************************************/
 /* --- END Utility Functions -- */
 /******************************************************************************/

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -3366,17 +3366,16 @@ int wolfTPM2_CreateAndLoadAIK(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* aikKey,
     return rc;
 }
 
-int wolfTPM2_GetTime(WOLFTPM2_KEY* aikKey, GetTime_Out* out)
+int wolfTPM2_GetTime(WOLFTPM2_KEY* aikKey, GetTime_Out* getTimeOut)
 {
     int rc;
     GetTime_In getTimeCmd;
-    GetTime_Out getTimeOut;
 
-    if(out == NULL) return BAD_FUNC_ARG;
+    if(getTimeOut == NULL) return BAD_FUNC_ARG;
 
     /* GetTime */
     XMEMSET(&getTimeCmd, 0, sizeof(getTimeCmd));
-    XMEMSET(&getTimeOut, 0, sizeof(getTimeOut));
+    XMEMSET(getTimeOut, 0, sizeof(*getTimeOut));
     getTimeCmd.privacyAdminHandle = TPM_RH_ENDORSEMENT;
     /* TPM_RH_NULL is a valid handle for NULL signature */
     getTimeCmd.signHandle = aikKey->handle.hndl;
@@ -3384,15 +3383,12 @@ int wolfTPM2_GetTime(WOLFTPM2_KEY* aikKey, GetTime_Out* out)
     getTimeCmd.inScheme.scheme = TPM_ALG_RSASSA;
     getTimeCmd.inScheme.details.rsassa.hashAlg = TPM_ALG_SHA256;
     getTimeCmd.qualifyingData.size = 0; /* optional */
-    rc = TPM2_GetTime(&getTimeCmd, &getTimeOut);
+    rc = TPM2_GetTime(&getTimeCmd, getTimeOut);
     if (rc != TPM_RC_SUCCESS) {
     #ifdef DEBUG_WOLFTPM
         printf("TPM2_GetTime failed 0x%x: %s\n", rc, wolfTPM2_GetRCString(rc));
     #endif
     }
-
-    /* TODO: Decide what to return. For now, the output structure of GetTime */
-    out = &getTimeOut;
 
     return rc;
 }

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -301,7 +301,7 @@ WOLFTPM_API int wolfTPM2_CreateSRK(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* srkKey, TPM_
     const byte* auth, int authSz);
 WOLFTPM_API int wolfTPM2_CreateAndLoadAIK(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* aikKey,
     TPM_ALG_ID alg, WOLFTPM2_KEY* srkKey, const byte* auth, int authSz);
-WOLFTPM_API int wolfTPM2_GetTime(WOLFTPM2_KEY* aikKey, GetTime_Out* out);
+WOLFTPM_API int wolfTPM2_GetTime(WOLFTPM2_KEY* aikKey, GetTime_Out* getTimeOut);
 
 /* moved to tpm.h native code. macros here for backwards compatibility */
 #define wolfTPM2_SetupPCRSel  TPM2_SetupPCRSel

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -293,7 +293,14 @@ WOLFTPM_API int wolfTPM2_GetKeyTemplate_KeyedHash(TPMT_PUBLIC* publicTemplate,
     TPM_ALG_ID hashAlg, int isSign, int isDecrypt);
 WOLFTPM_API int wolfTPM2_GetKeyTemplate_RSA_EK(TPMT_PUBLIC* publicTemplate);
 WOLFTPM_API int wolfTPM2_GetKeyTemplate_ECC_EK(TPMT_PUBLIC* publicTemplate);
+WOLFTPM_API int wolfTPM2_GetKeyTemplate_RSA_SRK(TPMT_PUBLIC* publicTemplate);
+WOLFTPM_API int wolfTPM2_GetKeyTemplate_RSA_AIK(TPMT_PUBLIC* publicTemplate);
 WOLFTPM_API int wolfTPM2_GetNvAttributesTemplate(TPM_HANDLE auth, word32* nvAttributes);
+WOLFTPM_API int wolfTPM2_CreateEK(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* ekKey, TPM_ALG_ID alg);
+WOLFTPM_API int wolfTPM2_CreateSRK(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* srkKey, TPM_ALG_ID alg,
+    const byte* auth, int authSz);
+WOLFTPM_API int wolfTPM2_CreateAndLoadAIK(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* aikKey,
+    TPM_ALG_ID alg, WOLFTPM2_KEY* srkKey, const byte* auth, int authSz);
 
 /* moved to tpm.h native code. macros here for backwards compatibility */
 #define wolfTPM2_SetupPCRSel  TPM2_SetupPCRSel

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -301,6 +301,7 @@ WOLFTPM_API int wolfTPM2_CreateSRK(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* srkKey, TPM_
     const byte* auth, int authSz);
 WOLFTPM_API int wolfTPM2_CreateAndLoadAIK(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* aikKey,
     TPM_ALG_ID alg, WOLFTPM2_KEY* srkKey, const byte* auth, int authSz);
+WOLFTPM_API int wolfTPM2_GetTime(WOLFTPM2_KEY* aikKey, GetTime_Out* out);
 
 /* moved to tpm.h native code. macros here for backwards compatibility */
 #define wolfTPM2_SetupPCRSel  TPM2_SetupPCRSel


### PR DESCRIPTION
This PR adds new wolfTPM2 wrappers for easier use by application developers.

First two wrappers are for creating typical and always needed keys like the EK and SRK.
Second set of wrappers are for Attestation purposes, Attestation Identity Keys(AIK) and signed timestamp(GetTime). In addition, the signed_timestamp is updated to use the new wrappers. This has the benefit to highlight the required authSession and Policy details, which i think is important.

List of new wrappers:
* wolfTPM2_CreateEK
* wolfTPM2_CreateSRK
* wolfTPM2_CreateAndLoadAIK
* wolfTPM2_GetTime

Currently the wolfTPM2_GetTime returns the output structure from the TPM2 command as we do not know what the user would want to use the timestamp for since it has more information than just the TPM2/system uptime. I am looking for fedback on what the output structure or variable could be. Maybe we could create wolfTPM2_TIMESTAMP structure?

Looking forward to any and all feedback!

PR 100, Wow =)