### PR TITLE
Add example of a TPM2.0 Quote using wolfTPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,9 @@ examples/csr/csr
 examples/tls/tls_client
 examples/pkcs7/pkcs7
 examples/timestamp/signed_timestamp
-examples/timestamp/pcr
+examples/pcr/quote
+examples/pcr/extend
+examples/pcr/reset
 pkcs7tpmsigned.p7s
 pkcs7tpmsignedex.p7s
 examples/tls/tls_server

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ examples/csr/csr
 examples/tls/tls_client
 examples/pkcs7/pkcs7
 examples/timestamp/signed_timestamp
+examples/timestamp/pcr
 pkcs7tpmsigned.p7s
 pkcs7tpmsignedex.p7s
 examples/tls/tls_server

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Portable TPM 2.0 project designed for embedded use.
 	* TLS Server
 	* Benchmarking TPM algorithms and TLS
 
-Note: See `examples/README.md` for details on using the examples.
+Note: See [examples/README.md](examples/README.md) for details on using the examples.
 
 
 ## TPM 2.0 Overview

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,7 +20,9 @@ Demonstrates calling the wolfTPM2_* wrapper API's.
 `./examples/wrap/wrap_test`
 
 
-## Attestation Use Case (TPM signed timestamp)
+## Attestation Use Cases
+
+# TPM signed timestamp, TPM2.0 GetTime
 
 Demonstrates creation of Attestation Identity Keys(AIK) and the generation of TPM signed timestamp that can be later used as protected report of the current system uptime.
 
@@ -28,6 +30,11 @@ This example demonstrates the use of authSession(authorization Session) and poli
 
 `./examples/timestamp/signed_timestamp`
 
+# TPM signed PCR(system) measurement, TPM2.0 Quote
+
+Demonstrates the generation of TPM2.0 Quote used for attestation of the system state by putting PCR value(s) in a TPM signed structure.
+
+`./examples/pcr/quote`
 
 ## CSR
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,8 @@ Demonstrates the generation of TPM2.0 Quote used for attestation of the system s
 More information about how to test and use PCR attestation can be found in the in README file located in the `pcr` folder of the example.
 
 `./examples/pcr/quote`
+`./examples/pcr/extend`
+`./examples/pcr/reset`
 
 ## CSR
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,9 +24,9 @@ Demonstrates calling the wolfTPM2_* wrapper API's.
 
 ### TPM signed timestamp, TPM2.0 GetTime
 
-Demonstrates creation of Attestation Identity Keys(AIK) and the generation of TPM signed timestamp that can be later used as protected report of the current system uptime.
+Demonstrates creation of Attestation Identity Keys (AIK) and the generation of TPM signed timestamp that can be later used as protected report of the current system uptime.
 
-This example demonstrates the use of authSession(authorization Session) and policySession(Policy authorization) to enable the Endorsement Hierarchy necessary for creating AIK. Then, the AIK is used to issue a TPM2_GetTime command using the wolfTPM2 native API. This provides us with TPM generated and signed timestamp that can be used as a system report of its uptime.
+This example demonstrates the use of `authSession` (authorization Session) and `policySession` (Policy authorization) to enable the Endorsement Hierarchy necessary for creating AIK. The AIK is used to issue a `TPM2_GetTime` command using the TPM 2.0 native API. This provides a TPM generated and signed timestamp that can be used as a system report of its uptime.
 
 `./examples/timestamp/signed_timestamp`
 
@@ -34,11 +34,12 @@ This example demonstrates the use of authSession(authorization Session) and poli
 
 Demonstrates the generation of TPM2.0 Quote used for attestation of the system state by putting PCR value(s) in a TPM signed structure.
 
-More information about how to test and use PCR attestation can be found in the in README file located in the `pcr` folder of the example.
+More information about how to test and use PCR attestation can be found in the in [examples/pcr/README.md](./examples/pcr/README.md).
 
 `./examples/pcr/quote`
 `./examples/pcr/extend`
 `./examples/pcr/reset`
+
 
 ## CSR
 
@@ -84,7 +85,7 @@ The TLS example uses TPM based ECDHE (ECC Ephemeral key) support. It can be disa
 
 To force ECC use with wolfSSL when RSA is enabled define `TLS_USE_ECC`.
 
-To use symmetric AES/Hashing/Hmac with the TPM define `WOLFTPM_USE_SYMMETRIC`.
+To use symmetric AES/Hashing/HMAC with the TPM define `WOLFTPM_USE_SYMMETRIC`.
 
 Generation of the Client and Server Certificates requires running:
 1. `./examples/csr/csr`
@@ -98,7 +99,7 @@ Generation of the Client and Server Certificates requires running:
 
 Examples show using a TPM key and certificate for TLS mutual authentication (client authentication).
 
-This example client connects to localhost on on port 11111 by default. These can be overriden using `TLS_HOST` and `TLS_PORT`.
+This example client connects to localhost on on port 11111 by default. These can be overridden using `TLS_HOST` and `TLS_PORT`.
 
 You can validate using the wolfSSL example server this like:
 `./examples/server/server -b -p 11111 -g -d`
@@ -109,7 +110,7 @@ or
 `./examples/server/server -b -p 11111 -g -A ./certs/tpm-ca-ecc-cert.pem`
 
 Then run the wolfTPM TLS client example:
-`./examples/tls/tls_client`. 
+`./examples/tls/tls_client`
 
 
 ### TLS Server
@@ -133,7 +134,7 @@ or
 Or using your browser: `https://localhost:11111`
 
 With browsers you will get certificate warnings until you load the test CA's `./certs/ca-rsa-cert.pem` and `./certs/ca-ecc-cert.pem` into your OS key store.
-For testing most browsers have a way to continue to the site anyways to bypass the warning. 
+For testing most browsers have a way to continue to the site anyways to bypass the warning.
 
 
 ## Benchmark

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ Demonstrates calling the wolfTPM2_* wrapper API's.
 
 ## Attestation Use Cases
 
-# TPM signed timestamp, TPM2.0 GetTime
+### TPM signed timestamp, TPM2.0 GetTime
 
 Demonstrates creation of Attestation Identity Keys(AIK) and the generation of TPM signed timestamp that can be later used as protected report of the current system uptime.
 
@@ -30,9 +30,11 @@ This example demonstrates the use of authSession(authorization Session) and poli
 
 `./examples/timestamp/signed_timestamp`
 
-# TPM signed PCR(system) measurement, TPM2.0 Quote
+### TPM signed PCR(system) measurement, TPM2.0 Quote
 
 Demonstrates the generation of TPM2.0 Quote used for attestation of the system state by putting PCR value(s) in a TPM signed structure.
+
+More information about how to test and use PCR attestation can be found in the in README file located in the `pcr` folder of the example.
 
 `./examples/pcr/quote`
 

--- a/examples/bench/include.am
+++ b/examples/bench/include.am
@@ -5,7 +5,7 @@ if BUILD_EXAMPLES
 noinst_PROGRAMS += examples/bench/bench
 noinst_HEADERS  += examples/bench/bench.h
 examples_bench_bench_SOURCES      = examples/bench/bench.c \
-									   examples/tpm_io.c
+                                    examples/tpm_io.c
 examples_bench_bench_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_bench_bench_DEPENDENCIES = src/libwolftpm.la
 endif

--- a/examples/include.am
+++ b/examples/include.am
@@ -8,6 +8,7 @@ include examples/tls/include.am
 include examples/csr/include.am
 include examples/pkcs7/include.am
 include examples/timestamp/include.am
+include examples/pcr/include.am
 
 dist_example_DATA+= examples/README.md \
                     examples/tpm_io.c \

--- a/examples/native/include.am
+++ b/examples/native/include.am
@@ -5,7 +5,7 @@ if BUILD_EXAMPLES
 noinst_PROGRAMS += examples/native/native_test
 noinst_HEADERS  += examples/native/native_test.h
 examples_native_native_test_SOURCES      = examples/native/native_test.c \
-									       examples/tpm_io.c
+                                           examples/tpm_io.c
 examples_native_native_test_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_native_native_test_DEPENDENCIES = src/libwolftpm.la
 endif

--- a/examples/pcr/README.md
+++ b/examples/pcr/README.md
@@ -1,47 +1,96 @@
 # Quote & Attestation Demo
 
