### PR TITLE
Add STM32 CubeMX I2C support

### DIFF
--- a/IDE/OPENSTM32/Inc/user_settings.h
+++ b/IDE/OPENSTM32/Inc/user_settings.h
@@ -22,8 +22,8 @@ extern "C" {
 #undef  WOLFSSL_STM32F4
 #define WOLFSSL_STM32F4
 
-#undef  WOLFSSL_STM32_CUBEMX_SPI
-#define WOLFSSL_STM32_CUBEMX_SPI
+#undef  WOLFSSL_STM32_CUBEMX
+#define WOLFSSL_STM32_CUBEMX
 
 /* Optionally Disable Hardware Hashing Support */
 //#define NO_STM32_HASH

--- a/IDE/OPENSTM32/Inc/user_settings.h
+++ b/IDE/OPENSTM32/Inc/user_settings.h
@@ -22,8 +22,8 @@ extern "C" {
 #undef  WOLFSSL_STM32F4
 #define WOLFSSL_STM32F4
 
-#undef  WOLFTPM_STM32_CUBEMX_SPI
-#define WOLFTPM_STM32_CUBEMX_SPI
+#undef  WOLFSSL_STM32_CUBEMX_SPI
+#define WOLFSSL_STM32_CUBEMX_SPI
 
 /* Optionally Disable Hardware Hashing Support */
 //#define NO_STM32_HASH

--- a/IDE/OPENSTM32/Inc/user_settings.h
+++ b/IDE/OPENSTM32/Inc/user_settings.h
@@ -22,8 +22,8 @@ extern "C" {
 #undef  WOLFSSL_STM32F4
 #define WOLFSSL_STM32F4
 
-#undef  WOLFSSL_STM32_CUBEMX_SPI
-#define WOLFSSL_STM32_CUBEMX_SPI
+#undef  WOLFTPM_STM32_CUBEMX_SPI
+#define WOLFTPM_STM32_CUBEMX_SPI
 
 /* Optionally Disable Hardware Hashing Support */
 //#define NO_STM32_HASH

--- a/IDE/OPENSTM32/Inc/user_settings.h
+++ b/IDE/OPENSTM32/Inc/user_settings.h
@@ -22,8 +22,8 @@ extern "C" {
 #undef  WOLFSSL_STM32F4
 #define WOLFSSL_STM32F4
 
-#undef  WOLFSSL_STM32_CUBEMX
-#define WOLFSSL_STM32_CUBEMX
+#undef  WOLFSSL_STM32_CUBEMX_SPI
+#define WOLFSSL_STM32_CUBEMX_SPI
 
 /* Optionally Disable Hardware Hashing Support */
 //#define NO_STM32_HASH

--- a/examples/tpm_io.c
+++ b/examples/tpm_io.c
@@ -89,8 +89,10 @@
         #endif
     #endif
 
+#elif defined(WOLFSSL_STM32_CUBEMX_I2C)
+    #define TPM2_I2C_ADDR 0x2e
 
-#elif defined(WOLFSSL_STM32_CUBEMX)
+#elif defined(WOLFSSL_STM32_CUBEMX_SPI)
 
 #elif defined(WOLFSSL_ATMEL)
     #include "asf.h"
@@ -323,8 +325,74 @@
     }
 #endif /* WOLFTPM_I2C */
 
-#elif defined(WOLFSSL_STM32_CUBEMX)
-    /* STM32 CubeMX Hal */
+#elif defined(WOLFSSL_STM32_CUBEMX_I2C)
+    /* STM32 CubeMX HAL I2C */
+    #define STM32_CUBEMX_I2C_TIMEOUT 250
+    static int i2c_read(void* userCtx, word32 reg, byte* data, int len)
+    {
+        int rc;
+        int i2cAddr = (TPM2_I2C_ADDR << 1) | 0x01; /* For I2C read LSB is 1 */
+        byte buf[MAX_SPI_FRAMESIZE+1];
+        I2C_HandleTypeDef* hi2c = (I2C_HandleTypeDef*)userCtx;
+
+        /* TIS layer should never provide a buffer larger than this,
+           but double check for good coding practice */
+        if (len > MAX_SPI_FRAMESIZE)
+            return BAD_FUNC_ARG;
+
+        buf[0] = (reg & 0xFF);
+        rc = HAL_I2C_Master_Receive(&hi2c, i2cAddr, data, len, STM32_CUBEMX_I2C_TIMEOUT);
+
+        if (rc != -1) {
+            XMEMCPY(data, buf+1, len);
+            return TPM_RC_SUCCESS;
+        }
+
+        return TPM_RC_FAILURE;
+    }
+
+    static int i2c_write(void* userCtx, word32 reg, byte* data, int len)
+    {
+        int rc;
+        int i2cAddr = (TPM2_I2C_ADDR << 1); /* I2C write operation, LSB is 0 */
+        byte buf[MAX_SPI_FRAMESIZE+1];
+        I2C_HandleTypeDef* hi2c = (I2C_HandleTypeDef*)userCtx;
+
+        /* TIS layer should never provide a buffer larger than this,
+           but double check for good coding practice */
+        if (len > MAX_SPI_FRAMESIZE)
+            return BAD_FUNC_ARG;
+
+        buf[0] = (reg & 0xFF); /* TPM register address */
+        XMEMCPY(buf + 1, data, len);
+        rc = HAL_I2C_Master_Transmit(&hi2c, TPM2_I2C_ADDR << 1, buf, len);
+
+        if (rc != -1) {
+            return TPM_RC_SUCCESS;
+        }
+
+        return TPM_RC_FAILURE;
+    }
+
+    static int TPM2_IoCb_STCubeMX_I2C(TPM2_CTX* ctx, int isRead, word32 addr,
+        byte* buf, word16 size, void* userCtx)
+    {
+        int ret = TPM_RC_FAILURE;
+
+        if (userCtx != NULL) {
+            if (isRead)
+                ret = i2c_read(userCtx, addr, buf, size);
+            else
+                ret = i2c_write(userCtx, addr, buf, size);
+        }
+
+        (void)ctx;
+
+        return ret;
+    } /* WOLFSSL_STM32_CUBEMX_SPI */
+
+#elif defined(WOLFSSL_STM32_CUBEMX_SPI)
+    /* STM32 CubeMX Hal SPI */
     #define STM32_CUBEMX_SPI_TIMEOUT 250
     static int TPM2_IoCb_STCubeMX_SPI(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
         word16 xferSz, void* userCtx)
@@ -396,7 +464,7 @@
         (void)ctx;
 
         return ret;
-    }
+    } /* WOLFSSL_STM32_CUBEMX_SPI */
 
 #elif defined(WOLFSSL_ATMEL)
     /* Atmel ASF */
@@ -772,7 +840,7 @@ int TPM2_IoCb(TPM2_CTX* ctx, int isRead, word32 addr, byte* buf, word16 size,
     void* userCtx)
 {
     int ret = TPM_RC_FAILURE;
-#ifndef WOLFTPM_I2C
+#if !defined(WOLFTPM_I2C) && !defined(WOLFSSL_STM32_CUBEMX_I2C)
     byte txBuf[MAX_SPI_FRAMESIZE+TPM_TIS_HEADER_SZ];
     byte rxBuf[MAX_SPI_FRAMESIZE+TPM_TIS_HEADER_SZ];
 #endif
@@ -799,6 +867,9 @@ int TPM2_IoCb(TPM2_CTX* ctx, int isRead, word32 addr, byte* buf, word16 size,
         (void)size;
         (void)userCtx;
     #endif
+#elif defined(WOLFSSL_STM32_CUBEMX_I2C)
+    /* Use STM32 CubeMX HAL for I2C */
+    ret = TPM2_IoCb_STCubeMX_I2C(ctx, isRead, addr, buf, size, userCtx);
 #else
     /* Build SPI format buffer */
     if (isRead) {

--- a/examples/tpm_io.c
+++ b/examples/tpm_io.c
@@ -89,10 +89,10 @@
         #endif
     #endif
 
-#elif defined(WOLFTPM_STM32_CUBEMX_I2C)
+#elif defined(WOLFSSL_STM32_CUBEMX_I2C)
     #define TPM2_I2C_ADDR 0x2e
 
-#elif defined(WOLFTPM_STM32_CUBEMX_SPI)
+#elif defined(WOLFSSL_STM32_CUBEMX_SPI)
 
 #elif defined(WOLFSSL_ATMEL)
     #include "asf.h"
@@ -325,7 +325,7 @@
     }
 #endif /* WOLFTPM_I2C */
 
-#elif defined(WOLFTPM_STM32_CUBEMX_I2C)
+#elif defined(WOLFSSL_STM32_CUBEMX_I2C)
     /* STM32 CubeMX HAL I2C */
     #define STM32_CUBEMX_I2C_TIMEOUT 250
     static int i2c_read(void* userCtx, word32 reg, byte* data, int len)
@@ -389,9 +389,9 @@
         (void)ctx;
 
         return ret;
-    } /* WOLFTPM_STM32_CUBEMX_SPI */
+    } /* WOLFSSL_STM32_CUBEMX_SPI */
 
-#elif defined(WOLFTPM_STM32_CUBEMX_SPI)
+#elif defined(WOLFSSL_STM32_CUBEMX_SPI)
     /* STM32 CubeMX Hal SPI */
     #define STM32_CUBEMX_SPI_TIMEOUT 250
     static int TPM2_IoCb_STCubeMX_SPI(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
@@ -464,7 +464,7 @@
         (void)ctx;
 
         return ret;
-    } /* WOLFTPM_STM32_CUBEMX_SPI */
+    } /* WOLFSSL_STM32_CUBEMX_SPI */
 
 #elif defined(WOLFSSL_ATMEL)
     /* Atmel ASF */
