### PR TITLE
Added NPCT75x Nuvoton support and dynamic module detection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Tested with:
 * Infineon OPTIGA (TM) Trusted Platform Module 2.0 SLB 9670.
 * LetsTrust: http://letstrust.de (https://buyzero.de/collections/andere-platinen/products/letstrust-hardware-tpm-trusted-platform-module). Compact Raspberry Pi TPM 2.0 board based on Infineon SLB 9670.
 * ST ST33TP* TPM 2.0 module (SPI and I2C)
-* Microchip ATTPM20
-* Nuvoton NPCT650 TPM2.0
+* Microchip ATTPM20 module
+* Nuvoton NPCT65X or NPCT75x TPM2.0 module
 
 #### Device Identification
 
@@ -95,6 +95,9 @@ Mfg NTZ (0), Vendor Z32H330, Fw 7.51 (419631892), FIPS 140-2 0, CC-EAL4 0
 Nuvoton NPCT650 TPM2.0
 Mfg NTC (0), Vendor rlsNPCT , Fw 1.3 (65536), FIPS 140-2 0, CC-EAL4 0
 
+Nuvoton NPCT750 TPM2.0
+TPM2: Caps 0x30000697, Did 0x00fc, Vid 0x1050, Rid 0x 1
+Mfg NTC (0), Vendor NPCT75x"!!4rls, Fw 7.2 (131072), FIPS 140-2 1, CC-EAL4 0
 
 ## Building
 
@@ -124,6 +127,7 @@ autogen.sh requires: automake and libtool: `sudo apt-get install automake libtoo
 --enable-i2c            Enable I2C TPM Support (default: disabled, requires advio) - WOLFTPM_I2C
 --enable-mchp           Enable Microchip TPM Support (default: disabled) - WOLFTPM_MCHP
 WOLFTPM_TIS_LOCK        Enable Linux Named Semaphore for locking access to SPI device for concurrent access between processes.
+--enable-nuvoton        Enable Nuvoton NPCT65x/NPCT75x Support (default: disabled) - WOLFTPM_NUVOTON
 WOLFTPM_USE_SYMMETRIC   Enables symmetric AES/Hashing/HMAC support for TLS examples.
 WOLFTPM2_USE_SW_ECDHE   Disables use of TPM for ECC ephemeral key generation and shared secret.
 TLS_BENCH_MODE          Enables TLS benchmarking mode.
@@ -165,6 +169,13 @@ Build wolfTPM:
 ```
 ./autogen.sh
 ./configure --enable-mchp
+### Building Nuvoton
+
+Build wolfTPM:
+
+```
+./autogen.sh
+./configure --enable-nuvoton
 make
 ```
 
@@ -367,6 +378,28 @@ ECC      256 key gen        7 ops took 1.033 sec, avg 147.608 ms, 6.775 ops/sec
 ECDSA    256 sign           6 ops took 1.141 sec, avg 190.149 ms, 5.259 ops/sec
 ECDSA    256 verify         4 ops took 1.061 sec, avg 265.216 ms, 3.771 ops/sec
 ECDHE    256 agree          6 ops took 1.055 sec, avg 175.915 ms, 5.685 ops/sec
