### PR TITLE
New auth session handling for TPM2 command handlers

### DIFF
--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -279,6 +279,39 @@ TPM_RC TPM2_SetSessionAuth(TPMS_AUTH_COMMAND* cmd)
     return rc;
 }
 
+/* Finds the number of active Auth Session in the given TPM2 context */
+TPM_RC TPM2_CountAuthSessions(TPM2_CTX *ctx, int *authSessionCount)
+{
+    int sessionCount, sessionHandle;
+
+    if(ctx == NULL || ctx->authCmd == NULL || authSessionCount == NULL)
+        return TPM_RC_FAILURE;
+
+    for(sessionCount = 0; sessionCount < MAX_SESSION_NUM; sessionCount++) {
+        sessionHandle = ctx->authCmd[sessionCount].sessionHandle;
+        /* According to the TCG Spec, Part 1, Chapter 15.4
+         * Session Handles have most significant octet at
+         * 0x02 for HMAC sessions
+         * 0x03 for Policy sessions
+         * Password sessions use predefined value of TPM_RS_PW
+         * Trial sessions are not of interest
+         */
+        if(sessionHandle != TPM_RS_PW) {
+            /* Not a password session, mask the most significant octet(MSO) */
+            sessionHandle &= 0xFF000000;
+            /* Check MSO for an HMAC or Policy session, otherwise invalid */
+            if(sessionHandle ^ 0x02000000 && sessionHandle ^ 0x03000000)
+                break;
+        }
+    }
+
+    *authSessionCount = sessionCount;
+#ifdef DEBUG_WOLFTPM
+    printf("Found %d auth sessions in the active TPM context\n", sessionCount);
+#endif
+    return TPM_RC_SUCCESS;
+}
+
 TPM_RC TPM2_ChipStartup(TPM2_CTX* ctx, int timeoutTries)
 {
     TPM_RC rc;
@@ -723,7 +756,7 @@ TPM_RC TPM2_PCR_Extend(PCR_Extend_In* in)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->pcrHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendU32(&packet, in->digests.count);
         for (i=0; i<(int)in->digests.count; i++) {
             UINT16 hashAlg = in->digests.digests[i].hashAlg;
@@ -756,7 +789,7 @@ TPM_RC TPM2_Create(Create_In* in, Create_Out* out)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->parentHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendSensitiveCreate(&packet, &in->inSensitive);
         TPM2_Packet_AppendPublic(&packet, &in->inPublic);
         TPM2_Packet_AppendU16(&packet, in->outsideInfo.size);
@@ -836,7 +869,7 @@ TPM_RC TPM2_CreatePrimary(CreatePrimary_In* in, CreatePrimary_Out* out)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->primaryHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendSensitiveCreate(&packet, &in->inSensitive);
         TPM2_Packet_AppendPublic(&packet, &in->inPublic);
         TPM2_Packet_AppendU16(&packet, in->outsideInfo.size);
@@ -918,7 +951,7 @@ TPM_RC TPM2_Load(Load_In* in, Load_Out* out)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->parentHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendU16(&packet, in->inPrivate.size);
         TPM2_Packet_AppendBytes(&packet, in->inPrivate.buffer,
             in->inPrivate.size);
@@ -976,7 +1009,7 @@ TPM_RC TPM2_Unseal(Unseal_In* in, Unseal_Out* out)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->itemHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS, TPM_CC_Unseal);
 
         /* send command */
@@ -1078,7 +1111,7 @@ TPM_RC TPM2_LoadExternal(LoadExternal_In* in, LoadExternal_Out* out)
 
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         if (in->inPrivate.sensitiveArea.authValue.size > 0 ||
@@ -1186,7 +1219,7 @@ TPM_RC TPM2_ActivateCredential(ActivateCredential_In* in,
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->activateHandle);
         TPM2_Packet_AppendU32(&packet, in->keyHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 2);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendU16(&packet, in->credentialBlob.size);
         TPM2_Packet_AppendBytes(&packet, in->credentialBlob.buffer,
             in->credentialBlob.size);
@@ -1267,7 +1300,7 @@ TPM_RC TPM2_ObjectChangeAuth(ObjectChangeAuth_In* in, ObjectChangeAuth_Out* out)
         TPM2_Packet_AppendU32(&packet, in->objectHandle);
         TPM2_Packet_AppendU32(&packet, in->parentHandle);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->newAuth.size);
         TPM2_Packet_AppendBytes(&packet, in->newAuth.buffer,
@@ -1306,7 +1339,7 @@ TPM_RC TPM2_Duplicate(Duplicate_In* in, Duplicate_Out* out)
         TPM2_Packet_AppendU32(&packet, in->objectHandle);
         TPM2_Packet_AppendU32(&packet, in->newParentHandle);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->encryptionKeyIn.size);
         TPM2_Packet_AppendBytes(&packet, in->encryptionKeyIn.buffer,
@@ -1358,7 +1391,7 @@ TPM_RC TPM2_Rewrap(Rewrap_In* in, Rewrap_Out* out)
         TPM2_Packet_AppendU32(&packet, in->oldParent);
         TPM2_Packet_AppendU32(&packet, in->newParent);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->inDuplicate.size);
         TPM2_Packet_AppendBytes(&packet, in->inDuplicate.buffer,
@@ -1407,7 +1440,7 @@ TPM_RC TPM2_Import(Import_In* in, Import_Out* out)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->parentHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendU16(&packet, in->encryptionKey.size);
         TPM2_Packet_AppendBytes(&packet, in->encryptionKey.buffer,
             in->encryptionKey.size);
@@ -1456,7 +1489,7 @@ TPM_RC TPM2_RSA_Encrypt(RSA_Encrypt_In* in, RSA_Encrypt_Out* out)
 
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         TPM2_Packet_AppendU16(&packet, in->message.size);
@@ -1504,7 +1537,7 @@ TPM_RC TPM2_RSA_Decrypt(RSA_Decrypt_In* in, RSA_Decrypt_Out* out)
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->keyHandle);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->cipherText.size);
         TPM2_Packet_AppendBytes(&packet, in->cipherText.buffer,
@@ -1553,7 +1586,7 @@ TPM_RC TPM2_ECDH_KeyGen(ECDH_KeyGen_In* in, ECDH_KeyGen_Out* out)
 
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
         TPM2_Packet_Finalize(&packet, st, TPM_CC_ECDH_KeyGen);
 
@@ -1590,7 +1623,7 @@ TPM_RC TPM2_ECDH_ZGen(ECDH_ZGen_In* in, ECDH_ZGen_Out* out)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->keyHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendPoint(&packet, &in->inPoint);
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS, TPM_CC_ECDH_ZGen);
 
