### PR TITLE
Added RSA sign/verify support and expanded RSA key loading API's

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,10 +578,11 @@ Connection: close
 
 
 ## Todo
+
 * Add support for encrypting / decrypting parameters.
 * Add support for SensitiveToPrivate inner and outer.
 * Add runtime support for detecting module type ST33, SLB9670 or ATTPM20.
-
+* Update to v1.59 of specification.
 
 ## Support
 

--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -656,9 +656,9 @@ void TPM2_Packet_AppendSignature(TPM2_Packet* packet, TPMT_SIGNATURE* sig)
 {
     int digestSz;
 
-    TPM2_Packet_AppendU16(packet, sig->sigAlgo);
+    TPM2_Packet_AppendU16(packet, sig->sigAlg);
 
-    switch (sig->sigAlgo) {
+    switch (sig->sigAlg) {
     case TPM_ALG_ECDSA:
     case TPM_ALG_ECDAA:
         TPM2_Packet_AppendU16(packet, sig->signature.ecdsa.hash);
@@ -692,9 +692,9 @@ void TPM2_Packet_ParseSignature(TPM2_Packet* packet, TPMT_SIGNATURE* sig)
 {
     int digestSz;
 
-    TPM2_Packet_ParseU16(packet, &sig->sigAlgo);
+    TPM2_Packet_ParseU16(packet, &sig->sigAlg);
 
-    switch (sig->sigAlgo) {
+    switch (sig->sigAlg) {
     case TPM_ALG_ECDSA:
     case TPM_ALG_ECDAA:
         TPM2_Packet_ParseU16(packet, &sig->signature.ecdsa.hash);

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1146,7 +1146,7 @@ typedef struct TPMS_SCHEME_HASH {
 } TPMS_SCHEME_HASH;
 
 typedef struct TPMS_SCHEME_ECDAA {
-    TPMI_ALG_HASH hashAlgo;
+    TPMI_ALG_HASH hashAlg;
     UINT16 count;
 } TPMS_SCHEME_ECDAA;
 
@@ -1316,7 +1316,7 @@ typedef union TPMU_SIGNATURE {
 } TPMU_SIGNATURE;
 
 typedef struct TPMT_SIGNATURE {
-    TPMI_ALG_SIG_SCHEME sigAlgo;
+    TPMI_ALG_SIG_SCHEME sigAlg;
     TPMU_SIGNATURE signature;
 } TPMT_SIGNATURE;
 

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -135,10 +135,18 @@ WOLFTPM_API int wolfTPM2_LoadPrivateKey(WOLFTPM2_DEV* dev,
     TPM2B_SENSITIVE* sens);
 WOLFTPM_API int wolfTPM2_LoadRsaPublicKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const byte* rsaPub, word32 rsaPubSz, word32 exponent);
+WOLFTPM_API int wolfTPM2_LoadRsaPublicKey_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
+    const byte* rsaPub, word32 rsaPubSz, word32 exponent, 
+    TPMI_ALG_RSA_SCHEME scheme, TPMI_ALG_HASH hashAlg);
 WOLFTPM_API int wolfTPM2_LoadRsaPrivateKey(WOLFTPM2_DEV* dev,
     const WOLFTPM2_KEY* parentKey, WOLFTPM2_KEY* key,
     const byte* rsaPub, word32 rsaPubSz, word32 exponent,
     const byte* rsaPriv, word32 rsaPrivSz);
+WOLFTPM_API int wolfTPM2_LoadRsaPrivateKey_ex(WOLFTPM2_DEV* dev,
+    const WOLFTPM2_KEY* parentKey, WOLFTPM2_KEY* key,
+    const byte* rsaPub, word32 rsaPubSz, word32 exponent,
+    const byte* rsaPriv, word32 rsaPrivSz,
+    TPMI_ALG_RSA_SCHEME scheme, TPMI_ALG_HASH hashAlg);
 WOLFTPM_API int wolfTPM2_LoadEccPublicKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     int curveId, const byte* eccPubX, word32 eccPubXSz,
     const byte* eccPubY, word32 eccPubYSz);
@@ -178,11 +186,17 @@ WOLFTPM_API int wolfTPM2_EccKey_WolfToPubPoint(WOLFTPM2_DEV* dev, ecc_key* wolfK
 
 WOLFTPM_API int wolfTPM2_SignHash(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const byte* digest, int digestSz, byte* sig, int* sigSz);
+WOLFTPM_API int wolfTPM2_SignHashScheme(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
+    const byte* digest, int digestSz, byte* sig, int* sigSz,
+    TPMI_ALG_SIG_SCHEME sigAlg, TPMI_ALG_HASH hashAlg);
 WOLFTPM_API int wolfTPM2_VerifyHash(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const byte* sig, int sigSz, const byte* digest, int digestSz);
 WOLFTPM_API int wolfTPM2_VerifyHash_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const byte* sig, int sigSz, const byte* digest, int digestSz,
-    int ecdsaHashAlg);
+    int hashAlg);
+WOLFTPM_API int wolfTPM2_VerifyHashScheme(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
+    const byte* sig, int sigSz, const byte* digest, int digestSz,
+    TPMI_ALG_SIG_SCHEME sigAlg, TPMI_ALG_HASH hashAlg);
 
 WOLFTPM_API int wolfTPM2_ECDHGenKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* ecdhKey,
     int curve_id, const byte* auth, int authSz);


### PR DESCRIPTION
TPM RSA sign and verify wrapper support:
* Added RSA support for `wolfTPM2_SignHash` and `wolfTPM2_VerifyHash`.
* Added `wolfTPM2_SignHash_ex` and `wolfTPM2_VerifyHash_ex` support for signature scheme and hash algo.
* Added `wolfTPM2_LoadRsaPrivateKey_ex` and `wolfTPM2_LoadRsaPublicKey_ex` support for signature scheme and hash algo.
* Fix for typo on hashAlg and sigAlg (per spec).
* Added RSA sign/verify examples for PKCSv1.5 (SSA) and PSS padding schemes.
* Fixes for building without ECC key import/export.