### PR TITLE
Fix examples to use same AIK for persistent key

### DIFF
--- a/examples/csr/csr.c
+++ b/examples/csr/csr.c
@@ -199,12 +199,10 @@ int TPM2_CSR_Example(void* userCtx)
     }
 
 #ifndef NO_RSA
-    /* Create/Load RSA key for CSR */
+    /* Create/Load RSA key for CSR (AIK) */
     rc = wolfTPM2_ReadPublicKey(&dev, &rsaKey, TPM2_DEMO_RSA_KEY_HANDLE);
     if (rc != 0) {
-        rc = wolfTPM2_GetKeyTemplate_RSA(&publicTemplate,
-            TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
-            TPMA_OBJECT_decrypt | TPMA_OBJECT_sign | TPMA_OBJECT_noDA);
+        rc = wolfTPM2_GetKeyTemplate_RSA_AIK(&publicTemplate);
         if (rc != 0) goto exit;
         rc = wolfTPM2_CreateAndLoadKey(&dev, &rsaKey, &storageKey.handle,
             &publicTemplate, (byte*)gKeyAuth, sizeof(gKeyAuth)-1);
@@ -234,13 +232,10 @@ int TPM2_CSR_Example(void* userCtx)
 
 
 #ifdef HAVE_ECC
-    /* Create/Load ECC key for CSR */
+    /* Create/Load ECC key for CSR (AIK) */
     rc = wolfTPM2_ReadPublicKey(&dev, &eccKey, TPM2_DEMO_ECC_KEY_HANDLE);
     if (rc != 0) {
-        rc = wolfTPM2_GetKeyTemplate_ECC(&publicTemplate,
-            TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
-            TPMA_OBJECT_sign | TPMA_OBJECT_noDA,
-            TPM_ECC_NIST_P256, TPM_ALG_ECDSA);
+        rc = wolfTPM2_GetKeyTemplate_ECC_AIK(&publicTemplate);
         if (rc != 0) goto exit;
         rc = wolfTPM2_CreateAndLoadKey(&dev, &eccKey, &storageKey.handle,
             &publicTemplate, (byte*)gKeyAuth, sizeof(gKeyAuth)-1);

--- a/examples/csr/csr.c
+++ b/examples/csr/csr.c
@@ -299,8 +299,8 @@ int main(void)
     (defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB))
     rc = TPM2_CSR_Example(NULL);
 #else
-    printf("Wrapper/CertReq/CryptoDev code not compiled in\n");
-    printf("Build wolfssl with ./configure --enable-certgen --enable-certreq --enable-certext --enable-cryptodev\n");
+    printf("Wrapper/CertReq/CryptoCb code not compiled in\n");
+    printf("Build wolfssl with ./configure --enable-certgen --enable-certreq --enable-certext --enable-cryptocb\n");
 #endif
 
     return rc;

--- a/examples/pkcs7/pkcs7.c
+++ b/examples/pkcs7/pkcs7.c
@@ -424,8 +424,8 @@ int main(void)
     (defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB))
     rc = TPM2_PKCS7_Example(NULL);
 #else
-    printf("Wrapper/PKCS7/CryptoDev code not compiled in\n");
-    printf("Build wolfssl with ./configure --enable-pkcs7 --enable-cryptodev\n");
+    printf("Wrapper/PKCS7/CryptoCb code not compiled in\n");
+    printf("Build wolfssl with ./configure --enable-pkcs7 --enable-cryptocb\n");
 #endif
 
     return rc;

--- a/examples/pkcs7/pkcs7.c
+++ b/examples/pkcs7/pkcs7.c
@@ -348,12 +348,10 @@ int TPM2_PKCS7_Example(void* userCtx)
             storageKey.handle.auth.size);
     }
 
-    /* Create/Load RSA key for PKCS7 signing */
+    /* Create/Load RSA key for PKCS7 signing (AIK) */
     rc = wolfTPM2_ReadPublicKey(&dev, &rsaKey, TPM2_DEMO_RSA_KEY_HANDLE);
     if (rc != 0) {
-        rc = wolfTPM2_GetKeyTemplate_RSA(&publicTemplate,
-            TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
-            TPMA_OBJECT_decrypt | TPMA_OBJECT_sign | TPMA_OBJECT_noDA);
+        rc = wolfTPM2_GetKeyTemplate_RSA_AIK(&publicTemplate);
         if (rc != 0) goto exit;
         rc = wolfTPM2_CreateAndLoadKey(&dev, &rsaKey, &storageKey.handle,
             &publicTemplate, (byte*)gKeyAuth, sizeof(gKeyAuth)-1);
@@ -365,11 +363,10 @@ int TPM2_PKCS7_Example(void* userCtx)
         if (rc != 0) goto exit;
     }
     else {
-        /* specify auth password for rsa key */
+        /* specify auth password for RSA key */
         rsaKey.handle.auth.size = sizeof(gKeyAuth)-1;
         XMEMCPY(rsaKey.handle.auth.buffer, gKeyAuth, rsaKey.handle.auth.size);
     }
-
 
     /* load DER certificate for TPM key (obtained by running
         `./examples/csr/csr` and `./certs/certreq.sh`) */

--- a/examples/tls/tls_client.c
+++ b/examples/tls/tls_client.c
@@ -163,12 +163,10 @@ int TPM2_TLS_Client(void* userCtx)
     }
 
 #ifndef NO_RSA
