### PR TITLE
Cleanups, removed unused code from the PCR examples

### DIFF
--- a/examples/pcr/extend.c
+++ b/examples/pcr/extend.c
@@ -66,7 +66,6 @@ int TPM2_Extend_Test(void* userCtx, int argc, char *argv[])
     BYTE dataBuffer[1024];
     Sha256 sha256;
 #endif
-    TPM_HANDLE sessionHandle = TPM_RH_NULL;
     TPMS_AUTH_COMMAND session[MAX_SESSION_NUM];
 
     union {
@@ -74,7 +73,6 @@ int TPM2_Extend_Test(void* userCtx, int argc, char *argv[])
         PCR_Read_In pcrRead;
 #endif
         PCR_Extend_In pcrExtend;
-        FlushContext_In flushCtx;
         byte maxInput[MAX_COMMAND_SIZE];
     } cmdIn;
 #ifdef DEBUG_WOLFTPM
@@ -184,12 +182,6 @@ int TPM2_Extend_Test(void* userCtx, int argc, char *argv[])
 #endif
 
 exit:
-
-    /* Close session */
-    if (sessionHandle != TPM_RH_NULL) {
-        cmdIn.flushCtx.flushHandle = sessionHandle;
-        TPM2_FlushContext(&cmdIn.flushCtx);
-    }
 
     wolfTPM2_Cleanup(&dev);
 

--- a/examples/pcr/reset.c
+++ b/examples/pcr/reset.c
@@ -47,7 +47,6 @@ int TPM2_Reset_Test(void* userCtx, int argc, char *argv[])
 {
     int pcrIndex, rc = -1;
     WOLFTPM2_DEV dev;
-    TPM_HANDLE sessionHandle = TPM_RH_NULL;
     TPMS_AUTH_COMMAND session[MAX_SESSION_NUM];
 
     union {
@@ -55,7 +54,6 @@ int TPM2_Reset_Test(void* userCtx, int argc, char *argv[])
         PCR_Read_In pcrRead;
 #endif
         PCR_Reset_In pcrReset;
-        FlushContext_In flushCtx;
         byte maxInput[MAX_COMMAND_SIZE];
     } cmdIn;
 #ifdef DEBUG_WOLFTPM
@@ -125,12 +123,6 @@ int TPM2_Reset_Test(void* userCtx, int argc, char *argv[])
 #endif
 
 exit:
-
-    /* Close session */
-    if (sessionHandle != TPM_RH_NULL) {
-        cmdIn.flushCtx.flushHandle = sessionHandle;
-        TPM2_FlushContext(&cmdIn.flushCtx);
-    }
 
     wolfTPM2_Cleanup(&dev);
 


### PR DESCRIPTION
Another improvement on the examples. After I had to dig in the TPM Sessions again, because of the XOR attributes bug, I realized we have session code that is not needed in some of the examples.

* Policy session is not used for PCR extend and reset
* Policy session is not required for generating a Quote using AIK under SRK

Signed-off-by: Dimitar Tomov <dimi@designfirst.ee>