@@ -1692,7 +1725,7 @@ TPM_RC TPM2_ZGen_2Phase(ZGen_2Phase_In* in, ZGen_2Phase_Out* out)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->keyA);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendPoint(&packet, &in->inQsB);
         TPM2_Packet_AppendPoint(&packet, &in->inQeB);
         TPM2_Packet_AppendU16(&packet, in->inScheme);
@@ -1728,7 +1761,7 @@ TPM_RC TPM2_EncryptDecrypt(EncryptDecrypt_In* in, EncryptDecrypt_Out* out)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->keyHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU8(&packet, in->decrypt);
         TPM2_Packet_AppendU16(&packet, in->mode);
@@ -1774,7 +1807,7 @@ TPM_RC TPM2_EncryptDecrypt2(EncryptDecrypt2_In* in, EncryptDecrypt2_Out* out)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->keyHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->inData.size);
         TPM2_Packet_AppendBytes(&packet, in->inData.buffer, in->inData.size);
@@ -1823,7 +1856,7 @@ TPM_RC TPM2_Hash(Hash_In* in, Hash_Out* out)
 
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         TPM2_Packet_AppendU16(&packet, in->data.size);
@@ -1874,7 +1907,7 @@ TPM_RC TPM2_HMAC(HMAC_In* in, HMAC_Out* out)
         TPM2_Packet_Init(ctx, &packet);
 
         TPM2_Packet_AppendU32(&packet, in->handle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->buffer.size);
         TPM2_Packet_AppendBytes(&packet, in->buffer.buffer, in->buffer.size);
@@ -1914,7 +1947,7 @@ TPM_RC TPM2_HMAC_Start(HMAC_Start_In* in, HMAC_Start_Out* out)
         TPM2_Packet_Init(ctx, &packet);
 
         TPM2_Packet_AppendU32(&packet, in->handle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->auth.size);
         TPM2_Packet_AppendBytes(&packet, in->auth.buffer, in->auth.size);