+```
+
+Run on Nuvoton NPCT750 at 43MHz:
+
+```
+RNG                 16 KB took 1.114 seconds,   14.368 KB/s
+Benchmark symmetric AES-128-CBC-enc not supported!
+Benchmark symmetric AES-128-CBC-dec not supported!
+Benchmark symmetric AES-256-CBC-enc not supported!
+Benchmark symmetric AES-256-CBC-dec not supported!
+SHA1               120 KB took 1.012 seconds,  118.618 KB/s
+SHA256             122 KB took 1.012 seconds,  120.551 KB/s
+SHA384             120 KB took 1.003 seconds,  119.608 KB/s
+RSA     2048 key gen        5 ops took 17.043 sec, avg 3408.678 ms, 0.293 ops/sec
+RSA     2048 Public       134 ops took 1.004 sec, avg 7.490 ms, 133.517 ops/sec
+RSA     2048 Private       15 ops took 1.054 sec, avg 70.261 ms, 14.233 ops/sec
+RSA     2048 Pub  OAEP    116 ops took 1.002 sec, avg 8.636 ms, 115.797 ops/sec
+RSA     2048 Priv OAEP     15 ops took 1.061 sec, avg 70.716 ms, 14.141 ops/sec
+ECC      256 key gen       12 ops took 1.008 sec, avg 84.020 ms, 11.902 ops/sec
+ECDSA    256 sign          18 ops took 1.015 sec, avg 56.399 ms, 17.731 ops/sec
+ECDSA    256 verify        26 ops took 1.018 sec, avg 39.164 ms, 25.533 ops/sec
+ECDHE    256 agree         35 ops took 1.029 sec, avg 29.402 ms, 34.011 ops/sec
 ```
 
 ### TPM2 Native Tests

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ There are examples here for Linux, STM32 CubeMX, Atmel ASF and BareBox. The adva
 Tested with:
 
 * Infineon OPTIGA (TM) Trusted Platform Module 2.0 SLB 9670.
-* LetsTrust: http://letstrust.de (https://buyzero.de/collections/andere-platinen/products/letstrust-hardware-tpm-trusted-platform-module). Compact Raspberry Pi TPM 2.0 board based on Infineon SLB 9670.
+    - LetsTrust: [http://letstrust.de] (<https://buyzero.de/collections/andere-platinen/products/letstrust-hardware-tpm-trusted-platform-module).> Compact Raspberry Pi TPM 2.0 board based on Infineon SLB 9670.
 * ST ST33TP* TPM 2.0 module (SPI and I2C)
 * Microchip ATTPM20 module
 * Nuvoton NPCT65X or NPCT75x TPM2.0 module
@@ -84,6 +84,10 @@ Mfg IFX (1), Vendor SLB9670, Fw 7.85 (4555), FIPS 140-2 1, CC-EAL4 1
 ST ST33TP SPI
 TPM2: Caps 0x1a7e2882, Did 0x0000, Vid 0x104a, Rid 0x4e
 Mfg STM  (2), Vendor , Fw 74.8 (1151341959), FIPS 140-2 1, CC-EAL4 0
+
+ST ST33TP I2C
+TPM2: Caps 0x1a7e2882, Did 0x0000, Vid 0x104a, Rid 0x4e
+Mfg STM  (2), Vendor , Fw 74.9 (1151341959), FIPS 140-2 1, CC-EAL4 0
 
 Microchip ATTPM20
 TPM2: Caps 0x30000695, Did 0x3205, Vid 0x1114, Rid 0x 1 
@@ -118,21 +122,26 @@ autogen.sh requires: automake and libtool: `sudo apt-get install automake libtoo
 ### Build options and defines
 
 ```
---enable-debug          Add debug code/turns off optimizations (yes|no|verbose) - DEBUG_WOLFTPM, WOLFTPM_DEBUG_VERBOSE, WOLFTPM_DEBUG_IO
+--enable-debug          Add debug code/turns off optimizations (yes|no|verbose|io) - DEBUG_WOLFTPM, WOLFTPM_DEBUG_VERBOSE, WOLFTPM_DEBUG_IO
 --enable-examples       Enable Examples (default: enabled)
 --enable-wrapper        Enable wrapper code (default: enabled) - WOLFTPM2_NO_WRAPPER
 --enable-wolfcrypt      Enable wolfCrypt hooks for RNG, Auth Sessions and Parameter encryption (default: enabled) - WOLFTPM2_NO_WOLFCRYPT
 --enable-advio          Enable Advanced IO (default: disabled) - WOLFTPM_ADV_IO
---enable-st33           Enable ST33 TPM Support (default: disabled) - WOLFTPM_ST33
 --enable-i2c            Enable I2C TPM Support (default: disabled, requires advio) - WOLFTPM_I2C
---enable-mchp           Enable Microchip TPM Support (default: disabled) - WOLFTPM_MCHP
-WOLFTPM_TIS_LOCK        Enable Linux Named Semaphore for locking access to SPI device for concurrent access between processes.
+--enable-checkwaitstate Enable TIS / SPI Check Wait State support (default: depends on chip) - WOLFTPM_CHECK_WAIT_STATE
+--enable-smallstack     Enable options to reduce stack usage
+--enable-tislock        Enable Linux Named Semaphore for locking access to SPI device for concurrent access between processes - WOLFTPM_TIS_LOCK
+
+--enable-autodetect     Enable Runtime Module Detection (default: enable - when no module specified) - WOLFTPM_AUTODETECT
+--enable-infineon       Enable Infineon SLB9670 TPM Support (default: disabled)
+--enable-st             Enable ST ST33TPM Support (default: disabled) - WOLFTPM_ST33
+--enable-microchip      Enable Microchip ATTPM20 Support (default: disabled) - WOLFTPM_MCHP
 --enable-nuvoton        Enable Nuvoton NPCT65x/NPCT75x Support (default: disabled) - WOLFTPM_NUVOTON
+
 WOLFTPM_USE_SYMMETRIC   Enables symmetric AES/Hashing/HMAC support for TLS examples.
-WOLFTPM2_USE_SW_ECDHE   Disables use of TPM for ECC ephemeral key generation and shared secret.
+WOLFTPM2_USE_SW_ECDHE   Disables use of TPM for ECC ephemeral key generation and shared secret for TLS examples.
 TLS_BENCH_MODE          Enables TLS benchmarking mode.
 NO_TPM_BENCH            Disables the TPM benchmarking example.
---enable-smallstack     Enable options to reduce stack usage
 ```
 
 ### Building Infineon SLB9670