-This folder contains examples for performing local attestation. You will learn how to measure a system file using wolfTPM and then generate a TPM2.0 Quote as proof for that measurement. Find technology introduction below.
+This folder contains examples for performing local attestation. You will learn how to measure a system file using wolfTPM and then generate a TPM 2.0 Quote as proof for that measurement. See [Technology Introduction](## Technology introduction) below.
 
 ## List of examples
 
-The `./examples/pcr/` folder contains three tools for working with Platform Configuration Registers(PCR) and a demo script. It is recommended to build wolfTPM with debug output enabled using `./configure --enable-devtpm --enable-debug` before `make`. After sucesssfully building wolfTPM, simply launch the `./examples/pcr/demo.sh` script.
+The `./examples/pcr/` folder contains tools for working with Platform Configuration Registers (PCR). It is recommended to build wolfTPM with debug output enabled using `./configure --enable-debug` before `make` to see more logging output. There are example scripts to show using these PCR examples.
 
-* `./examples/pcr/reset` - use to clear the content of a PCR (restrictions apply, see below)
-* `./examples/pcr/extend` - use to modify the content of a PCR (extend is a cryptographic operation, see below)
-* `./examples/pcr/quote` - use to generate a TPM2.0 Quote structure containing the PCR digest and TPM-generated signature
+Examples:
+
+* `./examples/pcr/reset`: Used to clear the content of a PCR (restrictions apply, see below)
+* `./examples/pcr/extend`: Used to modify the content of a PCR (extend is a cryptographic operation, see below)
+* `./examples/pcr/quote`: Used to generate a TPM2.0 Quote structure containing the PCR digest and TPM-generated signature
+
+Scripts:
+
 * `./examples/pcr/demo.sh` - script demonstrating the tools above
 * `./examples/pcr/demo-quote-zip.sh` - script demonstrating how using the tools above a system file can be measured and a TPM-signed proof with that measurement generated
 
+
 ## Technology introduction
 
-### Platform Configuration Registers(PCR)
+### Platform Configuration Registers (PCR)
 
-PCRs in TPM2.0 are special registers that allow only one type of write operations to be performed on them. This is the `TPM2_Extend` cryptographic operation that preserves the old value of the PCR and combines it with newly provided hash digest. Doing so the PCR does not allow tampering of its content and provides reproducibility.
+PCRs in TPM2.0 are special registers that allow only one type of write operations to be performed on them. A TPM 2.0 extend operation is the only way to update a PCR.
 
-At power-up, the TPM resets all PCRs to their default state(all zeros or all ones, depending on the PCR). From this state, the TPM could generate the same PCR value only if the PCR is extended with the same hash digest. In case of multiple values(multiple extend operations), the values must be supplied in the correct order, otherwise the final PCR value would differ.
+At power-up, the TPM resets all PCRs to their default state (all zeros or all ones, depending on the PCR). From this state, the TPM can generate the same PCR value only if the PCR is extended with the same hash digest. In case of multiple values(multiple extend operations), the values must be supplied in the correct order, otherwise the final PCR value would differ.
 
-For example, doing a measured boot under Linux would generate the same PCR digest, if the kernel is the same at every boot. However, loading the same (A)Linux kernel, (B)initrd image and (C)configuration file would generate the same PCR digest only when the order of extend operations is consistent(for example, A-B-C). It does not matter which extend operation is first or last as long as the order is kept the same(for example, C-B-A would result in a reproducible digest, but it would differ from the A-B-C digest).
-
-### Quote
-
-Quote is a standard TPM2.0 operation that encapsulates the PCR digest in a TCG defined structure called TPMS_ATTEST together with TPM signature. The signature is produced from a TPM generated key called Attestation Identity Key(AIK) that only the TPM can use. This provides guarantee for the source of the Quote and PCR digest. Together, the Quote and PCR provide the means for system measurement and integrity.
+For example, doing a measured boot under Linux would generate the same PCR digest, if the kernel is the same at every boot. However, loading the same (A) Linux kernel, (B) initrd image and (C) configuration file would generate the same PCR digest only when the order of extend operations is consistent (for example, A-B-C). It does not matter which extend operation is first or last as long as the order is kept the same. For example, C-B-A would result in a reproducible digest, but it would differ from the A-B-C digest.
 
 ### Reset
 
 Not all PCRs are equal. The user can perform `extend` operation on all PCRs, but the user can `reset` only on one of them during normal runtime. This is what makes PCRs so useful.
 
 * PCR0-15 are reset at boot and can be cleared again(reset) only from reboot cycle.
-
 * PCR16 is a PCR for debug purposes. This is the PCR used by all tools above by default. It is safe to test and work with PCR16.
+* PCR17-22 are reserved for Dynamic Root of Trust Measurement (DRTM), an advanced topic that is to be covered separately.
 
-* PCR17-22 are reserved for Dynamic Root of Trust Measurement(DRTM), an advanced topic that is to be covered separately.
+### Extend
+
+The TPM 2.0 `TPM2_Extend` API uses a SHA1 or SHA256 cryptographic operation to combine the current value of the PCR and with newly provided hash digest.
+
+### Quote
+
+The TPM 2.0 `TPM2_Quote` API is a standard operation that encapsulates the PCR digest in a TCG defined structure called `TPMS_ATTEST` together with TPM signature. The signature is produced from a TPM generated key called Attestation Identity Key (AIK) that only the TPM can use. This provides guarantee for the source of the Quote and PCR digest. Together, the Quote and PCR provide the means for system measurement and integrity.
+
+## Example Usage
+
+### Reset Example Usage
+
+```sh
+$ ./examples/pcr/reset -?
+PCR index is out of range (0-23)
+Expected usage:
+./examples/pcr/reset [pcr]
+* pcr is a PCR index between 0-23 (default 16)
+Demo usage without parameters, resets PCR16.
+```
+
+### Extend Example Usage
+
+```sh
+$ ./examples/pcr/extend -?
+Incorrect arguments
+Expected usage:
+./examples/pcr/extend [pcr] [filename]
+* pcr is a PCR index between 0-23 (default 16)
+* filename points to file(data) to measure
+	If wolfTPM is built with --disable-wolfcrypt the file
+	must contain SHA256 digest ready for extend operation.
+	Otherwise, the extend tool computes the hash using wolfcrypt.
+Demo usage without parameters, extends PCR16 with known hash.
+```
+
+### Quote Example Usage
+
+```sh
+$ ./examples/pcr/quote -?
+Incorrect arguments
+Expected usage:
+./examples/pcr/quote [pcr] [filename]
+* pcr is a PCR index between 0-23 (default 16)
+* filename for saving the TPMS_ATTEST structure to a file
+Demo usage without parameters, generates quote over PCR16 and
+saves the output TPMS_ATTEST structure to "quote.blob" file.
+```
 
 ## Typical demo output
 
-All pcr examples can be used without arguments. This is the output of the `demo.sh` script:
+All PCR examples can be used without arguments. This is the output of the `./examples/pcr/demo.sh` script:
 
-```
-~/wolfTPM$ sudo ./examples/pcr/reset
+```sh
+$ ./examples/pcr/reset
 Demo how to reset a PCR (clear the PCR value)
 wolfTPM2_Init: success
 Trying to reset PCR16...
@@ -53,8 +102,8 @@ PCR16 digest:
 
 As expected, the PCR16 content is now set back to all zeroes. From this moment on we can generate predictable PCR digests(values) for system measurement. Similar to using PCR7 after boot, because PCR7 is reset at system boot. Using PCR16 allows us to skip system reboots and test safely.
 
-```
-~/wolfTPM$ sudo ./examples/pcr/extend
+```sh
+$ ./examples/pcr/extend
 Demo how to extend data into a PCR (TPM2.0 measurement)
 wolfTPM2_Init: success
 Hash to be used for measurement:
@@ -65,10 +114,10 @@ PCR16 digest:
     8c 7a 3b a2 6f 97 6e 8e cb be 7a 53 69 18 dc 73 | .z;.o.n...zSi..s
 ```
 
-Based on the old content of the PCR(all zeros) and the provided hash(SHA256 32-byte digest), the PCR gets its new value printed at the end of the `extend` example. This value will always be the same, if `reset` is launched before `extend`. To pass custom hash digest, the `extend` tool accepts PCR index as first argument(recommended to use 16 for PCR16) and user file as second argument.
+Based on the old content of the PCR (all zeros) and the provided hash (SHA256 32-byte digest), the PCR gets its new value printed at the end of the `extend` example. This value will always be the same, if `reset` is launched before `extend`. To pass custom hash digest, the `extend` tool accepts PCR index as first argument(recommended to use 16 for PCR16) and user file as second argument.
 
-```
-~/wolfTPM$ sudo ./examples/pcr/quote
+```sh
+$ ./examples/pcr/quote
 Demo of generating signed PCR measurement (TPM2.0 Quote)
 wolfTPM2_Init: success
 TPM2_CreatePrimary: 0x80000000 (314 bytes)
@@ -108,21 +157,22 @@ Before producing a TPM-signed structure containing the PCR measurement, the quot
 
 ## Steps for measuring a system file (performing local attestation)
 
-A system administrator wants to make sure the zip tool of an user is geniune(legitimate software, correct version and has not been tampred with). To do this, the SysAdmin resets PCR16 and can afterwards generate a PCR digest based on the zip binary that can be used for future references if the file has been modified.
+A system administrator wants to make sure the zip tool of an user is genuine (legitimate software, correct version and has not been tampered with). To do this, the SysAdmin resets PCR16 and can afterwards generate a PCR digest based on the zip binary that can be used for future references if the file has been modified.
 
+This is the output from `./examples/pcr/demo-quote-zip.sh` script.
 
-```
-~/wolfTPM$ sudo ./examples/pcr/reset
+```sh
+$ ./examples/pcr/reset 16
 ...
 Trying to reset PCR16...
 TPM2_PCR_Reset success
 ...
 ```
 
-This is a good known initial state of the PCR. By using the `extend` tool the SysAdmin feeds the `/usr/bin/zip` binary to Wolfcrypt for SHA256 hash computation, which then is used by wolfTPM to issue a TPM2_Extend operation in PCR16.
+This is a good known initial state of the PCR. By using the `extend` tool the SysAdmin feeds the `/usr/bin/zip` binary to wolfCrypt for SHA256 hash computation, which then is used by wolfTPM to issue a `TPM2_Extend` operation in PCR16.
 
-```
-~/wolfTPM$ sudo ./examples/pcr/extend 16 /usr/bin/zip
+```sh
+$ ./examples/pcr/extend 16 /usr/bin/zip
 ...
 TPM2_PCR_Extend success
 PCR16 digest:
@@ -132,8 +182,8 @@ PCR16 digest:
 
 Once the extend operation is finished, the SysAdmin wants to create a TPM2.0 Quote as proof of the measurement in PCR16.
 
-```
-~/wolfTPM$ sudo ./examples/pcr/quote 16 zip.quote
+```sh
+$ ./examples/pcr/quote 16 zip.quote
 ...
 TPM2_Quote: success
 TPM with signature attests (type 0x8018):
@@ -141,5 +191,4 @@ TPM with signature attests (type 0x8018):
 ...
 ```
 
-The result of the TPM2.0 Quote operation is saved in the `zip.quote` binary file. The TPMS_ATTEST structure of TPM2.0 Quote contains also useful clock and time information. For more about the TPM time attestation please check the `./examples/timestamp/signed_timestamp` example.
-
+The result of the TPM2.0 Quote operation is saved in the `zip.quote` binary file. The `TPMS_ATTEST` structure of TPM 2.0 Quote contains also useful clock and time information. For more about the TPM time attestation please check the `./examples/timestamp/signed_timestamp` example.

--- a/examples/pcr/README.md
+++ b/examples/pcr/README.md
@@ -1,0 +1,145 @@
+# Quote & Attestation Demo
+
+This folder contains examples for performing local attestation. You will learn how to measure a system file using wolfTPM and then generate a TPM2.0 Quote as proof for that measurement. Find technology introduction below.
+
+## List of examples
+
+The `./examples/pcr/` folder contains three tools for working with Platform Configuration Registers(PCR) and a demo script. It is recommended to build wolfTPM with debug output enabled using `./configure --enable-devtpm --enable-debug` before `make`. After sucesssfully building wolfTPM, simply launch the `./examples/pcr/demo.sh` script.
+
+* `./examples/pcr/reset` - use to clear the content of a PCR (restrictions apply, see below)
+* `./examples/pcr/extend` - use to modify the content of a PCR (extend is a cryptographic operation, see below)
+* `./examples/pcr/quote` - use to generate a TPM2.0 Quote structure containing the PCR digest and TPM-generated signature
+* `./examples/pcr/demo.sh` - script demonstrating the tools above
+* `./examples/pcr/demo-quote-zip.sh` - script demonstrating how using the tools above a system file can be measured and a TPM-signed proof with that measurement generated
+
+## Technology introduction
+
+### Platform Configuration Registers(PCR)
+
+PCRs in TPM2.0 are special registers that allow only one type of write operations to be performed on them. This is the `TPM2_Extend` cryptographic operation that preserves the old value of the PCR and combines it with newly provided hash digest. Doing so the PCR does not allow tampering of its content and provides reproducibility.
+
+At power-up, the TPM resets all PCRs to their default state(all zeros or all ones, depending on the PCR). From this state, the TPM could generate the same PCR value only if the PCR is extended with the same hash digest. In case of multiple values(multiple extend operations), the values must be supplied in the correct order, otherwise the final PCR value would differ.
+
+For example, doing a measured boot under Linux would generate the same PCR digest, if the kernel is the same at every boot. However, loading the same (A)Linux kernel, (B)initrd image and (C)configuration file would generate the same PCR digest only when the order of extend operations is consistent(for example, A-B-C). It does not matter which extend operation is first or last as long as the order is kept the same(for example, C-B-A would result in a reproducible digest, but it would differ from the A-B-C digest).
+
+### Quote
+
+Quote is a standard TPM2.0 operation that encapsulates the PCR digest in a TCG defined structure called TPMS_ATTEST together with TPM signature. The signature is produced from a TPM generated key called Attestation Identity Key(AIK) that only the TPM can use. This provides guarantee for the source of the Quote and PCR digest. Together, the Quote and PCR provide the means for system measurement and integrity.
+
+### Reset
+
+Not all PCRs are equal. The user can perform `extend` operation on all PCRs, but the user can `reset` only on one of them during normal runtime. This is what makes PCRs so useful.
+
+* PCR0-15 are reset at boot and can be cleared again(reset) only from reboot cycle.
+
+* PCR16 is a PCR for debug purposes. This is the PCR used by all tools above by default. It is safe to test and work with PCR16.
+
+* PCR17-22 are reserved for Dynamic Root of Trust Measurement(DRTM), an advanced topic that is to be covered separately.
+
+## Typical demo output
+
+All pcr examples can be used without arguments. This is the output of the `demo.sh` script:
+
+```
+~/wolfTPM$ sudo ./examples/pcr/reset
+Demo how to reset a PCR (clear the PCR value)
+wolfTPM2_Init: success
+Trying to reset PCR16...
+TPM2_PCR_Reset success
+PCR16 digest:
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................
+```
+
+As expected, the PCR16 content is now set back to all zeroes. From this moment on we can generate predictable PCR digests(values) for system measurement. Similar to using PCR7 after boot, because PCR7 is reset at system boot. Using PCR16 allows us to skip system reboots and test safely.
+
+```
+~/wolfTPM$ sudo ./examples/pcr/extend
+Demo how to extend data into a PCR (TPM2.0 measurement)
+wolfTPM2_Init: success
+Hash to be used for measurement:
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F
+TPM2_PCR_Extend success
+PCR16 digest:
+    bb 22 75 c4 9f 28 ad 52 ca e6 d5 5e 34 a9 74 a5 | ."u..(.R...^4.t.
+    8c 7a 3b a2 6f 97 6e 8e cb be 7a 53 69 18 dc 73 | .z;.o.n...zSi..s
+```
+
+Based on the old content of the PCR(all zeros) and the provided hash(SHA256 32-byte digest), the PCR gets its new value printed at the end of the `extend` example. This value will always be the same, if `reset` is launched before `extend`. To pass custom hash digest, the `extend` tool accepts PCR index as first argument(recommended to use 16 for PCR16) and user file as second argument.
+
+```
+~/wolfTPM$ sudo ./examples/pcr/quote
+Demo of generating signed PCR measurement (TPM2.0 Quote)
+wolfTPM2_Init: success
+TPM2_CreatePrimary: 0x80000000 (314 bytes)
+wolfTPM2_CreateEK: Endorsement 0x80000000 (314 bytes)
+TPM2_CreatePrimary: 0x80000001 (282 bytes)
+wolfTPM2_CreateSRK: Storage 0x80000001 (282 bytes)
+TPM2_StartAuthSession: sessionHandle 0x3000000
+TPM2_Create key: pub 280, priv 212
+TPM2_Load Key Handle 0x80000002
+wolfTPM2_CreateAndLoadAIK: AIK 0x80000002 (280 bytes)
+TPM2_Quote: success
+TPM with signature attests (type 0x8018):
+    TPM signed 1 count of PCRs
+    PCR digest:
+    c7 d4 27 2a 57 97 7f 66 1f bd 79 30 0a 1b bf ff | ..'*W..f..y0....
+    2e 43 57 cc 44 14 7a 82 11 aa 76 3f 9f 1b 3a 6c | .CW.D.z...v?..:l
+    TPM generated signature:
+    28 dc da 76 33 35 a5 85 2a 0c 0b e8 25 d0 f8 8d | (..v35..*...%...
+    1f ce c3 3b 71 64 ed 54 e6 4d 82 af f3 83 18 8e | ...;qd.T.M......
+    6e 2d 9f 9e 5a 86 4f 11 fe 13 84 94 cf 05 b9 d5 | n-..Z.O.........
+    eb 5a 34 39 b2 a5 7a 5f 52 c0 f4 e7 2b 70 b7 62 | .Z49..z_R...+p.b
+    6a fe 79 4e 2e 46 2e 43 d7 1c ef 2c 14 21 11 14 | j.yN.F.C...,.!..
+    95 01 93 a9 85 0d 02 c7 b2 f8 75 1a bd 59 da 56 | ..........u..Y.V
+    cc 43 e3 d2 aa 14 49 2a 59 26 09 9e c9 4b 1a 66 | .C....I*Y&...K.f
+    cb 77 65 95 79 69 89 bd 46 46 13 3d 2c a9 78 f8 | .we.yi..FF.=,.x.
+    2c ab 8a 4a 6b f2 97 67 86 37 f8 f6 9d 85 cd cf | ,..Jk..g.7......
+    a4 ae c6 d3 cf c1 63 92 8c 7b 88 79 90 54 0a ba | ......c..{.y.T..
+    8d c6 1c 8f 6e 6d 61 bc a9 2f 35 b0 1a 46 74 9a | ....nma../5..Ft.
+    e3 7d 39 33 52 1a f5 4b 07 8d 30 53 75 b5 68 40 | .}93R..K..0Su.h@
+    04 e7 a1 fc b1 93 5d 1e bc ca f4 a9 fa 75 d3 f6 | ......]......u..
+    3d 4a 5b 07 23 0e f0 f4 1f 97 23 76 1a ee 66 93 | =J[.#.....#v..f.
+    cd fd 9e 6f 2b d3 95 c5 51 cf f6 81 5b 97 a1 d2 | ...o+...Q...[...
+    06 45 c0 30 70 ad bd 36 66 9f 95 af 60 7c d5 a2 | .E.0p..6f...`|..
+```
+
+Before producing a TPM-signed structure containing the PCR measurement, the quote example starts by creating an Endorsement Key(EK) that is required for the TPM to operate. It serves essentially as the primary key for all other keys. Next, a Storage Key(SRK) is generated and under that SRK a special Attestation Identity Key(AIK) is added. Using the AIK the TPM can sign the quote structure.
+
+## Steps for measuring a system file (performing local attestation)
+
+A system administrator wants to make sure the zip tool of an user is geniune(legitimate software, correct version and has not been tampred with). To do this, the SysAdmin resets PCR16 and can afterwards generate a PCR digest based on the zip binary that can be used for future references if the file has been modified.
+
+
+```
+~/wolfTPM$ sudo ./examples/pcr/reset
+...
+Trying to reset PCR16...
+TPM2_PCR_Reset success
+...
+```
+
+This is a good known initial state of the PCR. By using the `extend` tool the SysAdmin feeds the `/usr/bin/zip` binary to Wolfcrypt for SHA256 hash computation, which then is used by wolfTPM to issue a TPM2_Extend operation in PCR16.
+
+```
+~/wolfTPM$ sudo ./examples/pcr/extend 16 /usr/bin/zip
+...
+TPM2_PCR_Extend success
+PCR16 digest:
+    2b bd 54 ae 08 5b 59 ef 90 42 d5 ca 5d df b5 b5 | +.T..[Y..B..]...
+    74 3a 26 76 d4 39 37 eb b0 53 f5 82 67 6f b4 aa | t:&v.97..S..go..
+```
+
+Once the extend operation is finished, the SysAdmin wants to create a TPM2.0 Quote as proof of the measurement in PCR16.
+
+```
+~/wolfTPM$ sudo ./examples/pcr/quote 16 zip.quote
+...
+TPM2_Quote: success
+TPM with signature attests (type 0x8018):
+    TPM signed 1 count of PCRs
+...
+```
+
+The result of the TPM2.0 Quote operation is saved in the `zip.quote` binary file. The TPMS_ATTEST structure of TPM2.0 Quote contains also useful clock and time information. For more about the TPM time attestation please check the `./examples/timestamp/signed_timestamp` example.
+

--- a/examples/pcr/demo-quote-zip.sh
+++ b/examples/pcr/demo-quote-zip.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+echo "wolfTPM Quote & Attestation demo"
+echo
+echo "Starting from a known PCR state"
+
+./examples/pcr/reset
+
+echo
+echo "Extending with precalculated hash value"
+echo
+
+./examples/pcr/extend 16 /usr/bin/zip
+
+echo
+echo "Generating TPM-signed structure with this PCR digest"
+echo
+
+./examples/pcr/quote 16 zip.quote
+
+echo
+echo "TPMS_ATTEST structure is saved to a binary file 'zip.quote'"
+echo

--- a/examples/pcr/demo-quote-zip.sh
+++ b/examples/pcr/demo-quote-zip.sh
@@ -4,7 +4,7 @@ echo "wolfTPM Quote & Attestation demo"
 echo
 echo "Starting from a known PCR state"
 
-./examples/pcr/reset
+./examples/pcr/reset 16
 
 echo
 echo "Extending with precalculated hash value"

--- a/examples/pcr/demo.sh
+++ b/examples/pcr/demo.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+echo "wolfTPM Quote & Attestation demo"
+echo
+echo "Starting from a known PCR state"
+
+./examples/pcr/reset
+
+echo
+echo "Extending with precalculated hash value"
+echo
+
+./examples/pcr/extend
+
+echo
+echo "Generating TPM-signed structure with this PCR digest"
+echo
+
+./examples/pcr/quote
+
+echo
+echo "TPMS_ATTEST structure is saved to a binary file 'quote.blob'"
+echo

--- a/examples/pcr/extend.c
+++ b/examples/pcr/extend.c
@@ -1,0 +1,170 @@
+/* extend.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/* This is a helper tool for extending hash into a TPM2.0 PCR */
+
+#include <wolftpm/tpm2_wrap.h>
+
+#include <examples/pcr/extend.h>
+#include <examples/tpm_io.h>
+#include <examples/tpm_test.h>
+
+#include <stdio.h>
+
+
+/******************************************************************************/
+/* --- BEGIN TPM2.0 PCR Extend example tool  -- */
+/******************************************************************************/
+
+inline static void usage(void)
+{
+    printf("Expected usage:\n");
+    printf("extend (pcr_number) (filename)\n");
+    printf("* pcr_number is a PCR index between 0-23\n");
+    printf("* filename points to file(data) to measure\n");
+    printf("Demo usage without parameters, extends PCR16 with known hash.\n");
+}
+
+int TPM2_Extend_Test(void* userCtx, int argc, char *argv[])
+{
+    int i, pcrIndex, rc = -1;
+    const char *filename = NULL;
+    FILE *dataFile = NULL;
+    WOLFTPM2_DEV dev;
+
+    union {
+        PCR_Extend_In pcrExtend;
+        PCR_Read_In pcrRead;
+        FlushContext_In flushCtx;
+        byte maxInput[MAX_COMMAND_SIZE];
+    } cmdIn;
+    union {
+        PCR_Read_Out pcrRead;
+        byte maxOutput[MAX_RESPONSE_SIZE];
+    } cmdOut;
+
+    TPM_HANDLE sessionHandle = TPM_RH_NULL;
+    TPMS_AUTH_COMMAND session[MAX_SESSION_NUM];
+
+    if(argc == 3) {
+        pcrIndex = strtol(argv[1], NULL, 10);
+        if(pcrIndex < 0 || pcrIndex > 23) {
+            printf("PCR index is out of range(0-23)\n");
+            goto exit;
+        }
+
+        filename = argv[2];
+        dataFile = fopen(filename, "rb");
+        if(dataFile == NULL) {
+            printf("Error openning file %s\n", filename);
+            usage();
+            goto exit;
+        }
+    }
+    else if(argc == 1) {
+        pcrIndex = 16; /* PCR16 is for DEBUG purposes, thus safe to use */
+    }
+    else {
+        printf("Incorrect arguments\n");
+        usage();
+        goto exit;
+    }
+
+    printf("Extending hash into a PCR (TPM2.0 measurement)\n");
+    rc = wolfTPM2_Init(&dev, TPM2_IoCb, userCtx);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("wolfTPM2_Init failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("wolfTPM2_Init: success\n");
+
+
+    /* Define the default session auth that has NULL password */
+    XMEMSET(session, 0, sizeof(session));
+    session[0].sessionHandle = TPM_RS_PW;
+    session[0].auth.size = 0; /* NULL Password */
+    TPM2_SetSessionAuth(session);
+
+    /* PCR Extend */
+    XMEMSET(&cmdIn.pcrExtend, 0, sizeof(cmdIn.pcrExtend));
+    cmdIn.pcrExtend.pcrHandle = pcrIndex;
+    cmdIn.pcrExtend.digests.count = 1;
+    cmdIn.pcrExtend.digests.digests[0].hashAlg = TPM_ALG_SHA256;
+    for (i=0; i<TPM_SHA256_DIGEST_SIZE; i++) {
+        cmdIn.pcrExtend.digests.digests[0].digest.H[i] = i;
+    }
+    rc = TPM2_PCR_Extend(&cmdIn.pcrExtend);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_PCR_Extend failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("TPM2_PCR_Extend success\n");
+
+    XMEMSET(&cmdIn.pcrRead, 0, sizeof(cmdIn.pcrRead));
+    TPM2_SetupPCRSel(&cmdIn.pcrRead.pcrSelectionIn,
+        TEST_WRAP_DIGEST, pcrIndex);
+    rc = TPM2_PCR_Read(&cmdIn.pcrRead, &cmdOut.pcrRead);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_PCR_Read failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("TPM2_PCR_Read: Index %d, Count %d\n",
+            pcrIndex, (int)cmdOut.pcrRead.pcrValues.count);
+    if (cmdOut.pcrRead.pcrValues.count > 0) {
+        printf("TPM2_PCR_Read: Index %d, Digest Sz %d, Update Counter %d\n",
+            pcrIndex,
+            (int)cmdOut.pcrRead.pcrValues.digests[0].size,
+            (int)cmdOut.pcrRead.pcrUpdateCounter);
+        TPM2_PrintBin(cmdOut.pcrRead.pcrValues.digests[0].buffer,
+                      cmdOut.pcrRead.pcrValues.digests[0].size);
+    }
+
+exit:
+
+    if (dataFile != NULL) {
+        fclose(dataFile);
+    }
+    /* Close session */
+    if (sessionHandle != TPM_RH_NULL) {
+        cmdIn.flushCtx.flushHandle = sessionHandle;
+        TPM2_FlushContext(&cmdIn.flushCtx);
+    }
+
+    wolfTPM2_Cleanup(&dev);
+    return rc;
+}
+
+/******************************************************************************/
+/* --- END TPM2.0 PCR Extend example tool -- */
+/******************************************************************************/
+
+
+#ifndef NO_MAIN_DRIVER
+int main(int argc, char *argv[])
+{
+    int rc;
+
+    rc = TPM2_Extend_Test(NULL, argc, argv);
+
+    return rc;
+}
+#endif

--- a/examples/pcr/extend.c
+++ b/examples/pcr/extend.c
@@ -79,7 +79,7 @@ int TPM2_Extend_Test(void* userCtx, int argc, char *argv[])
         pcrIndex = strtol(argv[1], NULL, 10);
         if(pcrIndex < 0 || pcrIndex > 23) {
             printf("PCR index is out of range(0-23)\n");
-            goto exit;
+            goto exit_badargs;
         }
 
         filename = argv[2];
@@ -87,7 +87,7 @@ int TPM2_Extend_Test(void* userCtx, int argc, char *argv[])
         if(dataFile == NULL) {
             printf("Error openning file %s\n", filename);
             usage();
-            goto exit;
+            goto exit_badargs;
         }
     }
     else if(argc == 1) {
@@ -96,7 +96,7 @@ int TPM2_Extend_Test(void* userCtx, int argc, char *argv[])
     else {
         printf("Incorrect arguments\n");
         usage();
-        goto exit;
+        goto exit_badargs;
     }
 
     printf("Demo how to extend data into a PCR (TPM2.0 measurement)\n");
@@ -167,9 +167,6 @@ int TPM2_Extend_Test(void* userCtx, int argc, char *argv[])
 
 exit:
 
-    if (dataFile != NULL) {
-        fclose(dataFile);
-    }
     /* Close session */
     if (sessionHandle != TPM_RH_NULL) {
         cmdIn.flushCtx.flushHandle = sessionHandle;
@@ -177,6 +174,13 @@ exit:
     }
 
     wolfTPM2_Cleanup(&dev);
+
+exit_badargs:
+
+    if (dataFile != NULL) {
+        fclose(dataFile);
+    }
+
     return rc;
 }
 

--- a/examples/pcr/extend.c
+++ b/examples/pcr/extend.c
@@ -58,10 +58,10 @@ int TPM2_Extend_Test(void* userCtx, int argc, char *argv[])
     /* Arbitrary user data provided through a file */
     const char *filename = NULL;
     FILE *dataFile = NULL;
-    unsigned char hash[TPM_SHA256_DIGEST_SIZE];
+    BYTE hash[TPM_SHA256_DIGEST_SIZE];
 #ifndef WOLFTPM2_NO_WOLFCRYPT
     /* Using wolfcrypt to hash input data */
-    unsigned char dataBuffer[1024];
+    BYTE dataBuffer[1024];
     Sha256 sha256;
 #endif
 

--- a/examples/pcr/extend.c
+++ b/examples/pcr/extend.c
@@ -66,14 +66,14 @@ int TPM2_Extend_Test(void* userCtx, int argc, char *argv[])
 #endif
 
     union {
-#ifdef WOLFTPM_DEBUG_VERBOSE
+#ifdef DEBUG_WOLFTPM
         PCR_Read_In pcrRead;
 #endif
         PCR_Extend_In pcrExtend;
         FlushContext_In flushCtx;
         byte maxInput[MAX_COMMAND_SIZE];
     } cmdIn;
-#ifdef WOLFTPM_DEBUG_VERBOSE
+#ifdef DEBUG_WOLFTPM
     union {
         PCR_Read_Out pcrRead;
         byte maxOutput[MAX_RESPONSE_SIZE];
@@ -167,7 +167,7 @@ int TPM2_Extend_Test(void* userCtx, int argc, char *argv[])
     }
     printf("TPM2_PCR_Extend success\n");
 
-#ifdef WOLFTPM_DEBUG_VERBOSE
+#ifdef DEBUG_WOLFTPM
     XMEMSET(&cmdIn.pcrRead, 0, sizeof(cmdIn.pcrRead));
     TPM2_SetupPCRSel(&cmdIn.pcrRead.pcrSelectionIn,
         TEST_WRAP_DIGEST, pcrIndex);
@@ -177,7 +177,7 @@ int TPM2_Extend_Test(void* userCtx, int argc, char *argv[])
         goto exit;
     }
 
-    printf("PCR%d value:\n", pcrIndex);
+    printf("PCR%d digest:\n", pcrIndex);
     TPM2_PrintBin(cmdOut.pcrRead.pcrValues.digests[0].buffer,
                   cmdOut.pcrRead.pcrValues.digests[0].size);
 #endif

--- a/examples/pcr/extend.h
+++ b/examples/pcr/extend.h
@@ -1,0 +1,35 @@
+/* extend.h
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef _EXTEND_H_
+#define _EXTEND_H_
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+int TPM2_Extend_Test(void* userCtx, int argc, char *argv[]);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* _quote_H_ */

--- a/examples/pcr/include.am
+++ b/examples/pcr/include.am
@@ -5,7 +5,7 @@ if BUILD_EXAMPLES
 noinst_PROGRAMS += examples/pcr/quote
 noinst_HEADERS  += examples/pcr/quote.h
 examples_pcr_quote_SOURCES      = examples/pcr/quote.c \
-									       examples/tpm_io.c
+                                  examples/tpm_io.c
 examples_pcr_quote_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_pcr_quote_DEPENDENCIES = src/libwolftpm.la
 endif

--- a/examples/pcr/include.am
+++ b/examples/pcr/include.am
@@ -6,7 +6,6 @@ noinst_PROGRAMS += examples/pcr/quote \
                    examples/pcr/extend \
                    examples/pcr/reset
 
-
 noinst_HEADERS  += examples/pcr/quote.h \
                    examples/pcr/extend.h \
                    examples/pcr/reset.h
@@ -30,6 +29,11 @@ endif
 dist_example_DATA+= examples/pcr/quote.c \
                     examples/pcr/extend.c \
                     examples/pcr/reset.c
+
 DISTCLEANFILES+= examples/pcr/.libs/quote \
                  examples/pcr/.libs/extend \
                  examples/pcr/.libs/reset
+
+EXTRA_DIST+= examples/pcr/README.md \
+             examples/pcr/demo.sh \
+             examples/pcr/demo-quote-zip.sh

--- a/examples/pcr/include.am
+++ b/examples/pcr/include.am
@@ -1,0 +1,14 @@
+# vim:ft=automake
+# All paths should be given relative to the root
+
+if BUILD_EXAMPLES
+noinst_PROGRAMS += examples/pcr/quote
+noinst_HEADERS  += examples/pcr/quote.h
+examples_pcr_quote_SOURCES      = examples/pcr/quote.c \
+									       examples/tpm_io.c
+examples_pcr_quote_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
+examples_pcr_quote_DEPENDENCIES = src/libwolftpm.la
+endif
+
+dist_example_DATA+= examples/pcr/quote.c
+DISTCLEANFILES+= examples/pcr/.libs/quote

--- a/examples/pcr/include.am
+++ b/examples/pcr/include.am
@@ -2,13 +2,24 @@
 # All paths should be given relative to the root
 
 if BUILD_EXAMPLES
-noinst_PROGRAMS += examples/pcr/quote
-noinst_HEADERS  += examples/pcr/quote.h
+noinst_PROGRAMS += examples/pcr/quote \
+                   examples/pcr/extend
+
+noinst_HEADERS  += examples/pcr/quote.h \
+                   examples/pcr/extend.h
+
 examples_pcr_quote_SOURCES      = examples/pcr/quote.c \
                                   examples/tpm_io.c
 examples_pcr_quote_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_pcr_quote_DEPENDENCIES = src/libwolftpm.la
+
+examples_pcr_extend_SOURCES      = examples/pcr/extend.c \
+                                   examples/tpm_io.c
+examples_pcr_extend_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
+examples_pcr_extend_DEPENDENCIES = src/libwolftpm.la
 endif
 
-dist_example_DATA+= examples/pcr/quote.c
-DISTCLEANFILES+= examples/pcr/.libs/quote
+dist_example_DATA+= examples/pcr/quote.c \
+                    examples/pcr/extend.c
+DISTCLEANFILES+= examples/pcr/.libs/quote \
+                 examples/pcr/.libs/extend

--- a/examples/pcr/include.am
+++ b/examples/pcr/include.am
@@ -3,10 +3,13 @@
 
 if BUILD_EXAMPLES
 noinst_PROGRAMS += examples/pcr/quote \
-                   examples/pcr/extend
+                   examples/pcr/extend \
+                   examples/pcr/reset
+
 
 noinst_HEADERS  += examples/pcr/quote.h \
-                   examples/pcr/extend.h
+                   examples/pcr/extend.h \
+                   examples/pcr/reset.h
 
 examples_pcr_quote_SOURCES      = examples/pcr/quote.c \
                                   examples/tpm_io.c
@@ -17,9 +20,16 @@ examples_pcr_extend_SOURCES      = examples/pcr/extend.c \
                                    examples/tpm_io.c
 examples_pcr_extend_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_pcr_extend_DEPENDENCIES = src/libwolftpm.la
+
+examples_pcr_reset_SOURCES      = examples/pcr/reset.c \
+                                  examples/tpm_io.c
+examples_pcr_reset_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
+examples_pcr_reset_DEPENDENCIES = src/libwolftpm.la
 endif
 
 dist_example_DATA+= examples/pcr/quote.c \
-                    examples/pcr/extend.c
+                    examples/pcr/extend.c \
+                    examples/pcr/reset.c
 DISTCLEANFILES+= examples/pcr/.libs/quote \
-                 examples/pcr/.libs/extend
+                 examples/pcr/.libs/extend \
+                 examples/pcr/.libs/reset

--- a/examples/pcr/quote.c
+++ b/examples/pcr/quote.c
@@ -52,7 +52,7 @@ int TPM2_Quote_Test(void* userCtx, int argc, char *argv[])
 {
     int pcrIndex, rc = -1;
     const char *filename = NULL;
-    UINT8 *data = NULL;
+    BYTE *data = NULL;
     FILE *quoteBlob = NULL;
     WOLFTPM2_DEV dev;
     TPMS_ATTEST attestedData;

--- a/examples/pcr/quote.c
+++ b/examples/pcr/quote.c
@@ -243,7 +243,7 @@ int TPM2_Quote_Test(void* userCtx, int argc, char *argv[])
     printf("TPM with signature attests (type 0x%x):\n", attestedData.type);
     printf("\tTPM signed %lu count of PCRs\n",
         (unsigned long)attestedData.attested.quote.pcrSelect.count);
-#ifdef WOLFTPM_DEBUG_VERBOSE
+#ifdef DEBUG_WOLFTPM
     printf("\tPCR digest:\n");
     TPM2_PrintBin(attestedData.attested.quote.pcrDigest.buffer,
         attestedData.attested.quote.pcrDigest.size);

--- a/examples/pcr/quote.c
+++ b/examples/pcr/quote.c
@@ -98,21 +98,21 @@ int TPM2_Quote_Test(void* userCtx, int argc, char *argv[])
         if (pcrIndex < 0 || pcrIndex > 23) {
             printf("PCR index is out of range(0-23)\n");
             usage();
-            goto exit;
+            goto exit_badargs;
         }
         filename = argv[2];
     }
     else {
         printf("Incorrect arguments\n");
         usage();
-        goto exit;
+        goto exit_badargs;
     }
 
     quoteBlob = fopen(filename, "wb");
     if (quoteBlob == NULL) {
         printf("Error openning file %s\n", filename);
         usage();
-        goto exit;
+        goto exit_badargs;
     }
 
     printf("Demo of generating signed PCR measurement (TPM2.0 Quote)\n");
@@ -252,10 +252,6 @@ int TPM2_Quote_Test(void* userCtx, int argc, char *argv[])
 
 exit:
 
-    if (quoteBlob != NULL) {
-        fclose(quoteBlob);
-    }
-
     /* Close session */
     if (sessionHandle != TPM_RH_NULL) {
         cmdIn.flushCtx.flushHandle = sessionHandle;
@@ -268,6 +264,13 @@ exit:
     wolfTPM2_UnloadHandle(&dev, &endorse.handle);
 
     wolfTPM2_Cleanup(&dev);
+
+exit_badargs:
+
+    if (quoteBlob != NULL) {
+        fclose(quoteBlob);
+    }
+
     return rc;
 }
 

--- a/examples/pcr/quote.c
+++ b/examples/pcr/quote.c
@@ -1,0 +1,236 @@
+/* quote.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/* This example shows how to generate a TPM2.0 Quote that holds a signed
+ * PCR measurement. PCR values are used as basis for system integrity.
+ */
+
+#include <wolftpm/tpm2_wrap.h>
+
+#include <examples/pcr/quote.h>
+#include <examples/tpm_io.h>
+#include <examples/tpm_test.h>
+
+#include <stdio.h>
+
+
+#define SET_PCR_SELECT_BIT( pcrSelection, pcr ) \
+                                                (pcrSelection).pcrSelect[( (pcr)/8 )] |= ( 1 << ( (pcr) % 8) );
+
+/******************************************************************************/
+/* --- BEGIN TPM2.0 Quote Test -- */
+/******************************************************************************/
+
+int TPM2_Quote_Test(void* userCtx)
+{
+    int rc;
+    /* UINT32 i; */
+    WOLFTPM2_DEV dev;
+    TPMS_ATTEST attestedData;
+
+    union {
+        Quote_In quoteAsk;
+        /* For managing TPM session */
+        StartAuthSession_In authSes;
+        PolicySecret_In policySecret;
+        /* For removing keys after use */
+        FlushContext_In flushCtx;
+        byte maxInput[MAX_COMMAND_SIZE];
+    } cmdIn;
+    union {
+        Quote_Out quoteResult;
+        /* Output from session operations */
+        StartAuthSession_Out authSes;
+        PolicySecret_Out policySecret;
+        byte maxOutput[MAX_RESPONSE_SIZE];
+    } cmdOut;
+
+    TPM_HANDLE sessionHandle = TPM_RH_NULL;
+
+    WOLFTPM2_KEY endorse; /* EK  */
+    WOLFTPM2_KEY storage; /* SRK */
+    WOLFTPM2_KEY rsaKey;  /* AIK */
+
+    const byte storagePwd[] = "WolfTPMpassword";
+    const byte usageAuth[] = "ThisIsASecretUsageAuth";
+
+    TPMS_AUTH_COMMAND session[MAX_SESSION_NUM];
+
+    XMEMSET(&endorse, 0, sizeof(endorse));
+    XMEMSET(&storage, 0, sizeof(storage));
+    XMEMSET(&rsaKey, 0, sizeof(rsaKey));
+
+    printf("Demo of generating signed PCR measurement (TPM2.0 Quote)\n");
+    rc = wolfTPM2_Init(&dev, TPM2_IoCb, userCtx);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("wolfTPM2_Init failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("wolfTPM2_Init: success\n");
+
+
+    /* Define the default session auth that has NULL password */
+    XMEMSET(session, 0, sizeof(session));
+    session[0].sessionHandle = TPM_RS_PW;
+    session[0].auth.size = 0; /* NULL Password */
+    TPM2_SetSessionAuth(session);
+
+
+    /* Create Endorsement Key, also called EK */
+    rc = wolfTPM2_CreateEK(&dev, &endorse, TPM_ALG_RSA);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("wolfTPM2_CreateEK: Endorsement failed 0x%x: %s\n",
+            rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("wolfTPM2_CreateEK: Endorsement 0x%x (%d bytes)\n",
+        (word32)endorse.handle.hndl, endorse.pub.size);
+
+
+    /* Create Storage Key, also called SRK */
+    rc = wolfTPM2_CreateSRK(&dev, &storage, TPM_ALG_RSA, storagePwd,
+        sizeof(storagePwd)-1);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("wolfTPM2_CreateSRK: Storage failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("wolfTPM2_CreateSRK: Storage 0x%x (%d bytes)\n",
+        (word32)storage.handle.hndl, storage.pub.size);
+
+
+    /* Start Auth Session */
+    XMEMSET(&cmdIn.authSes, 0, sizeof(cmdIn.authSes));
+    cmdIn.authSes.sessionType = TPM_SE_POLICY;
+    cmdIn.authSes.tpmKey = TPM_RH_NULL;
+    cmdIn.authSes.bind = TPM_RH_NULL;
+    cmdIn.authSes.symmetric.algorithm = TPM_ALG_NULL;
+    cmdIn.authSes.authHash = TPM_ALG_SHA256;
+    cmdIn.authSes.nonceCaller.size = TPM_SHA256_DIGEST_SIZE;
+    rc = TPM2_GetNonce(cmdIn.authSes.nonceCaller.buffer,
+                       cmdIn.authSes.nonceCaller.size);
+    if (rc < 0) {
+        printf("TPM2_GetNonce failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    rc = TPM2_StartAuthSession(&cmdIn.authSes, &cmdOut.authSes);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_StartAuthSession failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    sessionHandle = cmdOut.authSes.sessionHandle;
+    printf("TPM2_StartAuthSession: sessionHandle 0x%x\n", (word32)sessionHandle);
+
+
+    /* set session auth for storage key */
+    session[0].auth.size = sizeof(storagePwd)-1;
+    XMEMCPY(session[0].auth.buffer, storagePwd, session[0].auth.size);
+
+
+    /* Create an RSA key for Attestation purposes */
+    rc = wolfTPM2_CreateAndLoadAIK(&dev, &rsaKey, TPM_ALG_RSA, &storage,
+        usageAuth, sizeof(usageAuth)-1);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("wolfTPM2_CreateAndLoadAIK failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("wolfTPM2_CreateAndLoadAIK: AIK 0x%x (%d bytes)\n",
+        (word32)rsaKey.handle.hndl, rsaKey.pub.size);
+
+
+    /* set auth for using the AIK */
+    session[0].auth.size = sizeof(usageAuth)-1;
+    XMEMCPY(session[0].auth.buffer, usageAuth, session[0].auth.size);
+
+    /* Prepare Quote request */
+    XMEMSET(&cmdIn.quoteAsk, 0, sizeof(cmdIn.quoteAsk));
+    XMEMSET(&cmdOut.quoteResult, 0, sizeof(cmdOut.quoteResult));
+    cmdIn.quoteAsk.signHandle = rsaKey.handle.hndl;
+    cmdIn.quoteAsk.inScheme.scheme = TPM_ALG_RSASSA;
+    cmdIn.quoteAsk.inScheme.details.rsassa.hashAlg = TPM_ALG_SHA256;
+    cmdIn.quoteAsk.qualifyingData.size = 0; /* optional */
+    /* Set the PCR for signing */
+    cmdIn.quoteAsk.PCRselect.count = 1;
+    cmdIn.quoteAsk.PCRselect.pcrSelections[0].hash = TPM_ALG_SHA256;
+    cmdIn.quoteAsk.PCRselect.pcrSelections[0].sizeofSelect = 3;
+    /* PCR16 is for DEBUG purposes, therefore safe to use for a demo */
+    SET_PCR_SELECT_BIT(cmdIn.quoteAsk.PCRselect.pcrSelections[0], 16);
+
+
+    /* Get PCR measurement signed by the TPM using the AIK key */
+    rc = TPM2_Quote(&cmdIn.quoteAsk, &cmdOut.quoteResult);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_Quote failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("TPM2_Quote: success\n");
+
+    rc = TPM2_ParseAttest(&cmdOut.quoteResult.quoted, &attestedData);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_Packet_ParseAttest failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    if (attestedData.magic != TPM_GENERATED_VALUE) {
+        printf("\tError, attested data not generated by the TPM = 0x%X\n",
+            attestedData.magic);
+    }
+
+    printf("TPM with signature attests (type 0x%x):\n", attestedData.type);
+    printf("\tTPM signed %lu PCR\n",
+        (unsigned long)attestedData.attested.quote.pcrSelect.count);
+
+exit:
+
+    /* Close session */
+    if (sessionHandle != TPM_RH_NULL) {
+        cmdIn.flushCtx.flushHandle = sessionHandle;
+        TPM2_FlushContext(&cmdIn.flushCtx);
+    }
+
+    /* Close key handles */
+    wolfTPM2_UnloadHandle(&dev, &rsaKey.handle);
+    wolfTPM2_UnloadHandle(&dev, &storage.handle);
+    wolfTPM2_UnloadHandle(&dev, &endorse.handle);
+
+    wolfTPM2_Cleanup(&dev);
+    return rc;
+}
+
+/******************************************************************************/
+/* --- END TPM2.0 Quote Test -- */
+/******************************************************************************/
+
+
+#ifndef NO_MAIN_DRIVER
+int main(void)
+{
+    int rc;
+
+    rc = TPM2_Quote_Test(NULL);
+
+    return rc;
+}
+#endif

--- a/examples/pcr/quote.c
+++ b/examples/pcr/quote.c
@@ -30,6 +30,7 @@
 #include <examples/tpm_test.h>
 
 #include <stdio.h>
+#include <stdlib.h> /* strtol */
 
 const char defaultFilename[] = "quote.blob\0";
 
@@ -37,10 +38,11 @@ const char defaultFilename[] = "quote.blob\0";
 /* --- BEGIN TPM2.0 Quote Test -- */
 /******************************************************************************/
 
-inline static void usage(void)
+static void usage(void)
 {
-    printf("Expected usage: extend (pcr_number) (filename)\n");
-    printf("* pcr_number is a number between 0-23\n");
+    printf("Expected usage:\n");
+    printf("./examples/pcr/quote [pcr] [filename]\n");
+    printf("* pcr is a PCR index between 0-23 (default 16)\n");
     printf("* filename for saving the TPMS_ATTEST structure to a file\n");
     printf("Demo usage without parameters, generates quote over PCR16 and\n"
            "saves the output TPMS_ATTEST structure to \"quote.blob\" file.\n");
@@ -110,7 +112,7 @@ int TPM2_Quote_Test(void* userCtx, int argc, char *argv[])
 
     quoteBlob = fopen(filename, "wb");
     if (quoteBlob == NULL) {
-        printf("Error openning file %s\n", filename);
+        printf("Error opening file %s\n", filename);
         usage();
         goto exit_badargs;
     }

--- a/examples/pcr/quote.h
+++ b/examples/pcr/quote.h
@@ -26,7 +26,7 @@
     extern "C" {
 #endif
 
-int TPM2_Quote_Test(void* userCtx);
+int TPM2_Quote_Test(void* userCtx, int argc, char *argv[]);
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/examples/pcr/quote.h
+++ b/examples/pcr/quote.h
@@ -1,0 +1,35 @@
+/* quote.h
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef _QUOTE_H_
+#define _QUOTE_H_
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+int TPM2_Quote_Test(void* userCtx);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* _quote_H_ */

--- a/examples/pcr/reset.c
+++ b/examples/pcr/reset.c
@@ -1,0 +1,157 @@
+/* reset.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/* This is a helper tool for reseting the value of a TPM2.0 PCR */
+
+#include <wolftpm/tpm2_wrap.h>
+
+#include <examples/pcr/reset.h>
+#include <examples/tpm_io.h>
+#include <examples/tpm_test.h>
+
+#include <stdio.h>
+#include <stdlib.h> /* strtol */
+
+
+/******************************************************************************/
+/* --- BEGIN TPM2.0 PCR Reset example tool  -- */
+/******************************************************************************/
+
+static void usage(void)
+{
+    printf("Expected usage:\n");
+    printf("./examples/pcr/reset [pcr]\n");
+    printf("* pcr is a PCR index between 0-23 (default 16)\n");
+    printf("Demo usage without parameters, resets PCR16.\n");
+}
+
+int TPM2_Reset_Test(void* userCtx, int argc, char *argv[])
+{
+    int pcrIndex, rc = -1;
+    WOLFTPM2_DEV dev;
+
+    union {
+#ifdef WOLFTPM_DEBUG_VERBOSE
+        PCR_Read_In pcrRead;
+#endif
+        PCR_Reset_In pcrReset;
+        FlushContext_In flushCtx;
+        byte maxInput[MAX_COMMAND_SIZE];
+    } cmdIn;
+#ifdef WOLFTPM_DEBUG_VERBOSE
+    union {
+        PCR_Read_Out pcrRead;
+        byte maxOutput[MAX_RESPONSE_SIZE];
+    } cmdOut;
+#endif
+
+
+    TPM_HANDLE sessionHandle = TPM_RH_NULL;
+    TPMS_AUTH_COMMAND session[MAX_SESSION_NUM];
+
+    if(argc == 2) {
+        pcrIndex = strtol(argv[1], NULL, 10);
+        if(pcrIndex < 0 || pcrIndex > 23) {
+            printf("PCR index is out of range(0-23)\n");
+            goto exit_badargs;
+        }
+    }
+    else if(argc == 1) {
+        pcrIndex = 16; /* PCR16 is for DEBUG purposes, thus safe to use */
+    }
+    else {
+        printf("Incorrect arguments\n");
+        usage();
+        goto exit_badargs;
+    }
+
+    printf("Demo how to reset a PCR (clear PCR value)\n");
+    rc = wolfTPM2_Init(&dev, TPM2_IoCb, userCtx);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("wolfTPM2_Init failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("wolfTPM2_Init: success\n");
+
+
+    /* Define the default session auth that has NULL password */
+    XMEMSET(session, 0, sizeof(session));
+    session[0].sessionHandle = TPM_RS_PW;
+    session[0].auth.size = 0; /* NULL Password */
+    TPM2_SetSessionAuth(session);
+
+    /* Prepare PCR Reset command */
+    XMEMSET(&cmdIn.pcrReset, 0, sizeof(cmdIn.pcrReset));
+    cmdIn.pcrReset.pcrHandle = pcrIndex;
+    printf("Trying to reset PCR%d...\n", cmdIn.pcrReset.pcrHandle);
+    rc = TPM2_PCR_Reset(&cmdIn.pcrReset);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_PCR_Reset failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("TPM2_PCR_Reset success\n");
+
+#ifdef WOLFTPM_DEBUG_VERBOSE
+    XMEMSET(&cmdIn.pcrRead, 0, sizeof(cmdIn.pcrRead));
+    TPM2_SetupPCRSel(&cmdIn.pcrRead.pcrSelectionIn,
+        TEST_WRAP_DIGEST, pcrIndex);
+    rc = TPM2_PCR_Read(&cmdIn.pcrRead, &cmdOut.pcrRead);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_PCR_Read failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+
+    printf("PCR%d value:\n", pcrIndex);
+    TPM2_PrintBin(cmdOut.pcrRead.pcrValues.digests[0].buffer,
+                  cmdOut.pcrRead.pcrValues.digests[0].size);
+#endif
+
+exit:
+
+    /* Close session */
+    if (sessionHandle != TPM_RH_NULL) {
+        cmdIn.flushCtx.flushHandle = sessionHandle;
+        TPM2_FlushContext(&cmdIn.flushCtx);
+    }
+
+    wolfTPM2_Cleanup(&dev);
+
+exit_badargs:
+
+    return rc;
+}
+
+/******************************************************************************/
+/* --- END TPM2.0 PCR Reset example tool -- */
+/******************************************************************************/
+
+
+#ifndef NO_MAIN_DRIVER
+int main(int argc, char *argv[])
+{
+    int rc;
+
+    rc = TPM2_Reset_Test(NULL, argc, argv);
+
+    return rc;
+}
+#endif

--- a/examples/pcr/reset.c
+++ b/examples/pcr/reset.c
@@ -28,7 +28,7 @@
 #include <examples/tpm_test.h>
 
 #include <stdio.h>
-#include <stdlib.h> /* strtol */
+#include <stdlib.h> /* atoi */
 
 
 /******************************************************************************/
@@ -39,14 +39,16 @@ static void usage(void)
 {
     printf("Expected usage:\n");
     printf("./examples/pcr/reset [pcr]\n");
-    printf("* pcr is a PCR index between 0-23 (default 16)\n");
-    printf("Demo usage without parameters, resets PCR16.\n");
+    printf("* pcr is a PCR index between 0-23 (default %d)\n", TPM2_TEST_PCR);
+    printf("Demo usage without parameters, resets PCR%d.\n", TPM2_TEST_PCR);
 }
 
 int TPM2_Reset_Test(void* userCtx, int argc, char *argv[])
 {
     int pcrIndex, rc = -1;
     WOLFTPM2_DEV dev;
+    TPM_HANDLE sessionHandle = TPM_RH_NULL;
+    TPMS_AUTH_COMMAND session[MAX_SESSION_NUM];
 
     union {
 #ifdef DEBUG_WOLFTPM
@@ -63,19 +65,16 @@ int TPM2_Reset_Test(void* userCtx, int argc, char *argv[])
     } cmdOut;
 #endif
 
-
-    TPM_HANDLE sessionHandle = TPM_RH_NULL;
-    TPMS_AUTH_COMMAND session[MAX_SESSION_NUM];
-
-    if(argc == 2) {
-        pcrIndex = strtol(argv[1], NULL, 10);
-        if(pcrIndex < 0 || pcrIndex > 23) {
-            printf("PCR index is out of range(0-23)\n");
+    if (argc == 2) {
+        pcrIndex = atoi(argv[1]);
+        if (pcrIndex < 0 || pcrIndex > 23 || *argv[1] < '0' || *argv[1] > '9') {
+            printf("PCR index is out of range (0-23)\n");
+            usage();
             goto exit_badargs;
         }
     }
-    else if(argc == 1) {
-        pcrIndex = 16; /* PCR16 is for DEBUG purposes, thus safe to use */
+    else if (argc == 1) {
+        pcrIndex = TPM2_TEST_PCR;
     }
     else {
         printf("Incorrect arguments\n");

--- a/examples/pcr/reset.c
+++ b/examples/pcr/reset.c
@@ -49,14 +49,14 @@ int TPM2_Reset_Test(void* userCtx, int argc, char *argv[])
     WOLFTPM2_DEV dev;
 
     union {
-#ifdef WOLFTPM_DEBUG_VERBOSE
+#ifdef DEBUG_WOLFTPM
         PCR_Read_In pcrRead;
 #endif
         PCR_Reset_In pcrReset;
         FlushContext_In flushCtx;
         byte maxInput[MAX_COMMAND_SIZE];
     } cmdIn;
-#ifdef WOLFTPM_DEBUG_VERBOSE
+#ifdef DEBUG_WOLFTPM
     union {
         PCR_Read_Out pcrRead;
         byte maxOutput[MAX_RESPONSE_SIZE];
@@ -110,7 +110,7 @@ int TPM2_Reset_Test(void* userCtx, int argc, char *argv[])
     }
     printf("TPM2_PCR_Reset success\n");
 
-#ifdef WOLFTPM_DEBUG_VERBOSE
+#ifdef DEBUG_WOLFTPM
     XMEMSET(&cmdIn.pcrRead, 0, sizeof(cmdIn.pcrRead));
     TPM2_SetupPCRSel(&cmdIn.pcrRead.pcrSelectionIn,
         TEST_WRAP_DIGEST, pcrIndex);
@@ -120,7 +120,7 @@ int TPM2_Reset_Test(void* userCtx, int argc, char *argv[])
         goto exit;
     }
 
-    printf("PCR%d value:\n", pcrIndex);
+    printf("PCR%d digest:\n", pcrIndex);
     TPM2_PrintBin(cmdOut.pcrRead.pcrValues.digests[0].buffer,
                   cmdOut.pcrRead.pcrValues.digests[0].size);
 #endif

--- a/examples/pcr/reset.h
+++ b/examples/pcr/reset.h
@@ -1,4 +1,4 @@
-/* clear.h
+/* reset.h
  *
  * Copyright (C) 2006-2020 wolfSSL Inc.
  *

--- a/examples/pcr/reset.h
+++ b/examples/pcr/reset.h
@@ -1,0 +1,35 @@
+/* clear.h
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef _CLEAR_H_
+#define _CLEAR_H_
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+int TPM2_Reset_Test(void* userCtx, int argc, char *argv[]);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* _clear_H_ */

--- a/examples/timestamp/include.am
+++ b/examples/timestamp/include.am
@@ -5,7 +5,7 @@ if BUILD_EXAMPLES
 noinst_PROGRAMS += examples/timestamp/signed_timestamp
 noinst_HEADERS  += examples/timestamp/signed_timestamp.h
 examples_timestamp_signed_timestamp_SOURCES      = examples/timestamp/signed_timestamp.c \
-									       examples/tpm_io.c
+                                                   examples/tpm_io.c
 examples_timestamp_signed_timestamp_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_timestamp_signed_timestamp_DEPENDENCIES = src/libwolftpm.la
 endif

--- a/examples/tls/include.am
+++ b/examples/tls/include.am
@@ -6,7 +6,7 @@ noinst_PROGRAMS += examples/tls/tls_client
 noinst_HEADERS  += examples/tls/tls_client.h \
                    examples/tls/tls_common.h
 examples_tls_tls_client_SOURCES      = examples/tls/tls_client.c \
-                                     = examples/tpm_io.c
+                                       examples/tpm_io.c
 examples_tls_tls_client_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_tls_tls_client_DEPENDENCIES = src/libwolftpm.la
 
@@ -22,7 +22,7 @@ noinst_PROGRAMS += examples/tls/tls_server
 noinst_HEADERS  += examples/tls/tls_server.h \
                    examples/tls/tls_common.h
 examples_tls_tls_server_SOURCES      = examples/tls/tls_server.c \
-                                     = examples/tpm_io.c
+                                       examples/tpm_io.c
 examples_tls_tls_server_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_tls_tls_server_DEPENDENCIES = src/libwolftpm.la
 

--- a/examples/tls/include.am
+++ b/examples/tls/include.am
@@ -6,7 +6,7 @@ noinst_PROGRAMS += examples/tls/tls_client
 noinst_HEADERS  += examples/tls/tls_client.h \
                    examples/tls/tls_common.h
 examples_tls_tls_client_SOURCES      = examples/tls/tls_client.c \
-									   examples/tpm_io.c
+                                     = examples/tpm_io.c
 examples_tls_tls_client_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_tls_tls_client_DEPENDENCIES = src/libwolftpm.la
 
@@ -14,7 +14,7 @@ noinst_PROGRAMS += examples/tls/tls_client_notpm
 noinst_HEADERS  += examples/tls/tls_client.h \
                    examples/tls/tls_common.h
 examples_tls_tls_client_notpm_SOURCES      = examples/tls/tls_client_notpm.c \
-									   examples/tpm_io.c
+                                             examples/tpm_io.c
 examples_tls_tls_client_notpm_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_tls_tls_client_notpm_DEPENDENCIES = src/libwolftpm.la
 
@@ -22,7 +22,7 @@ noinst_PROGRAMS += examples/tls/tls_server
 noinst_HEADERS  += examples/tls/tls_server.h \
                    examples/tls/tls_common.h
 examples_tls_tls_server_SOURCES      = examples/tls/tls_server.c \
-									   examples/tpm_io.c
+                                     = examples/tpm_io.c
 examples_tls_tls_server_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_tls_tls_server_DEPENDENCIES = src/libwolftpm.la
 

--- a/examples/tpm_test.h
+++ b/examples/tpm_test.h
@@ -49,6 +49,10 @@ static const char gKeyAuthAlt[] =     "ThisIsMyKeyAltAuth";
 static const char gUsageAuth[] =      "ThisIsASecretUsageAuth";
 static const char gNvAuth[] =         "ThisIsMyNvAuth";
 
+/* Default Test PCR */
+/* PCR16 is for DEBUG purposes, thus safe to use */
+#define TPM2_TEST_PCR 16
+
 #ifndef WOLFTPM_ST33
     #define TEST_AES_MODE TPM_ALG_CFB
 #else

--- a/examples/wrap/include.am
+++ b/examples/wrap/include.am
@@ -5,7 +5,7 @@ if BUILD_EXAMPLES
 noinst_PROGRAMS += examples/wrap/wrap_test
 noinst_HEADERS  += examples/wrap/wrap_test.h
 examples_wrap_wrap_test_SOURCES      = examples/wrap/wrap_test.c \
-									   examples/tpm_io.c
+                                       examples/tpm_io.c
 examples_wrap_wrap_test_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_wrap_wrap_test_DEPENDENCIES = src/libwolftpm.la
 endif


### PR DESCRIPTION
This PR is a result of #106 enhancement. 

After short fight with a strange TPM error "TPM2_Quote failed 0x3d5: TPM_RC_SENSITIVE: The sensitive area did not unmarshal correctly after decryption", I a happy to share that we now have a generic TPM2_Quote example.

I want to extend the example prints and possibly also output the TPM2_Quote result in a file(blob) for a later use, e.g. verification or other uses. @dgarske  I would appreciate your thoughts on this, because right now the user output of the example is just plain - Confirmation based on the output structure from the TPM2_Quote operation that indeed a PCR has been signed and TPM2 Quote generated.

Additionally, I am starting to work on PCR extend example, so we can demonstrate differences in Quotes. This is where the printing is also important. What do we print to the user who tries our demos.

Signed-off-by: Dimitar Tomov <dimi@designfirst.ee>