@@ -1954,7 +1987,7 @@ TPM_RC TPM2_HashSequenceStart(HashSequenceStart_In* in,
 
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         TPM2_Packet_AppendU16(&packet, in->auth.size);
@@ -1989,7 +2022,7 @@ TPM_RC TPM2_SequenceUpdate(SequenceUpdate_In* in)
         TPM2_Packet_Init(ctx, &packet);
 
         TPM2_Packet_AppendU32(&packet, in->sequenceHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->buffer.size);
         TPM2_Packet_AppendBytes(&packet, in->buffer.buffer, in->buffer.size);
@@ -2018,7 +2051,7 @@ TPM_RC TPM2_SequenceComplete(SequenceComplete_In* in, SequenceComplete_Out* out)
         TPM2_Packet_Init(ctx, &packet);
 
         TPM2_Packet_AppendU32(&packet, in->sequenceHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->buffer.size);
         TPM2_Packet_AppendBytes(&packet, in->buffer.buffer, in->buffer.size);
@@ -2068,7 +2101,7 @@ TPM_RC TPM2_EventSequenceComplete(EventSequenceComplete_In* in,
         TPM2_Packet_AppendU32(&packet, in->pcrHandle);
         TPM2_Packet_AppendU32(&packet, in->sequenceHandle);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 2);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->buffer.size);
         TPM2_Packet_AppendBytes(&packet, in->buffer.buffer, in->buffer.size);