@@ -168,7 +177,10 @@ Build wolfTPM:
 
 ```
 ./autogen.sh
-./configure --enable-mchp
+./configure --enable-microchip
+make
+```
+
 ### Building Nuvoton
 
 Build wolfTPM:

--- a/configure.ac
+++ b/configure.ac
@@ -199,6 +199,16 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_MCHP"
 fi
 
+# Nuvoton NPCT65x/NPCT75x
+AC_ARG_ENABLE([nuvoton],
+    [AS_HELP_STRING([--enable-nuvoton],[Enable Nuvoton NPCT65x/NPCT75x TPM Support (default: disabled)])],
+    [ ENABLED_NUVOTON=$enableval ],
+    [ ENABLED_NUVOTON=no ]
+    )
+if test "x$ENABLED_NUVOTON" = "xyes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_NUVOTON"
+fi
 
 # Infineon SLB9670
 ENABLED_INFINEON=no
@@ -243,6 +253,7 @@ AM_CONDITIONAL([BUILD_ST33], [test "x$ENABLED_ST33" = "xyes"])
 AM_CONDITIONAL([BUILD_MCHP], [test "x$ENABLED_MCHP" = "xyes"])
 AM_CONDITIONAL([BUILD_INFINEON], [test "x$ENABLED_INFINEON" = "xyes"])
 AM_CONDITIONAL([BUILD_DEVTPM], [test "x$ENABLED_DEVTPM" = "xyes"])
+AM_CONDITIONAL([BUILD_NUVOTON], [test "x$ENABLED_NUVOTON" = "xyes"])
 
 
 
@@ -361,3 +372,4 @@ echo "   * STM ST33:                  $ENABLED_ST33"
 echo "   * Microchip ATTPM20:         $ENABLED_MCHP"
 echo "   * I2C:                       $ENABLED_I2C"
 echo "   * Linux kernel TPM device:   $ENABLED_DEVTPM"
+echo "   * Nuvoton NPCT75x:           $ENABLED_NUVOTON"

--- a/configure.ac
+++ b/configure.ac
@@ -94,9 +94,14 @@ else
 fi
 
 # Verbose Logging
-if test "x$ax_enable_debug" = "xverbose"
+if test "x$ax_enable_debug" = "xverbose" || test "x$ax_enable_debug" = "xio"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_DEBUG_VERBOSE"
+fi
+# IO Logging
+if test "x$ax_enable_debug" = "xio"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_DEBUG_IO"
 fi
 
 
@@ -176,26 +181,35 @@ fi
 
 
 # STM ST33 Support
