### PR TITLE
Bugfixes for TPM2_Packet_AppendSymmetric and TPM2_Packet_ParseSymmetric

### DIFF
--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -355,17 +355,37 @@ void TPM2_Packet_ParsePCR(TPM2_Packet* packet, TPML_PCR_SELECTION* pcr)
 void TPM2_Packet_AppendSymmetric(TPM2_Packet* packet, TPMT_SYM_DEF* symmetric)
 {
     TPM2_Packet_AppendU16(packet, symmetric->algorithm);
-    if (symmetric->algorithm != TPM_ALG_NULL) {
-        TPM2_Packet_AppendU16(packet, symmetric->keyBits.sym);
-        TPM2_Packet_AppendU16(packet, symmetric->mode.sym);
+    switch (symmetric->algorithm) {
+        case TPM_ALG_XOR:
+            TPM2_Packet_AppendU16(packet, symmetric->keyBits.xor);
+            break;
+        case TPM_ALG_AES:
+            TPM2_Packet_AppendU16(packet, symmetric->keyBits.aes);
+            TPM2_Packet_AppendU16(packet, symmetric->mode.aes);
+            break;
+        case TPM_ALG_NULL:
+            break;
+        default:
+            TPM2_Packet_AppendU16(packet, symmetric->keyBits.sym);
+            TPM2_Packet_AppendU16(packet, symmetric->mode.sym);
     }
 }
 void TPM2_Packet_ParseSymmetric(TPM2_Packet* packet, TPMT_SYM_DEF* symmetric)
 {
     TPM2_Packet_ParseU16(packet, &symmetric->algorithm);
-    if (symmetric->algorithm != TPM_ALG_NULL) {
-        TPM2_Packet_ParseU16(packet, &symmetric->keyBits.sym);
-        TPM2_Packet_ParseU16(packet, &symmetric->mode.sym);
+    switch (symmetric->algorithm) {
+        case TPM_ALG_XOR:
+            TPM2_Packet_ParseU16(packet, &symmetric->keyBits.xor);
+            break;
+        case TPM_ALG_AES:
+            TPM2_Packet_ParseU16(packet, &symmetric->keyBits.aes);
+            TPM2_Packet_ParseU16(packet, &symmetric->mode.aes);
+            break;
+        case TPM_ALG_NULL:
+            break;
+        default:
+            TPM2_Packet_ParseU16(packet, &symmetric->keyBits.sym);
+            TPM2_Packet_ParseU16(packet, &symmetric->mode.sym);
     }
 }
 

--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -368,6 +368,7 @@ void TPM2_Packet_AppendSymmetric(TPM2_Packet* packet, TPMT_SYM_DEF* symmetric)
         default:
             TPM2_Packet_AppendU16(packet, symmetric->keyBits.sym);
             TPM2_Packet_AppendU16(packet, symmetric->mode.sym);
+            break;
     }
 }
 void TPM2_Packet_ParseSymmetric(TPM2_Packet* packet, TPMT_SYM_DEF* symmetric)
@@ -386,6 +387,7 @@ void TPM2_Packet_ParseSymmetric(TPM2_Packet* packet, TPMT_SYM_DEF* symmetric)
         default:
             TPM2_Packet_ParseU16(packet, &symmetric->keyBits.sym);
             TPM2_Packet_ParseU16(packet, &symmetric->mode.sym);
+            break;
     }
 }
 


### PR DESCRIPTION
While working on #110 , I encountered a bizarre issue when trying to create TPM session for parameter encryption with XOR.

I was getting TPM_RC_Command **command not supported** regardless of how I tried to create the XOR param.enc session.

After digging in the TCG spec and trying various configurations, running out of options, I decided to finally check the packet creation and found a tiny bug in the way wolfTPM handles symmetric attributes. 

The fix - For XOR operations only the algorithm type and keybits are to be appended. 

Good example of a tiny bug that can make a man sweat ...

Signed-off-by: Dimitar Tomov <dimi@designfirst.ee>