@@ -810,7 +810,7 @@ static int TPM2_IoCb_SPI(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
 
 #if defined(__linux__)
     ret = TPM2_IoCb_Linux_SPI(ctx, txBuf, rxBuf, xferSz, userCtx);
-#elif defined(WOLFTPM_STM32_CUBEMX)
+#elif defined(WOLFSSL_STM32_CUBEMX)
     ret = TPM2_IoCb_STCubeMX_SPI(ctx, txBuf, rxBuf, xferSz, userCtx);
 #elif defined(WOLFSSL_ATMEL)
     ret = TPM2_IoCb_Atmel_SPI(ctx, txBuf, rxBuf, xferSz, userCtx);
@@ -840,7 +840,7 @@ int TPM2_IoCb(TPM2_CTX* ctx, int isRead, word32 addr, byte* buf, word16 size,
     void* userCtx)
 {
     int ret = TPM_RC_FAILURE;
-#if !defined(WOLFTPM_I2C) && !defined(WOLFTPM_STM32_CUBEMX_I2C)
+#if !defined(WOLFTPM_I2C) && !defined(WOLFSSL_STM32_CUBEMX_I2C)
     byte txBuf[MAX_SPI_FRAMESIZE+TPM_TIS_HEADER_SZ];
     byte rxBuf[MAX_SPI_FRAMESIZE+TPM_TIS_HEADER_SZ];
 #endif
@@ -867,7 +867,7 @@ int TPM2_IoCb(TPM2_CTX* ctx, int isRead, word32 addr, byte* buf, word16 size,
         (void)size;
         (void)userCtx;
     #endif
-#elif defined(WOLFTPM_STM32_CUBEMX_I2C)
+#elif defined(WOLFSSL_STM32_CUBEMX_I2C)
     /* Use STM32 CubeMX HAL for I2C */
     ret = TPM2_IoCb_STCubeMX_I2C(ctx, isRead, addr, buf, size, userCtx);
 #else

--- a/examples/tpm_io.c
+++ b/examples/tpm_io.c
@@ -89,10 +89,10 @@
         #endif
     #endif
 
-#elif defined(WOLFSSL_STM32_CUBEMX_I2C)
+#elif defined(WOLFTPM_STM32_CUBEMX_I2C)
     #define TPM2_I2C_ADDR 0x2e
 
-#elif defined(WOLFSSL_STM32_CUBEMX_SPI)
+#elif defined(WOLFTPM_STM32_CUBEMX_SPI)
 
 #elif defined(WOLFSSL_ATMEL)
     #include "asf.h"
@@ -325,7 +325,7 @@
     }
 #endif /* WOLFTPM_I2C */
 
-#elif defined(WOLFSSL_STM32_CUBEMX_I2C)
+#elif defined(WOLFTPM_STM32_CUBEMX_I2C)
     /* STM32 CubeMX HAL I2C */
     #define STM32_CUBEMX_I2C_TIMEOUT 250
     static int i2c_read(void* userCtx, word32 reg, byte* data, int len)
@@ -389,9 +389,9 @@
         (void)ctx;
 
         return ret;
-    } /* WOLFSSL_STM32_CUBEMX_SPI */
+    } /* WOLFTPM_STM32_CUBEMX_SPI */
 