@@ -2116,7 +2149,7 @@ TPM_RC TPM2_Certify(Certify_In* in, Certify_Out* out)
         TPM2_Packet_AppendU32(&packet, in->objectHandle);
         TPM2_Packet_AppendU32(&packet, in->signHandle);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->qualifyingData.size);
         TPM2_Packet_AppendBytes(&packet, in->qualifyingData.buffer,
@@ -2162,7 +2195,7 @@ TPM_RC TPM2_CertifyCreation(CertifyCreation_In* in, CertifyCreation_Out* out)
         TPM2_Packet_AppendU32(&packet, in->signHandle);
         TPM2_Packet_AppendU32(&packet, in->objectHandle);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->qualifyingData.size);
         TPM2_Packet_AppendBytes(&packet, in->qualifyingData.buffer,
@@ -2218,7 +2251,7 @@ TPM_RC TPM2_Quote(Quote_In* in, Quote_Out* out)
 
         TPM2_Packet_AppendU32(&packet, in->signHandle);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->qualifyingData.size);
         TPM2_Packet_AppendBytes(&packet, in->qualifyingData.buffer,
@@ -2268,7 +2301,7 @@ TPM_RC TPM2_GetSessionAuditDigest(GetSessionAuditDigest_In* in,
         TPM2_Packet_AppendU32(&packet, in->signHandle);
         TPM2_Packet_AppendU32(&packet, in->sessionHandle);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 2);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->qualifyingData.size);
         TPM2_Packet_AppendBytes(&packet, in->qualifyingData.buffer,
@@ -2316,7 +2349,7 @@ TPM_RC TPM2_GetCommandAuditDigest(GetCommandAuditDigest_In* in,
         TPM2_Packet_AppendU32(&packet, in->privacyHandle);
         TPM2_Packet_AppendU32(&packet, in->signHandle);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 2);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->qualifyingData.size);
         TPM2_Packet_AppendBytes(&packet, in->qualifyingData.buffer,
@@ -2363,7 +2396,7 @@ TPM_RC TPM2_GetTime(GetTime_In* in, GetTime_Out* out)
         TPM2_Packet_AppendU32(&packet, in->privacyAdminHandle);
         TPM2_Packet_AppendU32(&packet, in->signHandle);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 2);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->qualifyingData.size);
         TPM2_Packet_AppendBytes(&packet, in->qualifyingData.buffer,
@@ -2408,7 +2441,7 @@ TPM_RC TPM2_Commit(Commit_In* in, Commit_Out* out)
 
         TPM2_Packet_AppendU32(&packet, in->signHandle);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendPoint(&packet, &in->P1);
 
@@ -2453,7 +2486,7 @@ TPM_RC TPM2_EC_Ephemeral(EC_Ephemeral_In* in, EC_Ephemeral_Out* out)
         TPM2_Packet_Init(ctx, &packet);
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
         TPM2_Packet_AppendU32(&packet, in->curveID);
         TPM2_Packet_Finalize(&packet, st, TPM_CC_EC_Ephemeral);
@@ -2495,7 +2528,7 @@ TPM_RC TPM2_VerifySignature(VerifySignature_In* in,
 
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         TPM2_Packet_AppendU16(&packet, in->digest.size);
@@ -2542,7 +2575,7 @@ TPM_RC TPM2_Sign(Sign_In* in, Sign_Out* out)
 
         TPM2_Packet_AppendU32(&packet, in->keyHandle);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->digest.size);
         TPM2_Packet_AppendBytes(&packet, in->digest.buffer, in->digest.size);
@@ -2590,7 +2623,7 @@ TPM_RC TPM2_SetCommandCodeAuditStatus(
 
         TPM2_Packet_AppendU32(&packet, in->auth);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->auditAlg);
 
@@ -2629,7 +2662,7 @@ TPM_RC TPM2_PCR_Event(PCR_Event_In* in, PCR_Event_Out* out)
         TPM2_Packet_Init(ctx, &packet);
 
         TPM2_Packet_AppendU32(&packet, in->pcrHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->eventData.size);
         TPM2_Packet_AppendBytes(&packet, in->eventData.buffer,
@@ -2675,7 +2708,7 @@ TPM_RC TPM2_PCR_Allocate(PCR_Allocate_In* in, PCR_Allocate_Out* out)
         TPM2_Packet_Init(ctx, &packet);
 
         TPM2_Packet_AppendU32(&packet, in->authHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendPCR(&packet, &in->pcrAllocation);
 
@@ -2713,7 +2746,7 @@ TPM_RC TPM2_PCR_SetAuthPolicy(PCR_SetAuthPolicy_In* in)
         TPM2_Packet_Init(ctx, &packet);
 
         TPM2_Packet_AppendU32(&packet, in->authHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->authPolicy.size);
         TPM2_Packet_AppendBytes(&packet, in->authPolicy.buffer,
@@ -2747,7 +2780,7 @@ TPM_RC TPM2_PCR_SetAuthValue(PCR_SetAuthValue_In* in)
         TPM2_Packet_Init(ctx, &packet);
 
         TPM2_Packet_AppendU32(&packet, in->pcrHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->auth.size);
         TPM2_Packet_AppendBytes(&packet, in->auth.buffer, in->auth.size);
@@ -2776,7 +2809,7 @@ TPM_RC TPM2_PCR_Reset(PCR_Reset_In* in)
         TPM2_Packet_Init(ctx, &packet);
 
         TPM2_Packet_AppendU32(&packet, in->pcrHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS, TPM_CC_PCR_Reset);
 
@@ -2807,7 +2840,7 @@ TPM_RC TPM2_PolicySigned(PolicySigned_In* in, PolicySigned_Out* out)
 
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         TPM2_Packet_AppendU16(&packet, in->nonceTPM.size);
@@ -2870,7 +2903,7 @@ TPM_RC TPM2_PolicySecret(PolicySecret_In* in, PolicySecret_Out* out)
         TPM2_Packet_AppendU32(&packet, in->authHandle);
         TPM2_Packet_AppendU32(&packet, in->policySession);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->nonceTPM.size);
         TPM2_Packet_AppendBytes(&packet, in->nonceTPM.buffer,
@@ -2930,7 +2963,7 @@ TPM_RC TPM2_PolicyTicket(PolicyTicket_In* in)
 
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         TPM2_Packet_AppendU16(&packet, in->timeout.size);
@@ -3011,7 +3044,7 @@ TPM_RC TPM2_PolicyPCR(PolicyPCR_In* in)
 
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         TPM2_Packet_AppendU16(&packet, in->pcrDigest.size);
@@ -3074,7 +3107,7 @@ TPM_RC TPM2_PolicyNV(PolicyNV_In* in)
         TPM2_Packet_AppendU32(&packet, in->nvIndex);
         TPM2_Packet_AppendU32(&packet, in->policySession);
 
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->operandB.size);
         TPM2_Packet_AppendBytes(&packet, in->operandB.buffer,
@@ -3111,7 +3144,7 @@ TPM_RC TPM2_PolicyCounterTimer(PolicyCounterTimer_In* in)
 
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         TPM2_Packet_AppendU16(&packet, in->operandB.size);
@@ -3176,7 +3209,7 @@ TPM_RC TPM2_PolicyCpHash(PolicyCpHash_In* in)
         TPM2_Packet_AppendU32(&packet, in->policySession);
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         TPM2_Packet_AppendU16(&packet, in->cpHashA.size);
@@ -3209,7 +3242,7 @@ TPM_RC TPM2_PolicyNameHash(PolicyNameHash_In* in)
         TPM2_Packet_AppendU32(&packet, in->policySession);
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         TPM2_Packet_AppendU16(&packet, in->nameHash.size);
@@ -3243,7 +3276,7 @@ TPM_RC TPM2_PolicyDuplicationSelect(PolicyDuplicationSelect_In* in)
         TPM2_Packet_AppendU32(&packet, in->policySession);
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         TPM2_Packet_AppendU16(&packet, in->objectName.size);
@@ -3283,7 +3316,7 @@ TPM_RC TPM2_PolicyAuthorize(PolicyAuthorize_In* in)
         TPM2_Packet_AppendU32(&packet, in->policySession);
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         TPM2_Packet_AppendU16(&packet, in->approvedPolicy.size);
@@ -3371,7 +3404,7 @@ TPM_RC TPM2_PolicyGetDigest(PolicyGetDigest_In* in, PolicyGetDigest_Out* out)
         TPM2_Packet_AppendU32(&packet, in->policySession);
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
         TPM2_Packet_Finalize(&packet, st, TPM_CC_PolicyGetDigest);
 
@@ -3435,7 +3468,7 @@ TPM_RC TPM2_PolicyTemplate(PolicyTemplate_In* in)
         TPM2_Packet_AppendU32(&packet, in->policySession);
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
         TPM2_Packet_AppendU16(&packet, in->templateHash.size);
         TPM2_Packet_AppendBytes(&packet, in->templateHash.buffer,
@@ -3465,7 +3498,7 @@ TPM_RC TPM2_PolicyAuthorizeNV(PolicyAuthorizeNV_In* in)
         TPM2_Packet_AppendU32(&packet, in->authHandle);
         TPM2_Packet_AppendU32(&packet, in->nvIndex);
         TPM2_Packet_AppendU32(&packet, in->policySession);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS,
             TPM_CC_PolicyAuthorizeNV);
 
@@ -3491,7 +3524,7 @@ TPM_RC TPM2_HierarchyControl(HierarchyControl_In* in)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->authHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendU32(&packet, in->enable);
         TPM2_Packet_AppendU8(&packet, in->state);
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS, TPM_CC_HierarchyControl);
@@ -3517,7 +3550,7 @@ TPM_RC TPM2_SetPrimaryPolicy(SetPrimaryPolicy_In* in)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->authHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendU16(&packet, in->authPolicy.size);
         TPM2_Packet_AppendBytes(&packet, in->authPolicy.buffer,
             in->authPolicy.size);
@@ -3545,7 +3578,7 @@ static TPM_RC TPM2_ChangeSeed(ChangeSeed_In* in, TPM_CC cc)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->authHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS, cc);
 
         /* send command */
@@ -3579,7 +3612,7 @@ TPM_RC TPM2_Clear(Clear_In* in)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->authHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS, TPM_CC_Clear);
 
         /* send command */
@@ -3603,7 +3636,7 @@ TPM_RC TPM2_ClearControl(ClearControl_In* in)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->auth);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendU8(&packet, in->disable);
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS, TPM_CC_ClearControl);
 
