### PR TITLE
Fix typo on WOLFTPM_USER_SETTINGS ifdef

### DIFF
--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -29,7 +29,7 @@
 #include <wolftpm/visibility.h>
 #include <stdint.h>
 
-#ifdef WOLFTPM_USER_SETTINGS
+#ifndef WOLFTPM_USER_SETTINGS
     /* use generated options.h or a custom one */
     #include <wolftpm/options.h>
 #endif


### PR DESCRIPTION
I stumbled upon this when testing my measured-boot example.

POSIX options.h is used when USER_SETTINGS are not available.

Thanks to @danielinux for confirming this issue.