### PR TITLE
Cleanup of the examples to use the key templates

### DIFF
--- a/examples/keygen/keygen.c
+++ b/examples/keygen/keygen.c
@@ -56,10 +56,6 @@ int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[])
     WOLFTPM2_SESSION tpmSession;
     TPM2B_AUTH auth;
     int bAIK = 1;
-#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
-    XFILE f;
-    size_t fileSz = 0;
-#endif
     const char* outputFile = "keyblob.bin";
 
     if (argc >= 2) {
@@ -178,14 +174,7 @@ int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[])
 
     /* Save key as encrypted blob to the disk */
 #if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
-    f = XFOPEN(outputFile, "wb");
-    if (f != XBADFILE) {
-        newKey.pub.size = sizeof(newKey.pub);
-        fileSz += XFWRITE(&newKey.pub, 1, sizeof(newKey.pub), f);
-        fileSz += XFWRITE(&newKey.priv, 1, sizeof(UINT16) + newKey.priv.size, f);
-        XFCLOSE(f);
-    }
-    printf("Wrote %d bytes to %s\n", (int)fileSz, outputFile);
+    rc = writeKeyBlob(outputFile, &newKey);
 #else
     printf("Key Public Blob %d\n", newKey.pub.size);
     TPM2_PrintBin((const byte*)&newKey.pub.publicArea, newKey.pub.size);

--- a/examples/keygen/keyimport.c
+++ b/examples/keygen/keyimport.c
@@ -54,10 +54,6 @@ int TPM2_Keyimport_Example(void* userCtx, int argc, char *argv[])
     TPMI_ALG_PUBLIC alg = TPM_ALG_RSA; /* TPM_ALG_ECC */
     TPM_ALG_ID paramEncAlg = TPM_ALG_NULL;
     WOLFTPM2_SESSION tpmSession;
-#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
-    XFILE f;
-    size_t fileSz = 0;
-#endif
     const char* outputFile = "keyblob.bin";
 
     if (argc >= 2) {
@@ -144,14 +140,7 @@ int TPM2_Keyimport_Example(void* userCtx, int argc, char *argv[])
 
     /* Save key as encrypted blob to the disk */
 #if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
-    f = XFOPEN(outputFile, "wb");
-    if (f != XBADFILE) {
-        impKey.pub.size = sizeof(impKey.pub);
-        fileSz += XFWRITE(&impKey.pub, 1, sizeof(impKey.pub), f);
-        fileSz += XFWRITE(&impKey.priv, 1, sizeof(UINT16) + impKey.priv.size, f);
-        XFCLOSE(f);
-    }
-    printf("Wrote %d bytes to %s\n", (int)fileSz, outputFile);
+    rc = writeKeyBlob(outputFile, &impKey);
 #else
     printf("Key Public Blob %d\n", impKey.pub.size);
     TPM2_PrintBin((const byte*)&impKey.pub.publicArea, impKey.pub.size);

--- a/examples/pkcs7/pkcs7.c
+++ b/examples/pkcs7/pkcs7.c
@@ -335,26 +335,19 @@ int TPM2_PKCS7_ExampleArgs(void* userCtx, int argc, char *argv[])
     if (rc != 0) goto exit;
 
     /* Create/Load RSA key for PKCS7 signing */
-    rc = wolfTPM2_ReadPublicKey(&dev, &rsaKey, TPM2_DEMO_RSA_KEY_HANDLE);
-    if (rc != 0) {
-        rc = wolfTPM2_GetKeyTemplate_RSA(&publicTemplate,
-            TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
-            TPMA_OBJECT_decrypt | TPMA_OBJECT_sign | TPMA_OBJECT_noDA);
-        if (rc != 0) goto exit;
-        rc = wolfTPM2_CreateAndLoadKey(&dev, &rsaKey, &storageKey.handle,
-            &publicTemplate, (byte*)gKeyAuth, sizeof(gKeyAuth)-1);
-        if (rc != 0) goto exit;
+    rc = wolfTPM2_GetKeyTemplate_RSA(&publicTemplate,
+                    TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
+                    TPMA_OBJECT_decrypt | TPMA_OBJECT_sign | TPMA_OBJECT_noDA);
+    if (rc != 0) goto exit;
 
-        /* Move this key into persistent storage */
-        rc = wolfTPM2_NVStoreKey(&dev, TPM_RH_OWNER, &rsaKey,
-            TPM2_DEMO_RSA_KEY_HANDLE);
-        if (rc != 0) goto exit;
-    }
-    else {
-        /* specify auth password for rsa key */
-        rsaKey.handle.auth.size = sizeof(gKeyAuth)-1;
-        XMEMCPY(rsaKey.handle.auth.buffer, gKeyAuth, rsaKey.handle.auth.size);
-    }
+    rc = getRSAkey(&dev,
+                   &storageKey,
+                   &rsaKey,
+                   NULL,
+                   tpmDevId,
+                   (byte*)gKeyAuth, sizeof(gKeyAuth)-1,
+                   &publicTemplate);
+    if (rc != 0) goto exit;
     wolfTPM2_SetAuthHandle(&dev, 0, &rsaKey.handle);
 
 

--- a/examples/tls/tls_server.c
+++ b/examples/tls/tls_server.c
@@ -130,6 +130,7 @@ int TPM2_TLS_ServerArgs(void* userCtx, int argc, char *argv[])
     int useECC = 0;
     TPM_ALG_ID paramEncAlg = TPM_ALG_NULL;
     WOLFTPM2_SESSION tpmSession;
+    TPMT_PUBLIC publicTemplate;
 
     /* initialize variables */
     XMEMSET(&storageKey, 0, sizeof(storageKey));
@@ -218,12 +219,17 @@ int TPM2_TLS_ServerArgs(void* userCtx, int argc, char *argv[])
 #ifndef NO_RSA
     if (!useECC) {
         /* Create/Load RSA key for TLS authentication */
+        rc = wolfTPM2_GetKeyTemplate_RSA(&publicTemplate,
+                    TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
+                    TPMA_OBJECT_decrypt | TPMA_OBJECT_sign | TPMA_OBJECT_noDA);
+        if (rc != 0) goto exit;
         rc = getRSAkey(&dev,
                     &storageKey,
                     &rsaKey,
                     &wolfRsaKey,
                     tpmDevId,
-                    (byte*)gKeyAuth, sizeof(gKeyAuth)-1);
+                    (byte*)gKeyAuth, sizeof(gKeyAuth)-1,
+                    &publicTemplate);
         if (rc != 0) goto exit;
     }
 #endif /* !NO_RSA */