@@ -3628,7 +3661,7 @@ TPM_RC TPM2_HierarchyChangeAuth(HierarchyChangeAuth_In* in)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->authHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendU16(&packet, in->newAuth.size);
         TPM2_Packet_AppendBytes(&packet, in->newAuth.buffer, in->newAuth.size);
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS,
@@ -3655,7 +3688,7 @@ TPM_RC TPM2_DictionaryAttackLockReset(DictionaryAttackLockReset_In* in)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->lockHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS,
             TPM_CC_DictionaryAttackLockReset);
 
@@ -3680,7 +3713,7 @@ TPM_RC TPM2_DictionaryAttackParameters(DictionaryAttackParameters_In* in)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->lockHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendU32(&packet, in->newMaxTries);
         TPM2_Packet_AppendU32(&packet, in->newRecoveryTime);
         TPM2_Packet_AppendU32(&packet, in->lockoutRecovery);
@@ -3709,7 +3742,7 @@ TPM_RC TPM2_PP_Commands(PP_Commands_In* in)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->auth);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU32(&packet, in->setList.count);
         for (i=0; i<(int)in->setList.count; i++) {
@@ -3744,7 +3777,7 @@ TPM_RC TPM2_SetAlgorithmSet(SetAlgorithmSet_In* in)
         TPM2_Packet_Init(ctx, &packet);
 
         TPM2_Packet_AppendU32(&packet, in->authHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU32(&packet, in->algorithmSet);
 
@@ -3773,7 +3806,7 @@ TPM_RC TPM2_FieldUpgradeStart(FieldUpgradeStart_In* in)
 
         TPM2_Packet_AppendU32(&packet, in->authorization);
         TPM2_Packet_AppendU32(&packet, in->keyHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->fuDigest.size);
         TPM2_Packet_AppendBytes(&packet, in->fuDigest.buffer,
@@ -3808,7 +3841,7 @@ TPM_RC TPM2_FieldUpgradeData(FieldUpgradeData_In* in, FieldUpgradeData_Out* out)
 
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         TPM2_Packet_AppendU16(&packet, in->fuData.size);
@@ -3857,7 +3890,7 @@ TPM_RC TPM2_FirmwareRead(FirmwareRead_In* in, FirmwareRead_Out* out)
 
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
         TPM2_Packet_AppendU32(&packet, in->sequenceNumber);
         TPM2_Packet_Finalize(&packet, st, TPM_CC_FirmwareRead);
@@ -3962,7 +3995,7 @@ TPM_RC TPM2_EvictControl(EvictControl_In* in)
 
         TPM2_Packet_AppendU32(&packet, in->auth);
         TPM2_Packet_AppendU32(&packet, in->objectHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendU32(&packet, in->persistentHandle);
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS, TPM_CC_EvictControl);
 
@@ -3990,7 +4023,7 @@ TPM_RC TPM2_ReadClock(ReadClock_Out* out)
 
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
         TPM2_Packet_Finalize(&packet, st, TPM_CC_ReadClock);
 
@@ -4030,7 +4063,7 @@ TPM_RC TPM2_ClockSet(ClockSet_In* in)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->auth);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU64(&packet, in->newTime);
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS, TPM_CC_ClockSet);
@@ -4056,7 +4089,7 @@ TPM_RC TPM2_ClockRateAdjust(ClockRateAdjust_In* in)
         TPM2_Packet packet;
         TPM2_Packet_Init(ctx, &packet);
         TPM2_Packet_AppendU32(&packet, in->auth);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendU8(&packet, in->rateAdjust);
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS, TPM_CC_ClockRateAdjust);
 
