### PR TITLE
Improve the TLS client mutual authentication example to clarify use of dummy key

### DIFF
--- a/examples/csr/csr.c
+++ b/examples/csr/csr.c
@@ -305,7 +305,7 @@ int main(void)
     rc = TPM2_CSR_Example(NULL);
 #else
     printf("Wrapper/CertReq/CryptoDev code not compiled in\n");
-    printf("Build wolfssl with ./configure --enable-certgen --enable-certreq --enable-certext --enable-cryptodev\n");
+    printf("Build wolfssl with ./configure --enable-certgen --enable-certreq --enable-certext --enable-cryptocb\n");
 #endif
 
     return rc;

--- a/examples/pkcs7/pkcs7.c
+++ b/examples/pkcs7/pkcs7.c
@@ -428,7 +428,7 @@ int main(void)
     rc = TPM2_PKCS7_Example(NULL);
 #else
     printf("Wrapper/PKCS7/CryptoDev code not compiled in\n");
-    printf("Build wolfssl with ./configure --enable-pkcs7 --enable-cryptodev\n");
+    printf("Build wolfssl with ./configure --enable-pkcs7 --enable-cryptocb\n");
 #endif
 
     return rc;

--- a/examples/tls/tls_client.c
+++ b/examples/tls/tls_client.c
@@ -57,6 +57,9 @@
  *
  * This example client connects to localhost on on port 11111 by default.
  * These can be overriden using `TLS_HOST` and `TLS_PORT`.
+ * 
+ * By default this example will loads RSA keys unless RSA is disabled (NO_RSA) 
+ * or the TLS_USE_ECC build option is used.
  *
  * You can validate using the wolfSSL example server this like:
  *   ./examples/server/server -b -p 11111 -g -d

--- a/examples/tls/tls_server.c
+++ b/examples/tls/tls_server.c
@@ -49,8 +49,12 @@
  * Run ./certs/certreq.sh
  * Result is: ./certs/server-rsa-cert.pem and ./certs/server-ecc-cert.pem
  *
- * This example server listens on port 11111 by default.
+ * This example server listens on port 11111 by default, but can be set at 
+ * build-time using `TLS_PORT`.
  *
+ * By default this example will loads RSA keys unless RSA is disabled (NO_RSA) 
+ * or the TLS_USE_ECC build option is used.
+ * 
  * You can validate using the wolfSSL example client this like:
  *  ./examples/client/client -h localhost -p 11111 -g -d
  *


### PR DESCRIPTION
ZD 10895.