### PR TITLE
Add lpc bus support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ autogen.sh requires: automake and libtool: `sudo apt-get install automake libtoo
 --enable-wolfcrypt      Enable wolfCrypt hooks for RNG, Auth Sessions and Parameter encryption (default: enabled) - WOLFTPM2_NO_WOLFCRYPT
 --enable-advio          Enable Advanced IO (default: disabled) - WOLFTPM_ADV_IO
 --enable-i2c            Enable I2C TPM Support (default: disabled, requires advio) - WOLFTPM_I2C
+--enable-lpc            Enable LPC TPM Support (default: disabled, requires advio) - WOLFTPM_LPC
 --enable-checkwaitstate Enable TIS / SPI Check Wait State support (default: depends on chip) - WOLFTPM_CHECK_WAIT_STATE
 --enable-smallstack     Enable options to reduce stack usage
 --enable-tislock        Enable Linux Named Semaphore for locking access to SPI device for concurrent access between processes - WOLFTPM_TIS_LOCK

--- a/configure.ac
+++ b/configure.ac
@@ -154,6 +154,19 @@ then
 fi
 
 
+# LPC Support
+AC_ARG_ENABLE([lpc],
+    [AS_HELP_STRING([--enable-lpc],[Enable LPC TPM Support (default: disabled)])],
+    [ ENABLED_LPC=$enableval ],
+    [ ENABLED_LPC=no ]
+    )
+
+if test "x$ENABLED_LPC" = "xyes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_LPC"
+fi
+
+
 # Advanced IO
 AC_ARG_ENABLE([advio],
     [AS_HELP_STRING([--enable-advio],[Enable Advanced IO (default: disabled)])],
@@ -347,6 +360,7 @@ AM_CONDITIONAL([BUILD_EXAMPLES], [test "x$ENABLED_EXAMPLES" = "xyes"])
 AM_CONDITIONAL([BUILD_WRAPPER], [test "x$ENABLED_WRAPPER" = "xyes"])
 AM_CONDITIONAL([HAVE_LIBWOLFSSL], [test "x$ENABLED_WOLFCRYPT" = "xyes"])
 AM_CONDITIONAL([BUILD_I2C], [test "x$ENABLED_I2C" = "xyes"])
+AM_CONDITIONAL([BUILD_LPC], [test "x$ENABLED_LPC" = "xyes"])
 AM_CONDITIONAL([BUILD_ADVIO], [test "x$ENABLED_ADVIO" = "xyes"])
 AM_CONDITIONAL([BUILD_ST], [test "x$ENABLED_ST" = "xyes"])
 AM_CONDITIONAL([BUILD_MICROCHIP], [test "x$ENABLED_MICROCHIP" = "xyes"])
@@ -471,6 +485,7 @@ echo "   * Examples:                  $ENABLED_EXAMPLES"
 echo "   * wolfCrypt:                 $ENABLED_WOLFCRYPT"
 echo "   * Advanced IO:               $ENABLED_ADVIO"
 echo "   * I2C:                       $ENABLED_I2C"
+echo "   * LPC:                       $ENABLED_LPC"
 echo "   * Linux kernel TPM device:   $ENABLED_DEVTPM"
 echo "   * SWTPM:                     $ENABLED_SWTPM"
 echo "   * WINAPI:                    $ENABLED_WINAPI"

--- a/examples/tpm_lpc.c
+++ b/examples/tpm_lpc.c
@@ -1,0 +1,134 @@
+/* tpm2_lpc.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+#include <wolftpm/tpm2.h>
+#include <wolftpm/tpm2_tis.h>
+
+/* This file implements LPC bus support for TPM devices
+
+TPM LPC must use LFRAME, LCLK, LADO
+
+    - LFRAME is used for starting new LPC cycle
+    - LCKL is a free running bus clock
+    - LADO{0:3} is the shared data, control and address bus, 4-bit wide
+
+According to the TCG TIS specification, a TPM on LPC supports two operations
+called "TPM Locality Read/Write" that are similar to the LPC I/O Read/Write.
+
+  LPC IO Write cycle:
+
+    LPC_START LPC_CYCDIR LPC_ADDR (!) LPC_DATA LPC_TAR LPC_SYNC (!) LPC_TAR
+
+  LPC IO Read cycle:
+
+    LPC_START LPC_CYCDIR LPC_ADDR (!) LPC_TAR LPC_SYNC LPC_DATA (!) LPC_TAR
+                                       ^TPM responds                  ^end
+
+  Notes:
+    - LPC_START uses reserved value for TPM peripherals
+    - LPC_DATA takes two cycles, because data is transfered 4 bits per cycle
+        -- however, LPC bus transfer is unlimited and happens byte by byte
+        -- therefore, LPC_DATA repeats as many times needed
+    - LPC_SYNC is used for TPM wait states
+        -- could last multiple LPC cycles
+    - first LPC_TAR gives LPC data bus to peripheral(TPM)
+        -- GPIO lines change direction in two LPC cycles
+    - second LPC_TAR takes back LPC data bus for host
+
+*/
+#define LPC_CYCLE_START_VALUE 0x0101 /* Defined by the TCG TIS specification */
+
+/* Values for the LP state machine executing the write and read */
+typedef enum LPC_STATE {
+    LPC_IDLE   = 0,
+    LPC_START  = 1,
+    LPC_CYCDIR = 2,
+    LPC_ADDR_0 = 3,
+    LPC_ADDR_1 = 4,
+    LPC_ADDR_2 = 5,
+    LPC_ADDR_3 = 6,
+    LPC_DATA_0 = 7,
+    LPC_DATA_1 = 8,
+    LPC_TAR_0  = 9,
+    LPC_TAR_1  = 10,
+    LPC_SYNC   = 11,
+    LPC_ABORT  = 12
+}LPC_IO_CYCLE_STATE_T;
+typedef UINT16 LPC_IO_CYCLE_STATE;
+
+/* TODO: Make member of TPM2_CTX and then gLPCstate becomes a pointer */
+static LPC_IO_CYCLE_STATE gLPCstate = LPC_IDLE;
+
+/* Prepare LPC-like interface on a Linux-powered device that does not have LPC
+ * - Use SPI to drive LCLK(SPI CLK) and LFRAME(CS)
+ * - Use additional GPIO to drive LADO{0:3}, the LPC data addr and control bus
+ *
+ * Most Linux SBC and SoC do not have native LPC support
+ */
+int TPM2_LPC_Init(void)
+{
+    int rc = 0;
+
+    /* Init Linux SPI */
+
+    /* TODO: Init GPIO for LADO{0:3} */
+
+    /* TODO: Pull-ups required on LADO lines */
+
+    return 0;
+}
+
+/* Host gives control of the LADO{0:3} lines to the TPM */
+int TPM2_LPC_LADOtoTPM(void)
+{
+    /* Usually done during a first TAR cycle */
+}
+
+/* Host takes back control of the LADO{0:3} lines */
+int TPM2_LPC_LADOtoHost(void)
+    /* Usually done during a second TAR cycle */
+{
+}
+
+void TPM2_LPC_GetState(LPC_IO_CYCLE_STATE* state)
+{
+    *state = gLPCstate;
+}
+
+void TPM2_LPC_SetState(LPC_IO_CYCLE_STATE state)
+{
+    gLPCstate = state;
+}
+
+int TPM2_LPC_Read(void)
+{
+    int rc = 0;
+
+    return rc;
+}
+
+int TPM2_LPC_Write(void)
+{
+    int rc = 0;
+
+    return rc;
+}


### PR DESCRIPTION
Most servers and data centers use TPM on LPC Bus. These systems have native LPC support and when run under Linux, there would be /dev/tpmX interface. However, with the rise of edge gateways and IIoT(Industrial IoT), there is increasing use of ARM SoC without native LPC support. These systems could not use TPM on the LPC bus.

This PR aims to address that and add LPC support for embedded Linux systems that want to use LPC TPM
- Adding LPC bus state machine
- Adding LPC cycle handling for TPM Locality Read/Write (similar to LPC IO Read/Write)
- Integrating with the existing tpm_io and preserving backward comparability
- Enable future extension to support bare metal LPC bus

There are various LPC bus specifics, here is a list of the design choices made to address those specifics:
1. LPC needs free running LCLK
Generation a free running clock manually under linux is not a good idea, therefore I am using the SPIdev CLK as LCKL :) 
2. LPC needs a dedicated LFRAME pin to signal the start of every new LPC Cycle
Manual control of that pin would be possible, however I think I could use the SPIdev CS for that purpose and simplify our LPC bus logic
3. LPC needs 4-bite wide shared data, control and address bus
Because there is not native LPC support, the natural choice is a bit bang of the already slow-by-design LPC protocol interface.
* Current code is written to support Linux GPIO Sysfs layer
* The code allows adding future support of other GPIO layers. For example, adding glue code for STM32 GPIO HAL, because STM32 also does not have native LPC hardware interface.

Future identified challenges:
- LPC SYNC cycle is used for TPM wait states and does not have a defined maximum, it is defined as multiple LPC cycles, as long as the TPM responds with 0x0101 or 0x0110 in the response to LPC_SYNC.
- LPC TAR cycle changed direction of pins

My test setup is RPI4 with Nuvoton NPC650 TPM2.0 module on LPC bus.

Originally, I tried extending the WOLFTPM_SPI to support LPC, but the 4-bit wide data lenght and LPC cycle specifics just did not allow for such simple solution. Therefore, I chose to add tpm_lpc.c layer to extend tpm_io.c in wolftpm/examples/... 

Looking forward to feedback @dgarske on the design choices and code so far, before continuing forward