@@ -4084,7 +4117,7 @@ TPM_RC TPM2_TestParms(TestParms_In* in)
 
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         TPM2_Packet_AppendU16(&packet, in->parameters.type);
@@ -4114,7 +4147,7 @@ TPM_RC TPM2_NV_DefineSpace(NV_DefineSpace_In* in)
         TPM2_Packet_Init(ctx, &packet);
 
         TPM2_Packet_AppendU32(&packet, in->authHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->auth.size);
         TPM2_Packet_AppendBytes(&packet, in->auth.buffer, in->auth.size);
@@ -4158,7 +4191,7 @@ TPM_RC TPM2_NV_UndefineSpace(NV_UndefineSpace_In* in)
 
         TPM2_Packet_AppendU32(&packet, in->authHandle);
         TPM2_Packet_AppendU32(&packet, in->nvIndex);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS, TPM_CC_NV_UndefineSpace);
 
@@ -4185,7 +4218,7 @@ TPM_RC TPM2_NV_UndefineSpaceSpecial(NV_UndefineSpaceSpecial_In* in)
 
         TPM2_Packet_AppendU32(&packet, in->nvIndex);
         TPM2_Packet_AppendU32(&packet, in->platform);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS,
             TPM_CC_NV_UndefineSpaceSpecial);
@@ -4215,7 +4248,7 @@ TPM_RC TPM2_NV_ReadPublic(NV_ReadPublic_In* in, NV_ReadPublic_Out* out)
         TPM2_Packet_AppendU32(&packet, in->nvIndex);
         st = TPM2_GetTag(ctx);
         if (st == TPM_ST_SESSIONS) {
-            TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+            TPM2_Packet_AppendAuth(&packet, ctx);
         }
 
         TPM2_Packet_Finalize(&packet, st, TPM_CC_NV_ReadPublic);
@@ -4266,7 +4299,7 @@ TPM_RC TPM2_NV_Write(NV_Write_In* in)
 
         TPM2_Packet_AppendU32(&packet, in->authHandle);
         TPM2_Packet_AppendU32(&packet, in->nvIndex);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->data.size);
         TPM2_Packet_AppendBytes(&packet, in->data.buffer, in->data.size);
@@ -4298,7 +4331,7 @@ TPM_RC TPM2_NV_Increment(NV_Increment_In* in)
 
         TPM2_Packet_AppendU32(&packet, in->authHandle);
         TPM2_Packet_AppendU32(&packet, in->nvIndex);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS, TPM_CC_NV_Increment);
 
@@ -4325,7 +4358,7 @@ TPM_RC TPM2_NV_Extend(NV_Extend_In* in)
 
         TPM2_Packet_AppendU32(&packet, in->authHandle);
         TPM2_Packet_AppendU32(&packet, in->nvIndex);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->data.size);
         TPM2_Packet_AppendBytes(&packet, in->data.buffer, in->data.size);
@@ -4355,7 +4388,7 @@ TPM_RC TPM2_NV_SetBits(NV_SetBits_In* in)
 
         TPM2_Packet_AppendU32(&packet, in->authHandle);
         TPM2_Packet_AppendU32(&packet, in->nvIndex);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU64(&packet, in->bits);
 