-AC_ARG_ENABLE([st33],
-    [AS_HELP_STRING([--enable-st33],[Enable ST33 TPM Support (default: disabled)])],
+AC_ARG_ENABLE([st33],,
     [ ENABLED_ST33=$enableval ],
     [ ENABLED_ST33=no ]
     )
+AC_ARG_ENABLE([st],
+    [AS_HELP_STRING([--enable-st],[Enable ST ST33 TPM Support (default: disabled)])],
+    [ ENABLED_ST=$enableval ],
+    [ ENABLED_ST=no ]
+    )
 
-if test "x$ENABLED_ST33" = "xyes"
+if test "x$ENABLED_ST33" = "xyes" || test "x$ENABLED_ST" = "xyes"
 then
+    ENABLED_ST33=yes
     AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_ST33"
 fi
 
-
-# Microchip ATTPM20 Support
-AC_ARG_ENABLE([mchp],
-    [AS_HELP_STRING([--enable-mchp],[Enable TPM 2.0 Support (default: disabled)])],
+# Microchip ATTPM20
+AC_ARG_ENABLE([mchp],,
     [ ENABLED_MCHP=$enableval ],
     [ ENABLED_MCHP=no ]
     )
-if test "x$ENABLED_MCHP" = "xyes"
+AC_ARG_ENABLE([microchip],
+    [AS_HELP_STRING([--enable-microchip],[Enable Microchip ATPM2.0 Support (default: disabled)])],
+    [ ENABLED_MICROCHIP=$enableval ],
+    [ ENABLED_MICROCHIP=no ]
+    )
+if test "x$ENABLED_MCHP" = "xyes" || test "x$ENABLED_MICROCHIP" = "xyes"
 then
+    ENABLED_MICROCHIP=yes
     AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_MCHP"
 fi
 
@@ -211,13 +225,35 @@ then
 fi
 
 # Infineon SLB9670
-ENABLED_INFINEON=no
-if test "x$ENABLED_MCHP" = "xno" && test "x$ENABLED_ST33" = "xno"
+AC_ARG_ENABLE([infineon],
+    [AS_HELP_STRING([--enable-infineon],[Enable Infineon SLB9670 TPM Support (default: disabled)])],
+    [ ENABLED_INFINEON=$enableval ],
+    [ ENABLED_INFINEON=no ]
+    )
+if test "x$ENABLED_INFINEON" = "xyes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_SLB9670"
-    ENABLED_INFINEON=yes
 fi
 
+
+# TIS / SPI Check Wait State support
+AC_ARG_ENABLE([checkwaitstate],
+    [AS_HELP_STRING([--enable-checkwaitstate],[Enable TIS / SPI Check Wait State support (default: depends on chip)])],
+    [ ENABLED_CHECKWAITSTATE=$enableval ],
+    [ ENABLED_CHECKWAITSTATE=no ]
+    )
+
+
+# TIS Layer Named Semaphore locking for concurrent access between processes.
+AC_ARG_ENABLE([tislock],
+    [AS_HELP_STRING([--enable-tislock],[TIS Layer Named Semaphore locking for concurrent access between processes. (default: disabled)])],
+    [ ENABLED_TIS_LOCK=$enableval ],
+    [ ENABLED_TIS_LOCK=no ]
+    )
+if test "x$ENABLED_TIS_LOCK" = "xyes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_TIS_LOCK"
+fi
 
 # Small Stack
 AC_ARG_ENABLE([smallstack],
@@ -234,6 +270,35 @@ then
     AM_CFLAGS="$AM_CFLAGS -DMAX_COMMAND_SIZE=1024 -DMAX_RESPONSE_SIZE=1024 -DWOLFTPM2_MAX_BUFFER=1500 -DMAX_SESSION_NUM=1 -DMAX_DIGEST_BUFFER=973"
 fi
 
+# Runtime Module Detection
+AC_ARG_ENABLE([autodetect],
+    [AS_HELP_STRING([--enable-autodetect],[Enable Runtime Module Detection (default: enable - when no module specified)])],
+    [ ENABLED_AUTODETECT=$enableval ],
+    [ ENABLED_AUTODETECT=test ]
+    )
+
+if test "x$ENABLED_AUTODETECT" = "xtest"
+then
+    # If a module hasn't been selected then enable auto-detection
+    if test "x$ENABLED_INFINEON" = "xno" && test "x$ENABLED_MCHP" = "xno" && test "x$ENABLED_ST" = "xno" && test "x$ENABLED_NUVOTON" = "xno"
+    then
+        ENABLED_AUTODETECT=yes
+    fi
+fi
+
+if test "x$ENABLED_AUTODETECT" = "xyes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_AUTODETECT"
+fi
+
+
+# TIS / SPI Check Wait State support
+# Required for all but Infineon only
+if test "x$ENABLED_CHECKWAITSTATE" = "xyes" || test "x$ENABLED_AUTODETECT" = "xyes" || test "x$ENABLED_INFINEON" = "xno" 
+then
+    ENABLED_CHECKWAITSTATE=yes
+    AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_CHECK_WAIT_STATE"
+fi
 
 
 # HARDEN FLAGS
@@ -249,11 +314,13 @@ AM_CONDITIONAL([BUILD_WRAPPER], [test "x$ENABLED_WRAPPER" = "xyes"])
 AM_CONDITIONAL([HAVE_LIBWOLFSSL], [test "x$ENABLED_WOLFCRYPT" = "xyes"])
 AM_CONDITIONAL([BUILD_I2C], [test "x$ENABLED_I2C" = "xyes"])
 AM_CONDITIONAL([BUILD_ADVIO], [test "x$ENABLED_ADVIO" = "xyes"])
-AM_CONDITIONAL([BUILD_ST33], [test "x$ENABLED_ST33" = "xyes"])
-AM_CONDITIONAL([BUILD_MCHP], [test "x$ENABLED_MCHP" = "xyes"])
+AM_CONDITIONAL([BUILD_ST], [test "x$ENABLED_ST" = "xyes"])
+AM_CONDITIONAL([BUILD_MICROCHIP], [test "x$ENABLED_MICROCHIP" = "xyes"])
 AM_CONDITIONAL([BUILD_INFINEON], [test "x$ENABLED_INFINEON" = "xyes"])
 AM_CONDITIONAL([BUILD_DEVTPM], [test "x$ENABLED_DEVTPM" = "xyes"])
 AM_CONDITIONAL([BUILD_NUVOTON], [test "x$ENABLED_NUVOTON" = "xyes"])
+AM_CONDITIONAL([BUILD_CHECKWAITSTATE], [test "x$ENABLED_CHECKWAITSTATE" = "xyes"])
+AM_CONDITIONAL([BUILD_AUTODETECT], [test "x$ENABLED_AUTODETECT" = "xyes"])
 
 
 
@@ -367,9 +434,13 @@ echo "   * Wrappers:                  $ENABLED_WRAPPER"
 echo "   * Examples:                  $ENABLED_EXAMPLES"
 echo "   * wolfCrypt:                 $ENABLED_WOLFCRYPT"
 echo "   * Advanced IO:               $ENABLED_ADVIO"
-echo "   * Infineon SLB9670           $ENABLED_INFINEON"
-echo "   * STM ST33:                  $ENABLED_ST33"
-echo "   * Microchip ATTPM20:         $ENABLED_MCHP"
 echo "   * I2C:                       $ENABLED_I2C"
 echo "   * Linux kernel TPM device:   $ENABLED_DEVTPM"
+echo "   * TIS/SPI Check Wait State:  $ENABLED_CHECKWAITSTATE"
+
+echo "   * Infineon SLB9670           $ENABLED_INFINEON"
+echo "   * STM ST33:                  $ENABLED_ST"
+echo "   * Microchip ATTPM20:         $ENABLED_MICROCHIP"
 echo "   * Nuvoton NPCT75x:           $ENABLED_NUVOTON"
+
+echo "   * Runtime Module Detection:  $ENABLED_AUTODETECT"

--- a/examples/bench/bench.c
+++ b/examples/bench/bench.c
@@ -156,7 +156,7 @@ static int bench_sym_aes(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* storageKey,
 
     XMEMSET(&aesKey, 0, sizeof(aesKey));
     rc = wolfTPM2_GetKeyTemplate_Symmetric(&publicTemplate, keyBits, algo,
-        YES, YES);
+        NO, YES);
     if (rc != 0) goto exit;
     rc = wolfTPM2_CreateAndLoadKey(dev, &aesKey, &storageKey->handle,
         &publicTemplate, (byte*)gUsageAuth, sizeof(gUsageAuth)-1);

--- a/examples/tpm_io.c
+++ b/examples/tpm_io.c
@@ -68,9 +68,13 @@
         #elif defined(WOLFTPM_ST33)
             /* STM ST33HTPH SPI uses CE0 */
             #define TPM2_SPI_DEV "/dev/spidev0.0"
+        #elif defined(WOLFTPM_NUVOTON)
+            /* Nuvoton NPCT75x uses CE0 */
+            #define TPM2_SPI_DEV_CS "0"
         #else
             /* OPTIGA SLB9670 and LetsTrust TPM use CE1 */
             #define TPM2_SPI_DEV "/dev/spidev0.1"
+            #define TPM2_SPI_DEV "/dev/spidev0."TPM2_SPI_DEV_CS
         #endif
     #endif
 

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -185,7 +185,7 @@ int TPM2_Wrapper_Test(void* userCtx)
         rc = wolfTPM2_GetKeyTemplate_RSA(&publicTemplate,
             TPMA_OBJECT_fixedTPM | TPMA_OBJECT_fixedParent |
             TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
-            TPMA_OBJECT_restricted | TPMA_OBJECT_sign | TPMA_OBJECT_decrypt | TPMA_OBJECT_noDA);
+            TPMA_OBJECT_restricted | TPMA_OBJECT_decrypt | TPMA_OBJECT_noDA);
         if (rc != 0) goto exit;
         rc = wolfTPM2_CreatePrimaryKey(&dev, &storageKey, TPM_RH_OWNER,
             &publicTemplate, (byte*)gStorageKeyAuth, sizeof(gStorageKeyAuth)-1);
@@ -775,7 +775,7 @@ int TPM2_Wrapper_Test(void* userCtx)
 
 
     rc = wolfTPM2_GetKeyTemplate_Symmetric(&publicTemplate, 128, TEST_AES_MODE,
-        YES, YES);
+        NO, YES);
     if (rc != 0) goto exit;
     rc = wolfTPM2_CreateAndLoadKey(&dev, &aesKey, &storageKey.handle,
         &publicTemplate, (byte*)gUsageAuth, sizeof(gUsageAuth)-1);

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -4604,7 +4604,7 @@ TPM_RC TPM2_NV_Certify(NV_Certify_In* in, NV_Certify_Out* out)
 /******************************************************************************/
 /* --- BEGIN Manufacture Specific TPM API's -- */
 /******************************************************************************/
-#ifdef WOLFTPM_ST33
+#if defined(WOLFTPM_ST33) || defined(WOLFTPM_AUTODETECT)
 int TPM2_SetCommandSet(SetCommandSet_In* in)
 {
     TPM_RC rc;
@@ -5100,6 +5100,16 @@ int TPM2_ParseAttest(const TPM2B_ATTEST* in, TPMS_ATTEST* out)
 
     TPM2_Packet_ParseAttest(&packet, out);
     return TPM_RC_SUCCESS;
+}
+
+UINT16 TPM2_GetVendorID(void)
+{
+    UINT16 vid = 0;
+    TPM2_CTX* ctx = TPM2_GetActiveCtx();
+    if (ctx) {
+        vid = (UINT16)(ctx->did_vid & 0xFFFF);
+    }
+    return vid;
 }
 
 #ifdef DEBUG_WOLFTPM

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -278,9 +278,19 @@ static int wolfTPM2_ParseCapabilities(WOLFTPM2_CAPS* caps,
                 }
                 else if (XMEMCMP(&caps->mfgStr, "STM", 3) == 0) {
                     caps->mfg = TPM_MFG_STM;
+                    caps->req_wait_state = 1;
                 }
                 else if (XMEMCMP(&caps->mfgStr, "MCHP", 4) == 0) {
                     caps->mfg = TPM_MFG_MCHP;
+                    caps->req_wait_state = 1;
+                }
+                else if (XMEMCMP(&caps->mfgStr, "NTC", 4) == 0) {
+                    caps->mfg = TPM_MFG_NUVOTON;
+                    caps->req_wait_state = 1;
+                }
+                else if (XMEMCMP(&caps->mfgStr, "NTZ", 4) == 0) {
+                    caps->mfg = TPM_MFG_NATIONTECH;
+                    caps->req_wait_state = 1;
                 }
                 break;
             case TPM_PT_VENDOR_STRING_1:
@@ -304,7 +314,7 @@ static int wolfTPM2_ParseCapabilities(WOLFTPM2_CAPS* caps,
                 caps->fwVerMinor = val & 0xFFFF;
                 break;
             case TPM_PT_FIRMWARE_VERSION_2:
-                if (caps->mfg == TPM_MFG_INFINEON) {
+                if (caps->mfg == TPM_MFG_INFINEON || caps->mfg == TPM_MFG_NUVOTON) {
                     caps->fwVerVendor = val >> 8;
                     caps->cc_eal4 = (val & 0x00000002) ? 0 : 1;
                 }

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -227,7 +227,7 @@ typedef enum {
 
     CC_VEND                         = 0x20000000,
     TPM_CC_Vendor_TCG_Test          = CC_VEND + 0x0000,
-#ifdef WOLFTPM_ST33
+#if defined(WOLFTPM_ST33) || defined(WOLFTPM_AUTODETECT)
     TPM_CC_SetMode                  = CC_VEND + 0x0307,
     TPM_CC_SetCommandSet            = CC_VEND + 0x0309,
     TPM_CC_RestoreEK                = CC_VEND + 0x030A,
@@ -2704,7 +2704,7 @@ WOLFTPM_API TPM_RC TPM2_NV_Certify(NV_Certify_In* in, NV_Certify_Out* out);
 
 
 /* Vendor Specific API's */
-#ifdef WOLFTPM_ST33
+#if defined(WOLFTPM_ST33) || defined(WOLFTPM_AUTODETECT)
 typedef struct {
     TPMI_RH_HIERARCHY authHandle;
     TPM_CC commandCode;
@@ -2732,7 +2732,7 @@ typedef struct {
     TPM_MODE_SET modeSet;
 } SetMode_In;
 WOLFTPM_API int TPM2_SetMode(SetMode_In* in);
-#endif /* WOLFTPM_ST33 */
+#endif /* WOLFTPM_ST33 || WOLFTPM_AUTODETECT */
 
 /* Non-standard API's */
 #define _TPM_Init TPM2_Init
@@ -2767,6 +2767,17 @@ WOLFTPM_API int TPM2_ParseAttest(const TPM2B_ATTEST* in, TPMS_ATTEST* out);
 #ifdef WOLFTPM2_USE_WOLF_RNG
 WOLFTPM_API int TPM2_GetWolfRng(WC_RNG** rng);
 #endif
+
+typedef enum {
+    TPM_VENDOR_UNKNOWN = 0,
+    TPM_VENDOR_INFINEON = 0x15d1,
+    TPM_VENDOR_STM = 0x104a,
+    TPM_VENDOR_MCHP = 0x1114,
+    TPM_VENDOR_NUVOTON = 0x1050,
+    TPM_VENDOR_NATIONTECH = 0x1B4E,
+} TPM_Vendor_t;
+
+WOLFTPM_API UINT16 TPM2_GetVendorID(void);
 
 #ifdef DEBUG_WOLFTPM
 WOLFTPM_API void TPM2_PrintBin(const byte* buffer, word32 length);

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -155,12 +155,18 @@ typedef int64_t  INT64;
 
 /* Microchip ATTPM20 */
 /* #define WOLFTPM_MCHP */
+/* Nuvoton NPCT75x TPM 2.0 module */
+/* #define WOLFTPM_NUVOTON */
 
 /* Infineon SLB9670 TPM 2.0 (default) */
 /* #define WOLFTPM_SLB9670 */
-#if !defined(WOLFTPM_ST33) && !defined(WOLFTPM_MCHP) && !defined(WOLFTPM_SLB9670)
+
+/* Define a default chip */
+#if !defined(WOLFTPM_ST33) && !defined(WOLFTPM_MCHP) && \
+    !defined(WOLFTPM_NUVOTON) && !defined(WOLFTPM_SLB9670)
     #define WOLFTPM_SLB9670
 #endif
+
 
 /* Chip Specific Settings */
 #ifdef WOLFTPM_MCHP
@@ -169,25 +175,39 @@ typedef int64_t  INT64;
     #ifndef WOLFTPM_CHECK_WAIT_STATE
         #define WOLFTPM_CHECK_WAIT_STATE
     #endif
+    /* Max: 36MHz (has issues so using 33MHz) */
+    #define TPM2_SPI_MAX_HZ_MICROCHIP 33000000
     #ifndef TPM2_SPI_MAX_HZ
-        /* Max: 36MHz (has issues so using 33MHz) */
-        #define TPM2_SPI_MAX_HZ 33000000
+        #define TPM2_SPI_MAX_HZ TPM2_SPI_MAX_HZ_MICROCHIP
     #endif
 #elif defined(WOLFTPM_ST33)
-    /* ST33TPM20 modules */
+    /* ST ST33TPM20 modules */
     /* Requires wait state support */
     #ifndef WOLFTPM_CHECK_WAIT_STATE
         #define WOLFTPM_CHECK_WAIT_STATE
     #endif
+    /* Max: 33MHz */
+    #define TPM2_SPI_MAX_HZ_ST 33000000
     #ifndef TPM2_SPI_MAX_HZ
-        /* Max: 33MHz */
-        #define TPM2_SPI_MAX_HZ 33000000
+        #define TPM2_SPI_MAX_HZ TPM2_SPI_MAX_HZ_ST
     #endif
-#else
-    /* OPTIGA SLB9670 */
+#elif defined(WOLFTPM_NUVOTON)
+    /* Nuvoton NPCT75x module */
+    /* Requires wait state support */
+    #ifndef WOLFTPM_CHECK_WAIT_STATE
+        #define WOLFTPM_CHECK_WAIT_STATE
+    #endif
+    #define TPM2_SPI_MAX_HZ_NUVOTON 43000000
     #ifndef TPM2_SPI_MAX_HZ
         /* Max: 43MHz */
-        #define TPM2_SPI_MAX_HZ 43000000
+        #define TPM2_SPI_MAX_HZ TPM2_SPI_MAX_HZ_NUVOTON
+    #endif
+#else
+    /* Infineon OPTIGA SLB9670 */
+    /* Max: 43MHz */
+    #define TPM2_SPI_MAX_HZ_INFINEON 43000000
+    #ifndef TPM2_SPI_MAX_HZ
+        #define TPM2_SPI_MAX_HZ TPM2_SPI_MAX_HZ_INFINEON
     #endif
 #endif
 

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -150,11 +150,12 @@ typedef int64_t  INT64;
 /* ---------------------------------------------------------------------------*/
 /* TPM HARDWARE TYPE */
 /* ---------------------------------------------------------------------------*/
+/* Microchip ATTPM20 */
+/* #define WOLFTPM_MCHP */
+
 /* ST ST33TP TPM 2.0 */
 /* #define WOLFTPM_ST33 */
 
-/* Microchip ATTPM20 */
-/* #define WOLFTPM_MCHP */
 /* Nuvoton NPCT75x TPM 2.0 module */
 /* #define WOLFTPM_NUVOTON */
 
@@ -209,6 +210,21 @@ typedef int64_t  INT64;
     #ifndef TPM2_SPI_MAX_HZ
         #define TPM2_SPI_MAX_HZ TPM2_SPI_MAX_HZ_INFINEON
     #endif
+#endif
+
+/* Auto-chip detection requires SPI wait state support and safe SPI bus speed */
+#ifdef WOLFTPM_AUTODETECT
+    /* SPI wait state checking must be enabled */
+    #undef  WOLFTPM_CHECK_WAIT_STATE
+    #define WOLFTPM_CHECK_WAIT_STATE
+
+    /* use a safe MHz (minimum of above) */
+    #undef TPM2_SPI_MAX_HZ
+    #define TPM2_SPI_MAX_HZ 33000000
+
+    /* always perform self-test (some chips require) */
+    #undef  WOLFTPM_PERFORM_SELFTEST
+    #define WOLFTPM_PERFORM_SELFTEST
 #endif
 
 

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -81,6 +81,8 @@ typedef enum WOLFTPM2_MFG {
     TPM_MFG_INFINEON,
     TPM_MFG_STM,
     TPM_MFG_MCHP,
+    TPM_MFG_NUVOTON,
+    TPM_MFG_NATIONTECH,
 } WOLFTPM2_MFG;
 typedef struct WOLFTPM2_CAPS {
     WOLFTPM2_MFG mfg;
@@ -94,6 +96,7 @@ typedef struct WOLFTPM2_CAPS {
     /* bits */
     word16 fips140_2 : 1; /* using FIPS mode */
     word16 cc_eal4   : 1; /* Common Criteria EAL4+ */
+    word16 req_wait_state : 1; /* requires SPI wait state */
 } WOLFTPM2_CAPS;
 
 /* NV Handles */


### PR DESCRIPTION
* Added NPCT75x Nuvoton support (`--enable-nuvoton`).
* Added dynamic module detection at run-time when using internal TIS. (on by default when no module is specified `--enable-autodetect`.
* Added some missing --enable options and documentation.