### PR TITLE
Add support for LetsTrust TPM2.0 on USB stick

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -213,6 +213,22 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_WINAPI"
 fi
 
+# LetsTrust TPM2.0 on UBS stick / Cypress USB2SPI Support
+AC_ARG_ENABLE([cyusb],
+    [AS_HELP_STRING([--enable-cyusb],[Enable use of TPM through a Cypress USB2SPI bridge (default: disabled)])],
+    [ ENABLED_CYUSB=$enableval ],
+    [ ENABLED_CYUSB=no ]
+    )
+
+if test "x$ENABLED_CYUSB" = "xyes"
+then
+    if test "x$ENABLED_DEVTPM" = "xyes"
+    then
+        AC_MSG_ERROR([Cannot enable both cyusb and devtpm])
+    fi
+
+    AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_CYUSB"
+fi
 
 # STM ST33 Support
 AC_ARG_ENABLE([st33],,
@@ -354,6 +370,7 @@ AM_CONDITIONAL([BUILD_INFINEON], [test "x$ENABLED_INFINEON" = "xyes"])
 AM_CONDITIONAL([BUILD_DEVTPM], [test "x$ENABLED_DEVTPM" = "xyes"])
 AM_CONDITIONAL([BUILD_SWTPM], [test "x$ENABLED_SWTPM" = "xyes"])
 AM_CONDITIONAL([BUILD_WINAPI], [test "x$ENABLED_WINAPI" = "xyes"])
+AM_CONDITIONAL([BUILD_CYUSB], [test "x$ENABLED_CYUSB" = "xyes"])
 AM_CONDITIONAL([BUILD_NUVOTON], [test "x$ENABLED_NUVOTON" = "xyes"])
 AM_CONDITIONAL([BUILD_CHECKWAITSTATE], [test "x$ENABLED_CHECKWAITSTATE" = "xyes"])
 AM_CONDITIONAL([BUILD_AUTODETECT], [test "x$ENABLED_AUTODETECT" = "xyes"])
@@ -474,6 +491,7 @@ echo "   * I2C:                       $ENABLED_I2C"
 echo "   * Linux kernel TPM device:   $ENABLED_DEVTPM"
 echo "   * SWTPM:                     $ENABLED_SWTPM"
 echo "   * WINAPI:                    $ENABLED_WINAPI"
+echo "   * CYUSB/LetsTrust USB2GO:    $ENABLED_CYUSB"
 echo "   * TIS/SPI Check Wait State:  $ENABLED_CHECKWAITSTATE"
 
 echo "   * Infineon SLB9670           $ENABLED_INFINEON"

--- a/examples/tpm_io.c
+++ b/examples/tpm_io.c
@@ -32,7 +32,8 @@
 /******************************************************************************/
 #if ! (defined(WOLFTPM_LINUX_DEV) || \
        defined(WOLFTPM_SWTPM) ||     \
-       defined(WOLFTPM_WINAPI) )
+       defined(WOLFTPM_WINAPI) ||    \
+       defined(WOLFTPM_CYUSB) )
 
 /* Configuration for the SPI interface */
 /* SPI Requirement: Mode 0 (CPOL=0, CPHA=0) */
@@ -864,7 +865,7 @@ int TPM2_IoCb(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
 }
 
 #endif /* WOLFTPM_ADV_IO */
-#endif /* !(WOLFTPM_LINUX_DEV || WOLFTPM_SWTPM || WOLFTPM_WINAPI) */
+#endif /* !(WOLFTPM_LINUX_DEV || WOLFTPM_SWTPM || WOLFTPM_WINAPI || WOLFTPM_CYUSB) */
 
 /******************************************************************************/
 /* --- END IO Callback Logic -- */

--- a/examples/tpm_io.h
+++ b/examples/tpm_io.h
@@ -29,7 +29,7 @@
 #endif
 
 /* TPM2 IO Examples */