@@ -4384,7 +4417,7 @@ TPM_RC TPM2_NV_WriteLock(NV_WriteLock_In* in)
 
         TPM2_Packet_AppendU32(&packet, in->authHandle);
         TPM2_Packet_AppendU32(&packet, in->nvIndex);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS, TPM_CC_NV_WriteLock);
 
@@ -4410,7 +4443,7 @@ TPM_RC TPM2_NV_GlobalWriteLock(NV_GlobalWriteLock_In* in)
         TPM2_Packet_Init(ctx, &packet);
 
         TPM2_Packet_AppendU32(&packet, in->authHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS,
             TPM_CC_NV_GlobalWriteLock);
@@ -4438,7 +4471,7 @@ TPM_RC TPM2_NV_Read(NV_Read_In* in, NV_Read_Out* out)
 
         TPM2_Packet_AppendU32(&packet, in->authHandle);
         TPM2_Packet_AppendU32(&packet, in->nvIndex);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->size);
         TPM2_Packet_AppendU16(&packet, in->offset);
@@ -4476,7 +4509,7 @@ TPM_RC TPM2_NV_ReadLock(NV_ReadLock_In* in)
 
         TPM2_Packet_AppendU32(&packet, in->authHandle);
         TPM2_Packet_AppendU32(&packet, in->nvIndex);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS, TPM_CC_NV_ReadLock);
 
@@ -4502,7 +4535,7 @@ TPM_RC TPM2_NV_ChangeAuth(NV_ChangeAuth_In* in)
         TPM2_Packet_Init(ctx, &packet);
 
         TPM2_Packet_AppendU32(&packet, in->nvIndex);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->newAuth.size);
         TPM2_Packet_AppendBytes(&packet, in->newAuth.buffer, in->newAuth.size);