-#elif defined(WOLFSSL_STM32_CUBEMX_SPI)
+#elif defined(WOLFTPM_STM32_CUBEMX_SPI)
     /* STM32 CubeMX Hal SPI */
     #define STM32_CUBEMX_SPI_TIMEOUT 250
     static int TPM2_IoCb_STCubeMX_SPI(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
@@ -464,7 +464,7 @@
         (void)ctx;
 
         return ret;
-    } /* WOLFSSL_STM32_CUBEMX_SPI */
+    } /* WOLFTPM_STM32_CUBEMX_SPI */
 
 #elif defined(WOLFSSL_ATMEL)
     /* Atmel ASF */
@@ -810,7 +810,7 @@ static int TPM2_IoCb_SPI(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
 
 #if defined(__linux__)
     ret = TPM2_IoCb_Linux_SPI(ctx, txBuf, rxBuf, xferSz, userCtx);
-#elif defined(WOLFSSL_STM32_CUBEMX)
+#elif defined(WOLFTPM_STM32_CUBEMX)
     ret = TPM2_IoCb_STCubeMX_SPI(ctx, txBuf, rxBuf, xferSz, userCtx);
 #elif defined(WOLFSSL_ATMEL)
     ret = TPM2_IoCb_Atmel_SPI(ctx, txBuf, rxBuf, xferSz, userCtx);
@@ -840,7 +840,7 @@ int TPM2_IoCb(TPM2_CTX* ctx, int isRead, word32 addr, byte* buf, word16 size,
     void* userCtx)
 {
     int ret = TPM_RC_FAILURE;
-#if !defined(WOLFTPM_I2C) && !defined(WOLFSSL_STM32_CUBEMX_I2C)
+#if !defined(WOLFTPM_I2C) && !defined(WOLFTPM_STM32_CUBEMX_I2C)
     byte txBuf[MAX_SPI_FRAMESIZE+TPM_TIS_HEADER_SZ];
     byte rxBuf[MAX_SPI_FRAMESIZE+TPM_TIS_HEADER_SZ];
 #endif
@@ -867,7 +867,7 @@ int TPM2_IoCb(TPM2_CTX* ctx, int isRead, word32 addr, byte* buf, word16 size,
         (void)size;
         (void)userCtx;
     #endif
-#elif defined(WOLFSSL_STM32_CUBEMX_I2C)
+#elif defined(WOLFTPM_STM32_CUBEMX_I2C)
     /* Use STM32 CubeMX HAL for I2C */
     ret = TPM2_IoCb_STCubeMX_I2C(ctx, isRead, addr, buf, size, userCtx);
 #else

--- a/examples/tpm_io.c
+++ b/examples/tpm_io.c
@@ -89,10 +89,10 @@
         #endif
     #endif
 
-#elif defined(WOLFSSL_STM32_CUBEMX_I2C)
-    #define TPM2_I2C_ADDR 0x2e
-
-#elif defined(WOLFSSL_STM32_CUBEMX_SPI)
+#elif defined(WOLFSSL_STM32_CUBEMX)
+    #ifdef WOLFTPM_I2C
+        #define TPM2_I2C_ADDR 0x2e
+    #endif
 
 #elif defined(WOLFSSL_ATMEL)
     #include "asf.h"
@@ -325,7 +325,8 @@
     }
 #endif /* WOLFTPM_I2C */
 
-#elif defined(WOLFSSL_STM32_CUBEMX_I2C)
+#elif defined(WOLFSSL_STM32_CUBEMX)
+    #ifdef WOLFTPM_I2C
     /* STM32 CubeMX HAL I2C */
     #define STM32_CUBEMX_I2C_TIMEOUT 250
     static int i2c_read(void* userCtx, word32 reg, byte* data, int len)
@@ -389,10 +390,9 @@
         (void)ctx;
 
         return ret;
-    } /* WOLFSSL_STM32_CUBEMX_SPI */
+    }
 