-#if defined(WOLFTPM_LINUX_DEV) || defined(WOLFTPM_SWTPM) || defined(WOLFTPM_WINAPI)
+#if defined(WOLFTPM_LINUX_DEV) || defined(WOLFTPM_SWTPM) || defined(WOLFTPM_WINAPI) || defined(WOLFTPM_CYUSB)
 #define TPM2_IoCb NULL
 #else
 

--- a/src/include.am
+++ b/src/include.am
@@ -21,6 +21,10 @@ if BUILD_WINAPI
 src_libwolftpm_la_SOURCES      += src/tpm2_winapi.c
 src_libwolftpm_la_LIBADD       = -ltbs
 endif
+if BUILD_CYUSB
+src_libwolftpm_la_SOURCES      += src/tpm2_cyusb.c
+src_libwolftpm_la_LIBADD       = -lcyusbserial
+endif
 
 src_libwolftpm_la_CFLAGS       = $(src_libwolftpm_la_EXTRAS) -DBUILDING_WOLFTPM $(AM_CFLAGS)
 src_libwolftpm_la_CPPFLAGS     = -DBUILDING_WOLFTPM $(AM_CPPFLAGS)

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -578,7 +578,7 @@ TPM_RC TPM2_Init_ex(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx,
     ctx->tcpCtx.fd = -1;
 #endif
 
-    #if defined(WOLFTPM_LINUX_DEV) || defined(WOLFTPM_SWTPM) || defined(WOLFTPM_WINAPI)
+    #if defined(WOLFTPM_LINUX_DEV) || defined(WOLFTPM_SWTPM) || defined(WOLFTPM_WINAPI) || defined(WOLFTPM_CYUSB)
     if (ioCb != NULL || userCtx != NULL) {
         return BAD_FUNC_ARG;
     }

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -26,6 +26,7 @@
 #include <wolftpm/tpm2_linux.h>
 #include <wolftpm/tpm2_swtpm.h>
 #include <wolftpm/tpm2_winapi.h>
+#include <wolftpm/tpm2_cyusb.h>
 #include <wolftpm/tpm2_param_enc.h>
 
 /******************************************************************************/
@@ -46,6 +47,9 @@ static volatile int gWolfCryptRefCount = 0;
 #elif defined(WOLFTPM_WINAPI)
 #define INTERNAL_SEND_COMMAND      TPM2_WinApi_SendCommand
 #define TPM2_INTERNAL_CLEANUP(ctx) TPM2_WinApi_Cleanup(ctx)
+#elif defined(WOLFTPM_CYUSB)
+#define INTERNAL_SEND_COMMAND      TPM2_CYUSB_SendCommand
+#define TPM2_INTERNAL_CLEANUP(ctx)
 #else
 #define INTERNAL_SEND_COMMAND      TPM2_TIS_SendCommand
 #define TPM2_INTERNAL_CLEANUP(ctx)

--- a/src/tpm2_cyusb.c
+++ b/src/tpm2_cyusb.c
@@ -1,0 +1,106 @@
+/* tpm2_cyusb.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+#ifdef WOLFTPM_CYUSB
+#include <wolftpm/tpm2_cyusb.h>
+#include <wolftpm/tpm2_packet.h>
+#include <wolftpm/tpm2_wrap.h>
+/* TODO figure out instructions for acquiring Cypress libusb */
+#include "../usb2go/cylib/common/header/CyUSBSerial.h"
+
+
+/* Support a single TPM using Cypress UBS */
+#ifndef TPM2_CYUSB_NUMBER
+#define TPM2_CYUSB_NUMBER 0
+#endif
+
+/* LetsTrust USB2GO TPM2.0 stick has SPI as interface zero(0) */
+#ifndef TPM2_CYUSB_INTERFACE
+#define TPM2_CYUSB_INTERFACE 0
+#endif
+
+/* Talk to a TPM device through the Cypress USB2SPI converter and libusb */
+int TPM2_CYUSB_SendCommand(TPM2_CTX* ctx, TPM2_Packet* packet)
+{
+    int rc = TPM_RC_FAILURE;
+    BYTE numberOfDevices;
+    CY_RETURN_STATUS rStatus;
+    CY_HANDLE handle;
+    CY_DATA_BUFFER writeBuf, readBuf;
+    int deviceNumber = TPM2_CYUSB_NUMBER;
+    int interfaceNumber=TPM2_CYUSB_INTERFACE;
+
+#ifdef WOLFTPM_DEBUG_VERBOSE
+    printf("Command size: %d\n", packet->pos);
+    TPM2_PrintBin(packet->buf, packet->pos);
+#endif
+
+    rStatus = CyLibraryInit();
+    if (rStatus != CY_SUCCESS) {
+        printf("CYUSB: Cypress USB library init failed ERRNO=%d\n", rStatus);
+    }
+    else {
+        rStatus = CyGetListofDevices(&numberOfDevices);
+        if (rStatus != CY_SUCCESS) {
+            printf("CYUSB: Unable to get the list of devices ERRNO=%d\n", rStatus);
+        }
+        else if (numberOfDevices > 1) {
+            printf("wolfTPM: Multiple TPM USB devices detected\n");
+            printf("wolfTPM: Leave only one TPM USB stick and try again.\n");
+        }
+        else {
+            rStatus = CyOpen(deviceNumber, interfaceNumber, &handle);
+            if (rStatus != CY_SUCCESS) {
+                printf("CYUSB: Unable to open the UBS device ERRNO=%d\n", rStatus);
+            }
+
+            writeBuf.length = packet->pos;
+            writeBuf.buffer = packet->buf;
+            /* TODO: Confirm the Cypress library can safely use one buffer */
+            readBuf.buffer = packet->buf;
+
+            /* Send the TPM command over the Cypress USB channel */
+            CySpiReadWrite(handle, &readBuf, &writeBuf, 5000);
+
+            /* The caller parses the TPM_Packet for correctness */
+            if (readBuf.transferCount >= TPM2_HEADER_SIZE) {
+               /* Enough bytes for a TPM response */
+               packet->pos = readBuf.transferCount;
+               rc = TPM_RC_SUCCESS;
+            }
+
+            CyClose(handle);
+        }
+    }
+
+#ifdef WOLFTPM_DEBUG_VERBOSE
+    if (rspSz > 0) {
+        printf("Response size: %d\n", (int)rspSz);
+        TPM2_PrintBin(packet->buf, rspSz);
+    }
+#endif
+
+    (void)ctx;
+
+    return rc;
+}
+#endif

--- a/src/tpm2_cyusb.c
+++ b/src/tpm2_cyusb.c
@@ -24,30 +24,91 @@
 #include <wolftpm/tpm2_cyusb.h>
 #include <wolftpm/tpm2_packet.h>
 #include <wolftpm/tpm2_wrap.h>
-/* TODO figure out instructions for acquiring Cypress libusb */
+/* TODO figure out a good way for acquiring and including the Cypress libusb */
 #include "../usb2go/cylib/common/header/CyUSBSerial.h"
 
-
-/* Support a single TPM using Cypress UBS */
-#ifndef TPM2_CYUSB_NUMBER
-#define TPM2_CYUSB_NUMBER 0
-#endif
 
 /* LetsTrust USB2GO TPM2.0 stick has SPI as interface zero(0) */
 #ifndef TPM2_CYUSB_INTERFACE
 #define TPM2_CYUSB_INTERFACE 0
 #endif
 
+#define TPM2_CYUSB_RC_NODEVICE (-1)
+#define TPM2_CYUSB_SIGNATURE_LENGTH 6
+
+/* Helper function to check Cypress magic value(signature */
+static int TPM2_CYUSB_VerifySignature(int deviceNumber)
+{
+    int rc = FALSE;
+    CY_HANDLE handle;
+    CY_RETURN_STATUS rStatus;
+    BYTE signature[TPM2_CYUSB_SIGNATURE_LENGTH];
+
+    rStatus = CyOpen(deviceNumber, TPM2_CYUSB_INTERFACE, &handle);
+    if (rStatus == CY_SUCCESS) {
+        rStatus = CyGetSignature(handle, signature);
+
+        rc = (rStatus == CY_SUCCESS) ? TRUE : FALSE;
+
+        CyClose (handle);
+    }
+
+    return rc;
+}
+
+
+/* Helper function to find a Cypress USB2SPI device
+ *
+ * Matches Cypress signature, device class and interface type
+ *
+ * Return value
+ * On success, the number of the device on the UBS bus
+ * On failure, TPM2_CYUSB_RC_NODEVICE is returned
+ */
+static int TPM2_CYUSB_FindDevice(int* deviceNumber) {
+    int devNum = TPM2_CYUSB_RC_NODEVICE;
+    BYTE deviceCount;
+    CY_DEVICE_INFO deviceInfo;
+    CY_RETURN_STATUS rStatus;
+
+    rStatus = CyGetListofDevices(&deviceCount);
+    if (rStatus != CY_SUCCESS) {
+        printf("CYUSB: Unable to get the list of devices ERRNO=%d\n", rStatus);
+        return TPM_RC_FAILURE;
+    }
+
+#ifdef DEBUG_WOLFTPM
+     printf("The first USB2SPI device found is tried as TPM2.0 on USB\n");
+#endif
+
+    for(devNum=0; devNum < deviceCount; devNum++) {
+        rStatus = CyGetDeviceInfo (devNum, &deviceInfo);
+        if (!rStatus) {
+            /* Verify magic Cypress value(signature) */
+            if (!TPM2_CYUSB_VerifySignature(devNum)) {
+                continue;
+            }
+            /* Verify this is indeed a Cypress UBS bridge for SPI */
+            if (deviceInfo.deviceClass[TPM2_CYUSB_INTERFACE] == CY_CLASS_VENDOR) {
+                if(deviceInfo.deviceType[TPM2_CYUSB_INTERFACE] == CY_TYPE_SPI) {
+                    break;
+                }
+            }
+        }
+    }
+
+    *deviceNumber = devNum;
+    return TPM_RC_SUCCESS;
+}
+
 /* Talk to a TPM device through the Cypress USB2SPI converter and libusb */
 int TPM2_CYUSB_SendCommand(TPM2_CTX* ctx, TPM2_Packet* packet)
 {
     int rc = TPM_RC_FAILURE;
-    BYTE numberOfDevices;
     CY_RETURN_STATUS rStatus;
     CY_HANDLE handle;
     CY_DATA_BUFFER writeBuf, readBuf;
-    int deviceNumber = TPM2_CYUSB_NUMBER;
-    int interfaceNumber=TPM2_CYUSB_INTERFACE;
+    int deviceNumber;
 
 #ifdef WOLFTPM_DEBUG_VERBOSE
     printf("Command size: %d\n", packet->pos);
@@ -57,22 +118,19 @@ int TPM2_CYUSB_SendCommand(TPM2_CTX* ctx, TPM2_Packet* packet)
     rStatus = CyLibraryInit();
     if (rStatus != CY_SUCCESS) {
         printf("CYUSB: Cypress USB library init failed ERRNO=%d\n", rStatus);
+        return rc;
+    }
+
+    rc = TPM2_CYUSB_FindDevice(&deviceNumber);
+    if (rc != TPM_RC_SUCCESS || deviceNumber == TPM2_CYUSB_RC_NODEVICE) {
+        printf("No matching UBS device found\n");
     }
     else {
-        rStatus = CyGetListofDevices(&numberOfDevices);
+        rStatus = CyOpen(deviceNumber, TPM2_CYUSB_INTERFACE, &handle);
         if (rStatus != CY_SUCCESS) {
-            printf("CYUSB: Unable to get the list of devices ERRNO=%d\n", rStatus);
-        }
-        else if (numberOfDevices > 1) {
-            printf("wolfTPM: Multiple TPM USB devices detected\n");
-            printf("wolfTPM: Leave only one TPM USB stick and try again.\n");
+            printf("CYUSB: Unable to open the UBS device ERRNO=%d\n", rStatus);
         }
         else {
-            rStatus = CyOpen(deviceNumber, interfaceNumber, &handle);
-            if (rStatus != CY_SUCCESS) {
-                printf("CYUSB: Unable to open the UBS device ERRNO=%d\n", rStatus);
-            }
-
             writeBuf.length = packet->pos;
             writeBuf.buffer = packet->buf;
             /* TODO: Confirm the Cypress library can safely use one buffer */
@@ -87,10 +145,11 @@ int TPM2_CYUSB_SendCommand(TPM2_CTX* ctx, TPM2_Packet* packet)
                packet->pos = readBuf.transferCount;
                rc = TPM_RC_SUCCESS;
             }
-
             CyClose(handle);
         }
     }
+
+    CyLibraryExit();
 
 #ifdef WOLFTPM_DEBUG_VERBOSE
     if (rspSz > 0) {

--- a/src/tpm2_cyusb.c
+++ b/src/tpm2_cyusb.c
@@ -137,7 +137,8 @@ int TPM2_CYUSB_SendCommand(TPM2_CTX* ctx, TPM2_Packet* packet)
             readBuf.buffer = packet->buf;
 
             /* Send the TPM command over the Cypress USB channel */
-            CySpiReadWrite(handle, &readBuf, &writeBuf, 5000);
+            rStatus = CySpiReadWrite(handle, &readBuf, &writeBuf, 5000);
+            printf("CYUSB: Unable to write to the TPM2.0 on USB ERRNO=%d\n", rStatus);
 
             /* The caller parses the TPM_Packet for correctness */
             if (readBuf.transferCount >= TPM2_HEADER_SIZE) {

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -50,7 +50,7 @@ static int wolfTPM2_Init_ex(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx,
     if (ctx == NULL)
         return BAD_FUNC_ARG;
 
-#if defined(WOLFTPM_LINUX_DEV) || defined(WOLFTPM_SWTPM) || defined(WOLFTPM_WINAPI)
+#if defined(WOLFTPM_LINUX_DEV) || defined(WOLFTPM_SWTPM) || defined(WOLFTPM_WINAPI) || defined(WOLFTPM_CYUSB)
     rc = TPM2_Init_minimal(ctx);
     /* Using standard file I/O for the Linux TPM device */
     (void)ioCb;

--- a/wolftpm/include.am
+++ b/wolftpm/include.am
@@ -11,6 +11,7 @@ nobase_include_HEADERS+= \
                          wolftpm/tpm2_linux.h \
                          wolftpm/tpm2_swtpm.h \
                          wolftpm/tpm2_winapi.h \
+                         wolftpm/tpm2_cyusb.h \
                          wolftpm/tpm2_param_enc.h \
                          wolftpm/tpm2_socket.h \
                          wolftpm/version.h \

--- a/wolftpm/tpm2_cyusb.h
+++ b/wolftpm/tpm2_cyusb.h
@@ -1,0 +1,39 @@
+/* tpm2_cyusb.h
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef _TPM2_CYUSB_H_
+#define _TPM2_CYUSB_H_
+
+#include <wolftpm/tpm2.h>
+#include <wolftpm/tpm2_packet.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+/* TPM2 IO for using TPM through a Cypress USB2SPI converter */
+WOLFTPM_LOCAL int TPM2_CYUSB_SendCommand(TPM2_CTX* ctx, TPM2_Packet* packet);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* _TPM2_CYUSB_H_ */


### PR DESCRIPTION
LetsTrust USB2GO uses Cypress USB2SPI bridge that requires (Cypress) libusb.

Signed-off-by: Dimitar Tomov <dimi@wolfssl.com>