@@ -4533,7 +4566,7 @@ TPM_RC TPM2_NV_Certify(NV_Certify_In* in, NV_Certify_Out* out)
         TPM2_Packet_AppendU32(&packet, in->signHandle);
         TPM2_Packet_AppendU32(&packet, in->authHandle);
         TPM2_Packet_AppendU32(&packet, in->nvIndex);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
 
         TPM2_Packet_AppendU16(&packet, in->qualifyingData.size);
         TPM2_Packet_AppendBytes(&packet, in->qualifyingData.buffer,
@@ -4589,7 +4622,7 @@ int TPM2_SetCommandSet(SetCommandSet_In* in)
         TPM2_Packet_Init(ctx, &packet);
 
         TPM2_Packet_AppendU32(&packet, in->authHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendU32(&packet, in->commandCode);
         TPM2_Packet_AppendU32(&packet, in->enableFlag);
         TPM2_Packet_AppendU32(&packet, in->lockFlag);
@@ -4618,7 +4651,7 @@ int TPM2_SetMode(SetMode_In* in)
         TPM2_Packet_Init(ctx, &packet);
 
         TPM2_Packet_AppendU32(&packet, in->authHandle);
-        TPM2_Packet_AppendAuth(&packet, ctx->authCmd, 1);
+        TPM2_Packet_AppendAuth(&packet, ctx);
         TPM2_Packet_AppendU8(&packet, in->modeSet.CmdToLowPower);
         TPM2_Packet_AppendU8(&packet, in->modeSet.BootToLowPower);
         TPM2_Packet_AppendU8(&packet, in->modeSet.modeLock);

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -284,10 +284,10 @@ TPM_RC TPM2_CountAuthSessions(TPM2_CTX *ctx, int *authSessionCount)
 {
     int sessionCount, sessionHandle;
 
-    if(ctx == NULL || ctx->authCmd == NULL || authSessionCount == NULL)
+    if (ctx == NULL || ctx->authCmd == NULL || authSessionCount == NULL)
         return TPM_RC_FAILURE;
 
-    for(sessionCount = 0; sessionCount < MAX_SESSION_NUM; sessionCount++) {
+    for (sessionCount = 0; sessionCount < MAX_SESSION_NUM; sessionCount++) {
         sessionHandle = ctx->authCmd[sessionCount].sessionHandle;
         /* According to the TCG Spec, Part 1, Chapter 15.4
          * Session Handles have most significant octet at
@@ -296,11 +296,11 @@ TPM_RC TPM2_CountAuthSessions(TPM2_CTX *ctx, int *authSessionCount)
          * Password sessions use predefined value of TPM_RS_PW
          * Trial sessions are not of interest
          */
-        if(sessionHandle != TPM_RS_PW) {
+        if (sessionHandle != TPM_RS_PW) {
             /* Not a password session, mask the most significant octet(MSO) */
             sessionHandle &= 0xFF000000;
             /* Check MSO for an HMAC or Policy session, otherwise invalid */
-            if(sessionHandle ^ 0x02000000 && sessionHandle ^ 0x03000000)
+            if ((sessionHandle ^ 0x02000000) && (sessionHandle ^ 0x03000000))
                 break;
         }
     }

--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -315,19 +315,24 @@ void TPM2_Packet_PlaceU32(TPM2_Packet* packet, int markSz)
     }
 }
 
+/* TODO: We should add a return code here */
 void TPM2_Packet_AppendAuth(TPM2_Packet* packet, TPM2_CTX* ctx)
 {
     int tmpSz = 0;
     int i, authCount;
     TPMS_AUTH_COMMAND *auth;
 
-    if (ctx == NULL) {
+    if (ctx == NULL)
         return;
-    }
 
     auth = ctx->authCmd;
+    if (auth == NULL)
+        return;
 
     if (TPM2_CountAuthSessions(ctx, &authCount) != TPM_RC_SUCCESS)
+        return;
+
+    if (authCount > MAX_SESSION_NUM)
         return;
 
     TPM2_Packet_MarkU32(packet, &tmpSz);

--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -315,14 +315,20 @@ void TPM2_Packet_PlaceU32(TPM2_Packet* packet, int markSz)
     }
 }
 
-void TPM2_Packet_AppendAuth(TPM2_Packet* packet, TPMS_AUTH_COMMAND* auth, const int authCount)
+void TPM2_Packet_AppendAuth(TPM2_Packet* packet, TPM2_CTX* ctx)
 {
     int tmpSz = 0;
-    int i;
+    int i, authCount;
+    TPMS_AUTH_COMMAND *auth;
 
-    if (auth == NULL || authCount > MAX_SESSION_NUM) {
+    if (ctx == NULL) {
         return;
     }
+
+    auth = ctx->authCmd;
+
+    if (TPM2_CountAuthSessions(ctx, &authCount) != TPM_RC_SUCCESS)
+        return;
 
     TPM2_Packet_MarkU32(packet, &tmpSz);
     for (i=0; i<authCount; i++) {

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -2799,6 +2799,8 @@ WOLFTPM_API int TPM2_ParseAttest(const TPM2B_ATTEST* in, TPMS_ATTEST* out);
 WOLFTPM_API int TPM2_GetWolfRng(WC_RNG** rng);
 #endif
 
+WOLFTPM_LOCAL TPM_RC TPM2_CountAuthSessions(TPM2_CTX* ctx, int* authSessionCount);
+
 typedef enum {
     TPM_VENDOR_UNKNOWN = 0,
     TPM_VENDOR_INFINEON = 0x15d1,

--- a/wolftpm/tpm2_packet.h
+++ b/wolftpm/tpm2_packet.h
@@ -70,7 +70,7 @@ WOLFTPM_LOCAL void TPM2_Packet_MarkU16(TPM2_Packet* packet, int* markSz);
 WOLFTPM_LOCAL int  TPM2_Packet_PlaceU16(TPM2_Packet* packet, int markSz);
 WOLFTPM_LOCAL void TPM2_Packet_MarkU32(TPM2_Packet* packet, int* markSz);
 WOLFTPM_LOCAL void TPM2_Packet_PlaceU32(TPM2_Packet* packet, int markSz);
-WOLFTPM_LOCAL void TPM2_Packet_AppendAuth(TPM2_Packet* packet, TPMS_AUTH_COMMAND* auth, const int authCount);
+WOLFTPM_LOCAL void TPM2_Packet_AppendAuth(TPM2_Packet* packet, TPM2_CTX* ctx);
 WOLFTPM_LOCAL void TPM2_Packet_ParseAuth(TPM2_Packet* packet, TPMS_AUTH_RESPONSE* auth);
 WOLFTPM_LOCAL void TPM2_Packet_AppendPCR(TPM2_Packet* packet, TPML_PCR_SELECTION* pcr);
 WOLFTPM_LOCAL void TPM2_Packet_ParsePCR(TPM2_Packet* packet, TPML_PCR_SELECTION* pcr);


### PR DESCRIPTION
In the run of #129 , we found that wolfTPM currently does not handle the maximum possible TPM sessions. 

I came up with two simple solutions, this one I think is better, because it uses the active TPM context.

It is best to make this change upstream regardless of the status of 129, because the current authSession handling results in TPM2 command handlers to include only the default amount of TPM sessions for a particular command.

For example, for TPM2_Create the handler would include only 1 session at all times regardless of how many sessions the user has set. For TPM2_Quote the handler would include only 2 sessions at all times, regardless if there are 3.