-    /* Create/Load RSA key for TLS authentication */
+    /* Create/Load RSA key for TLS authentication (AIK) */
     rc = wolfTPM2_ReadPublicKey(&dev, &rsaKey, TPM2_DEMO_RSA_KEY_HANDLE);
     if (rc != 0) {
-        rc = wolfTPM2_GetKeyTemplate_RSA(&publicTemplate,
-            TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
-            TPMA_OBJECT_decrypt | TPMA_OBJECT_sign | TPMA_OBJECT_noDA);
+        rc = wolfTPM2_GetKeyTemplate_RSA_AIK(&publicTemplate);
         if (rc != 0) goto exit;
         rc = wolfTPM2_CreateAndLoadKey(&dev, &rsaKey, &storageKey.handle,
             &publicTemplate, (byte*)gKeyAuth, sizeof(gKeyAuth)-1);
@@ -180,7 +178,7 @@ int TPM2_TLS_Client(void* userCtx)
         if (rc != 0) goto exit;
     }
     else {
-        /* specify auth password for rsa key */
+        /* specify auth password for RSA key */
         rsaKey.handle.auth.size = sizeof(gKeyAuth)-1;
         XMEMCPY(rsaKey.handle.auth.buffer, gKeyAuth, rsaKey.handle.auth.size);
     }
@@ -194,13 +192,10 @@ int TPM2_TLS_Client(void* userCtx)
 #endif /* !NO_RSA */
 
 #ifdef HAVE_ECC
-    /* Create/Load ECC key for TLS authentication */
+    /* Create/Load ECC key for TLS authentication (AIK) */
     rc = wolfTPM2_ReadPublicKey(&dev, &eccKey, TPM2_DEMO_ECC_KEY_HANDLE);
     if (rc != 0) {
-        rc = wolfTPM2_GetKeyTemplate_ECC(&publicTemplate,
-            TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
-            TPMA_OBJECT_sign | TPMA_OBJECT_noDA,
-            TPM_ECC_NIST_P256, TPM_ALG_ECDSA);
+        rc = wolfTPM2_GetKeyTemplate_ECC_AIK(&publicTemplate);
         if (rc != 0) goto exit;
         rc = wolfTPM2_CreateAndLoadKey(&dev, &eccKey, &storageKey.handle,
             &publicTemplate, (byte*)gKeyAuth, sizeof(gKeyAuth)-1);

--- a/examples/tls/tls_server.c
+++ b/examples/tls/tls_server.c
@@ -171,12 +171,10 @@ int TPM2_TLS_Server(void* userCtx)
     }
 
 #ifndef NO_RSA
-    /* Create/Load RSA key for TLS authentication */
+    /* Create/Load RSA key for TLS authentication (AIK) */
     rc = wolfTPM2_ReadPublicKey(&dev, &rsaKey, TPM2_DEMO_RSA_KEY_HANDLE);
     if (rc != 0) {
-        rc = wolfTPM2_GetKeyTemplate_RSA(&publicTemplate,
-            TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
-            TPMA_OBJECT_decrypt | TPMA_OBJECT_sign | TPMA_OBJECT_noDA);
+        rc = wolfTPM2_GetKeyTemplate_RSA_AIK(&publicTemplate);
         if (rc != 0) goto exit;
         rc = wolfTPM2_CreateAndLoadKey(&dev, &rsaKey, &storageKey.handle,
             &publicTemplate, (byte*)gKeyAuth, sizeof(gKeyAuth)-1);
@@ -188,7 +186,7 @@ int TPM2_TLS_Server(void* userCtx)
         if (rc != 0) goto exit;
     }
     else {
-        /* specify auth password for rsa key */
+        /* specify auth password for RSA key */
         rsaKey.handle.auth.size = sizeof(gKeyAuth)-1;
         XMEMCPY(rsaKey.handle.auth.buffer, gKeyAuth, rsaKey.handle.auth.size);
     }
@@ -202,13 +200,10 @@ int TPM2_TLS_Server(void* userCtx)
 #endif /* !NO_RSA */
 
 #ifdef HAVE_ECC
-    /* Create/Load ECC key for TLS authentication */
+    /* Create/Load ECC key for TLS authentication (AIK) */
     rc = wolfTPM2_ReadPublicKey(&dev, &eccKey, TPM2_DEMO_ECC_KEY_HANDLE);
     if (rc != 0) {
-        rc = wolfTPM2_GetKeyTemplate_ECC(&publicTemplate,
-            TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
-            TPMA_OBJECT_sign | TPMA_OBJECT_noDA,
-            TPM_ECC_NIST_P256, TPM_ALG_ECDSA);
+        rc = wolfTPM2_GetKeyTemplate_ECC_AIK(&publicTemplate);
         if (rc != 0) goto exit;
         rc = wolfTPM2_CreateAndLoadKey(&dev, &eccKey, &storageKey.handle,
             &publicTemplate, (byte*)gKeyAuth, sizeof(gKeyAuth)-1);

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -2475,6 +2475,10 @@ int wolfTPM2_Clear(WOLFTPM2_DEV* dev)
     XMEMSET(&in, 0, sizeof(in));
     in.authHandle = TPM_RH_LOCKOUT;
 
+    /* TODO: Set lockout password for TPM_RH_LOCKOUT using "TPM2_HierarchyChangeAuth" */
+    /* A Clear on the TPM_RH_LOCKOUT hierarchy will clear NV, but keep the EK Cert */
+    /* The platform hierarchy auth password (done at TPM manufacturing) protects the EK */
+
     rc = TPM2_Clear(&in);
     if (rc != TPM_RC_SUCCESS) {
     #ifdef DEBUG_WOLFTPM


### PR DESCRIPTION
Use the AIK template for the examples, so it can also be used for the signed timestamp example.
Added note about TPM2_Clear and lockout.