-#elif defined(WOLFSSL_STM32_CUBEMX_SPI)
-    /* STM32 CubeMX Hal SPI */
+    #else /* STM32 CubeMX Hal SPI */
     #define STM32_CUBEMX_SPI_TIMEOUT 250
     static int TPM2_IoCb_STCubeMX_SPI(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
         word16 xferSz, void* userCtx)
@@ -464,7 +464,8 @@
         (void)ctx;
 
         return ret;
-    } /* WOLFSSL_STM32_CUBEMX_SPI */
+    }
+    #endif /* WOLFTPM_I2C */
 
 #elif defined(WOLFSSL_ATMEL)
     /* Atmel ASF */
@@ -840,7 +841,7 @@ int TPM2_IoCb(TPM2_CTX* ctx, int isRead, word32 addr, byte* buf, word16 size,
     void* userCtx)
 {
     int ret = TPM_RC_FAILURE;
-#if !defined(WOLFTPM_I2C) && !defined(WOLFSSL_STM32_CUBEMX_I2C)
+#if !defined(WOLFTPM_I2C)
     byte txBuf[MAX_SPI_FRAMESIZE+TPM_TIS_HEADER_SZ];
     byte rxBuf[MAX_SPI_FRAMESIZE+TPM_TIS_HEADER_SZ];
 #endif
@@ -858,6 +859,9 @@ int TPM2_IoCb(TPM2_CTX* ctx, int isRead, word32 addr, byte* buf, word16 size,
     #if defined(__linux__)
         /* Use Linux I2C */
         ret = TPM2_IoCb_Linux_I2C(ctx, isRead, addr, buf, size, userCtx);
+    #elif defined(WOLFSSL_STM32_CUBEMX)
+        /* Use STM32 CubeMX HAL for I2C */
+        ret = TPM2_IoCb_STCubeMX_I2C(ctx, isRead, addr, buf, size, userCtx);
     #else
         /* TODO: Add your platform here for HW I2C interface */
         printf("Add your platform here for HW I2C interface\n");
@@ -867,9 +871,6 @@ int TPM2_IoCb(TPM2_CTX* ctx, int isRead, word32 addr, byte* buf, word16 size,
         (void)size;
         (void)userCtx;
     #endif
-#elif defined(WOLFSSL_STM32_CUBEMX_I2C)
-    /* Use STM32 CubeMX HAL for I2C */
-    ret = TPM2_IoCb_STCubeMX_I2C(ctx, isRead, addr, buf, size, userCtx);
 #else
     /* Build SPI format buffer */
     if (isRead) {


### PR DESCRIPTION
This PR adds support for he STM32 CubeMX HAL for I2C

To enable CubeMX I2C HAL

1. wolfTPM must be build using `--enable-i2c`
2. OpenSTM or STM32IDE should have the following define in their project settings: `WOLFSSL_STM32_CUBEMX`. 

**NB: To be tested and confirmed working**

ZD 11681 and https://www.wolfssl.com/forums/topic1680-tpm2iocbstcubemxi2c.html