@@ -231,12 +237,18 @@ int TPM2_TLS_ServerArgs(void* userCtx, int argc, char *argv[])
 #ifdef HAVE_ECC
     if (useECC) {
         /* Create/Load ECC key for TLS authentication */
+        rc = wolfTPM2_GetKeyTemplate_ECC(&publicTemplate,
+                TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
+                TPMA_OBJECT_sign | TPMA_OBJECT_noDA,
+                TPM_ECC_NIST_P256, TPM_ALG_ECDSA);
+        if (rc != 0) goto exit;
         rc = getECCkey(&dev,
                     &storageKey,
                     &eccKey,
                     &wolfEccKey,
                     tpmDevId,
-                    (byte*)gKeyAuth, sizeof(gKeyAuth)-1);
+                    (byte*)gKeyAuth, sizeof(gKeyAuth)-1,
+                    &publicTemplate);
         if (rc != 0) goto exit;
     }
 

--- a/examples/tpm_test_keys.h
+++ b/examples/tpm_test_keys.h
@@ -26,41 +26,46 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 
+WOLFTPM_LOCAL int readKeyBlob(const char* filename, WOLFTPM2_KEYBLOB* key);
+WOLFTPM_LOCAL int writeKeyBlob(const char* filename, WOLFTPM2_KEYBLOB* key);
+
+
+WOLFTPM_LOCAL int readAndLoadKey(WOLFTPM2_DEV* pDev,
+                          WOLFTPM2_KEY* key,
+                          WOLFTPM2_HANDLE* parent,
+                          const char* filename,
+                          const byte* auth,
+                          int authSz);
+
+WOLFTPM_LOCAL int createAndLoadKey(WOLFTPM2_DEV* pDev,
+                WOLFTPM2_KEY* key,
+                WOLFTPM2_HANDLE* parent,
+                const char* filename,
+                const byte* auth,
+                int authSz,
+                TPMT_PUBLIC* publicTemplate);
+
+
 WOLFTPM_LOCAL int getPrimaryStoragekey(WOLFTPM2_DEV* pDev,
                                        WOLFTPM2_KEY* pStorageKey,
                                        TPM_ALG_ID alg);
 
-#ifndef NO_RSA
-#ifdef WOLFTPM2_NO_WOLFCRYPT
 WOLFTPM_LOCAL int getRSAkey(WOLFTPM2_DEV* pDev,
                             WOLFTPM2_KEY* pStorageKey,
                             WOLFTPM2_KEY* key,
-                            const byte* auth, int authSz);
-#else
-WOLFTPM_LOCAL int getRSAkey(WOLFTPM2_DEV* pDev,
-                            WOLFTPM2_KEY* pStorageKey,
-                            WOLFTPM2_KEY* key,
-                            RsaKey* pWolfRsaKey,
+                            void* pWolfRsaKey,
                             int tpmDevId,
-                            const byte* auth, int authSz);
-#endif /* WOLFTPM2_NO_WOLFCRYPT */
-#endif
+                            const byte* auth, int authSz,
+                            TPMT_PUBLIC* publicTemplate);
 
-#ifdef HAVE_ECC
-#ifdef WOLFTPM2_NO_WOLFCRYPT
 WOLFTPM_LOCAL int getECCkey(WOLFTPM2_DEV* pDev,
                             WOLFTPM2_KEY* pStorageKey,
                             WOLFTPM2_KEY* key,
-                            const byte* auth, int authSz);
-#else
-WOLFTPM_LOCAL int getECCkey(WOLFTPM2_DEV* pDev,
-                            WOLFTPM2_KEY* pStorageKey,
-                            WOLFTPM2_KEY* key,
-                            ecc_key* pWolfEccKey,
+                            void* pWolfEccKey,
                             int tpmDevId,
-                            const byte* auth, int authSz);
-#endif
-#endif
+                            const byte* auth, int authSz,
+                            TPMT_PUBLIC* publicTemplate);
 
 #endif /* !WOLFTPM2_NO_WRAPPER */
+
 #endif /* _TPM_TEST_KEYS_H_ */

--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -410,6 +410,7 @@ void TPM2_Packet_AppendSymmetric(TPM2_Packet* packet, TPMT_SYM_DEF* symmetric)
 }
 void TPM2_Packet_ParseSymmetric(TPM2_Packet* packet, TPMT_SYM_DEF* symmetric)
 {
+    XMEMSET(symmetric, 0, sizeof(TPMT_SYM_DEF));
     TPM2_Packet_ParseU16(packet, &symmetric->algorithm);
     switch (symmetric->algorithm) {
         case TPM_ALG_XOR:


### PR DESCRIPTION
The PKCS7 example is failing because of a key mismatch between the TPM private key and the public key used in the certificate setup using the CSR and ./certs/certreq/sh`.

ZD 11163