### PR TITLE
Add seal example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -379,7 +379,7 @@ After successful key extraction using "read", the NV Index is destroyed. Therefo
 
 ## Seal / Unseal
 
-TPM 2.0 can protect secrets using a standard Seal/Unseal procedure. Seal can be created using a TPM 2.0 key or against a set of PCR values.
+TPM 2.0 can protect secrets using a standard Seal/Unseal procedure. Seal can be created using a TPM 2.0 key or against a set of PCR values. Note: Secret data sealed in a key is limited to a maximum size of 128 bytes.
 
 There are two examples available: `seal/seal` and `seal/unseal`.
 
@@ -392,6 +392,7 @@ Using the `seal` example we store securely our data in a newly generated TPM 2.0
 Please find example output from sealing and unsealing a secret message:
 
 ```
+
 $ ./examples/seal/seal keyblob.bin mySecretMessage
 TPM2.0 Simple Seal example
 	Key Blob: keyblob.bin
@@ -402,6 +403,7 @@ Created new TPM seal key (pub 46, priv 141 bytes)
 Wrote 193 bytes to keyblob.bin
 Key Public Blob 46
 Key Private Blob 141
+
 $ ./examples/keygen/keyload -persistent
 TPM2.0 Key load example
 	Key Blob: keyblob.bin
@@ -411,13 +413,16 @@ Reading 193 bytes from keyblob.bin
 Reading the private part of the key
 Loaded key to 0x80000001
 Key was made persistent at 0x81000202
+
 $ ./examples/seal/unseal message.raw
 Example how to unseal data using TPM2.0
 wolfTPM2_Init: success
 Unsealing succeeded
 Stored unsealed data to file = message.raw
+
 $ cat message.raw
 mySecretMessage
+
 ```
 
 After a successful unsealing, the data is stored into a new file. If no filename is provided, the `unseal` tool stores the data in `unseal.bin`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -377,6 +377,51 @@ Extraction of key from NVRAM at index 0x1800202 succeeded
 
 After successful key extraction using "read", the NV Index is destroyed. Therefore, to use "read" again, the "store" example must be run again as well.
 
+## Seal / Unseal
+
+TPM 2.0 can protect secrets using a standard Seal/Unseal procedure. Seal can be created using a TPM 2.0 key or against a set of PCR values.
+
+There are two examples available: `seal/seal` and `seal/unseal`.
+
+Demo usage is available, without parameters.
+
+### Sealing data into a TPM 2.0 Key
+
+Using the `seal` example we store securely our data in a newly generated TPM 2.0 key. Only when this key is loaded into the TPM, we could read back our secret data.
+
+Please find example output from sealing and unsealing a secret message:
+
+```
+$ ./examples/seal/seal keyblob.bin mySecretMessage
+TPM2.0 Simple Seal example
+	Key Blob: keyblob.bin
+	Use Parameter Encryption: NULL
+Loading SRK: Storage 0x81000200 (282 bytes)
+Sealing the user secret into a new TPM key
+Created new TPM seal key (pub 46, priv 141 bytes)
+Wrote 193 bytes to keyblob.bin
+Key Public Blob 46
+Key Private Blob 141
+$ ./examples/keygen/keyload -persistent
+TPM2.0 Key load example
+	Key Blob: keyblob.bin
+	Use Parameter Encryption: NULL
+Loading SRK: Storage 0x81000200 (282 bytes)
+Reading 193 bytes from keyblob.bin
+Reading the private part of the key
+Loaded key to 0x80000001
+Key was made persistent at 0x81000202
+$ ./examples/seal/unseal message.raw
+Example how to unseal data using TPM2.0
+wolfTPM2_Init: success
+Unsealing succeeded
+Stored unsealed data to file = message.raw
+$ cat message.raw
+mySecretMessage
+```
+
+After a successful unsealing, the data is stored into a new file. If no filename is provided, the `unseal` tool stores the data in `unseal.bin`.
+
 ## GPIO control
 
 Some TPM 2.0 modules have extra I/O functionalities and additional GPIO that the developer could use. This extra GPIO could be used to signal other subsystems about security events or system states.

--- a/examples/include.am
+++ b/examples/include.am
@@ -13,6 +13,7 @@ include examples/management/include.am
 include examples/keygen/include.am
 include examples/nvram/include.am
 include examples/gpio/include.am
+include examples/seal/include.am
 
 dist_example_DATA+= examples/README.md \
                     examples/tpm_io.c \

--- a/examples/keygen/keyload.c
+++ b/examples/keygen/keyload.c
@@ -127,7 +127,8 @@ int TPM2_Keyload_Example(void* userCtx, int argc, char *argv[])
     if (rc != 0) goto exit;
 #else
     /* TODO: Option to load hex blob */
-    printf("Loading blob from disk not supported\n");
+    printf("Loading blob from disk not supported. Enable wolfcrypt support.\n");
+    goto exit;
 #endif
 
     rc = wolfTPM2_LoadKey(&dev, &newKey, &storage.handle);

--- a/examples/seal/include.am
+++ b/examples/seal/include.am
@@ -1,0 +1,27 @@
+# vim:ft=automake
+# All paths should be given relative to the root
+
+if BUILD_EXAMPLES
+noinst_PROGRAMS += examples/seal/seal \
+                   examples/seal/unseal
+
+noinst_HEADERS  += examples/seal/seal.h
+
+examples_seal_seal_SOURCES      = examples/seal/seal.c \
+                                    examples/tpm_test_keys.c \
+                                    examples/tpm_io.c
+examples_seal_seal_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
+examples_seal_seal_DEPENDENCIES = src/libwolftpm.la
+
+examples_seal_unseal_SOURCES      = examples/seal/unseal.c \
+                                      examples/tpm_io.c
+examples_seal_unseal_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
+examples_seal_unseal_DEPENDENCIES = src/libwolftpm.la
+
+endif
+
+dist_example_DATA+= examples/seal/seal.c
+dist_example_DATA+= examples/seal/unseal.c
+
+DISTCLEANFILES+= examples/seal/.libs/seal
+DISTCLEANFILES+= examples/seal/.libs/unseal

--- a/examples/seal/seal.c
+++ b/examples/seal/seal.c
@@ -137,12 +137,13 @@ int TPM2_Seal_Example(void* userCtx, int argc, char *argv[])
 #if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
     rc = writeKeyBlob(outputFile, &newKey);
 #endif
-//#else
-    printf("Key Public Blob %d\n", newKey.pub.size);
+
+#ifdef DEBUG_WOLFTPM
+    printf("Key Seal, Public Blob %d\n", newKey.pub.size);
     TPM2_PrintBin((const byte*)&newKey.pub.publicArea, newKey.pub.size);
-    printf("Key Private Blob %d\n", newKey.priv.size);
+    printf("Key Seal, Private Blob %d\n", newKey.priv.size);
     TPM2_PrintBin(newKey.priv.buffer, newKey.priv.size);
-//#endif
+#endif
 
 exit:
 

--- a/examples/seal/seal.c
+++ b/examples/seal/seal.c
@@ -116,7 +116,7 @@ int TPM2_Seal_Example(void* userCtx, int argc, char *argv[])
 
     }
 
-    wolfTPM2_GetKeyTemplate_KeySeal(&publicTemplate);
+    wolfTPM2_GetKeyTemplate_KeySeal(&publicTemplate, TPM_ALG_SHA256);
 
     /* set session for authorization key */
     auth.size = (int)sizeof(gKeyAuth)-1;

--- a/examples/seal/seal.c
+++ b/examples/seal/seal.c
@@ -136,6 +136,8 @@ int TPM2_Seal_Example(void* userCtx, int argc, char *argv[])
     /* Save key as encrypted blob to the disk */
 #if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
     rc = writeKeyBlob(outputFile, &newKey);
+#else
+    printf("Storing key seal to file is not supported.\n");
 #endif
 
 #ifdef DEBUG_WOLFTPM

--- a/examples/seal/seal.c
+++ b/examples/seal/seal.c
@@ -1,0 +1,182 @@
+/* seal.c
+ *
+ * Copyright (C) 2006-2021 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/* Example for TPM 2.0 sealing a user secret using TPM key */
+
+#include <wolftpm/tpm2_wrap.h>
+
+#include <examples/seal/seal.h>
+#include <examples/tpm_io.h>
+#include <examples/tpm_test.h>
+#include <examples/tpm_test_keys.h>
+
+#ifndef WOLFTPM2_NO_WRAPPER
+
+/******************************************************************************/
+/* --- BEGIN TPM2.0 Seal Example -- */
+/******************************************************************************/
+static void usage(void)
+{
+    printf("Expected usage:\n");
+    printf("./examples/seal/seal [filename] [userdata]\n");
+    printf("* filename: Name of the file where the TPM key will be stored\n");
+    printf("* userdata: Arbitrary data to seal inside the TPM key (no whitespaces)\n");
+    printf("Demo usage, without parameters, uses keyblob.bin as a filename\n");
+}
+
+int TPM2_Seal_Example(void* userCtx, int argc, char *argv[])
+{
+    int rc;
+    WOLFTPM2_DEV dev;
+    WOLFTPM2_KEY storage; /* SRK */
+    WOLFTPM2_KEYBLOB newKey;
+    TPMT_PUBLIC publicTemplate;
+    TPM_ALG_ID paramEncAlg = TPM_ALG_NULL;
+    WOLFTPM2_SESSION tpmSession;
+    TPM2B_AUTH auth;
+    const char* outputFile = "keyblob.bin";
+    char defaultData[] = "My1Pass2Phrase3";
+    char *userData = defaultData;
+
+    if (argc >= 2) {
+        if (XSTRNCMP(argv[1], "-?", 2) == 0 ||
+            XSTRNCMP(argv[1], "-h", 2) == 0 ||
+            XSTRNCMP(argv[1], "--help", 6) == 0) {
+            usage();
+            return 0;
+        }
+        if (argv[1][0] != '-') {
+            outputFile = argv[1];
+        }
+    }
+    if (argc >= 3) {
+        if (argv[2][0] != '-') {
+            userData = argv[2];
+        }
+    }
+    while (argc > 1) {
+        if (XSTRNCMP(argv[argc-1], "-aes", 4) == 0) {
+            paramEncAlg = TPM_ALG_CFB;
+        }
+        if (XSTRNCMP(argv[argc-1], "-xor", 4) == 0) {
+            paramEncAlg = TPM_ALG_XOR;
+        }
+        argc--;
+    }
+
+    XMEMSET(&storage, 0, sizeof(storage));
+    XMEMSET(&newKey, 0, sizeof(newKey));
+    XMEMSET(&tpmSession, 0, sizeof(tpmSession));
+    XMEMSET(&auth, 0, sizeof(auth));
+
+    printf("TPM2.0 Simple Seal example\n");
+    printf("\tKey Blob: %s\n", outputFile);
+    printf("\tUse Parameter Encryption: %s\n", TPM2_GetAlgName(paramEncAlg));
+
+    rc = wolfTPM2_Init(&dev, TPM2_IoCb, userCtx);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("\nwolfTPM2_Init failed\n");
+        goto exit;
+    }
+
+    /* get SRK */
+    rc = getPrimaryStoragekey(&dev, &storage, TPM_ALG_RSA);
+    if (rc != 0) goto exit;
+
+    if (paramEncAlg != TPM_ALG_NULL) {
+        /* Start an authenticated session (salted / unbound) with parameter encryption */
+        rc = wolfTPM2_StartSession(&dev, &tpmSession, &storage, NULL,
+            TPM_SE_HMAC, paramEncAlg);
+        if (rc != 0) goto exit;
+        printf("TPM2_StartAuthSession: sessionHandle 0x%x\n",
+            (word32)tpmSession.handle.hndl);
+
+        /* set session for authorization of the storage key */
+        rc = wolfTPM2_SetAuthSession(&dev, 1, &tpmSession,
+            (TPMA_SESSION_decrypt | TPMA_SESSION_encrypt | TPMA_SESSION_continueSession));
+        if (rc != 0) goto exit;
+
+    }
+
+    wolfTPM2_GetKeyTemplate_KeySeal(&publicTemplate);
+
+    /* set session for authorization key */
+    auth.size = (int)sizeof(gKeyAuth)-1;
+    XMEMCPY(auth.buffer, gKeyAuth, auth.size);
+
+    printf("Sealing the user secret into a new TPM key\n");
+    rc = wolfTPM2_CreateKeySeal(&dev, &newKey, &storage.handle,
+                                &publicTemplate, auth.buffer, auth.size,
+                                (BYTE*)userData, (int)strlen(userData));
+    if (rc != TPM_RC_SUCCESS) {
+        printf("wolfTPM2_CreateKey failed\n");
+        goto exit;
+    }
+    printf("Created new TPM seal key (pub %d, priv %d bytes)\n",
+        newKey.pub.size, newKey.priv.size);
+
+    /* Save key as encrypted blob to the disk */
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
+    rc = writeKeyBlob(outputFile, &newKey);
+#endif
+//#else
+    printf("Key Public Blob %d\n", newKey.pub.size);
+    TPM2_PrintBin((const byte*)&newKey.pub.publicArea, newKey.pub.size);
+    printf("Key Private Blob %d\n", newKey.priv.size);
+    TPM2_PrintBin(newKey.priv.buffer, newKey.priv.size);
+//#endif
+
+exit:
+
+    if (rc != 0) {
+        printf("\nFailure 0x%x: %s\n\n", rc, wolfTPM2_GetRCString(rc));
+    }
+
+    /* Close handles */
+    wolfTPM2_UnloadHandle(&dev, &storage.handle);
+    wolfTPM2_UnloadHandle(&dev, &newKey.handle);
+    wolfTPM2_UnloadHandle(&dev, &tpmSession.handle);
+
+    wolfTPM2_Cleanup(&dev);
+    return rc;
+}
+
+/******************************************************************************/
+/* --- END TPM2.0 Seal Example -- */
+/******************************************************************************/
+#endif /* !WOLFTPM2_NO_WRAPPER */
+
+#ifndef NO_MAIN_DRIVER
+int main(int argc, char *argv[])
+{
+    int rc = NOT_COMPILED_IN;
+
+#ifndef WOLFTPM2_NO_WRAPPER
+    rc = TPM2_Seal_Example(NULL, argc, argv);
+#else
+    printf("KeyGen code not compiled in\n");
+    (void)argc;
+    (void)argv;
+#endif
+
+    return rc;
+}
+#endif

--- a/examples/seal/seal.h
+++ b/examples/seal/seal.h
@@ -1,0 +1,36 @@
+/* seal.h
+ *
+ * Copyright (C) 2006-2021 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef _SEAL_H_
+#define _SEAL_H_
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+int TPM2_Seal_Example(void* userCtx, int argc, char *argv[]);
+int TPM2_Unseal_Example(void* userCtx, int argc, char *argv[]);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* _SEAL_H_ */

--- a/examples/seal/unseal.c
+++ b/examples/seal/unseal.c
@@ -1,0 +1,152 @@
+/* unseal.c
+ *
+ * Copyright (C) 2006-2021 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/* This example demonstrates how to extract the data from a TPM seal object */
+
+#include <wolftpm/tpm2_wrap.h>
+
+#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(NO_FILESYSTEM)
+
+#include <examples/seal/seal.h>
+#include <examples/tpm_io.h>
+#include <examples/tpm_test.h>
+
+#include <stdio.h>
+#include <stdlib.h> /* atoi */
+
+
+/******************************************************************************/
+/* --- BEGIN TPM2.0 Unseal example --- */
+/******************************************************************************/
+
+static void usage(void)
+{
+    printf("Expected usage:\n");
+    printf("./examples/seal/unseal [filename]\n");
+    printf("* filename - File containg a TPM seal key\n");
+    printf("Demo usage, without arguments, uses keyblob.bin file input.\n");
+}
+
+int TPM2_Unseal_Example(void* userCtx, int argc, char *argv[])
+{
+    int rc;
+    WOLFTPM2_DEV dev;
+    WOLFTPM2_KEY key;
+    TPM2B_AUTH auth;
+    const char *filename = "unseal.bin";
+    XFILE fp = NULL;
+    size_t len;
+    Unseal_In cmdIn_unseal;
+    Unseal_Out cmdOut_unseal;
+
+    XMEMSET(&cmdIn_unseal, 0, sizeof(cmdIn_unseal));
+    XMEMSET(&cmdOut_unseal, 0, sizeof(cmdOut_unseal));
+    XMEMSET(&key, 0, sizeof(key));
+    XMEMSET(&auth, 0, sizeof(auth));
+
+    if (argc >= 2) {
+        if (XSTRNCMP(argv[1], "-?", 2) == 0 ||
+            XSTRNCMP(argv[1], "-h", 2) == 0 ||
+            XSTRNCMP(argv[1], "--help", 6) == 0) {
+            usage();
+            return 0;
+        }
+
+        if (argv[1][0] != '-') {
+            filename = argv[1];
+        }
+    }
+
+    printf("Example how to unseal data using TPM2.0\n");
+    rc = wolfTPM2_Init(&dev, TPM2_IoCb, userCtx);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("wolfTPM2_Init failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("wolfTPM2_Init: success\n");
+
+    /* Set authorization for using the seal key */
+    auth.size = (int)sizeof(gKeyAuth)-1;
+    XMEMCPY(auth.buffer, gKeyAuth, auth.size);
+    wolfTPM2_SetAuthPassword(&dev, 0, &auth);
+
+    cmdIn_unseal.itemHandle = TPM2_DEMO_PERSISTENT_KEY_HANDLE;
+    rc = TPM2_Unseal(&cmdIn_unseal, &cmdOut_unseal);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_Unseal failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("Unsealing succeeded\n");
+
+#ifdef DEBUG_WOLFTPM
+    printf("Unsealed data:\n");
+    TPM2_PrintBin(cmdOut_unseal.outData.buffer, cmdOut_unseal.outData.size);
+#endif
+
+#if !defined(NO_FILESYSTEM)
+    /* Output the unsealed data to a file */
+    if (filename) {
+        fp = XFOPEN(filename, "wb");
+        if (fp) {
+            len = XFWRITE(cmdOut_unseal.outData.buffer, 1, cmdOut_unseal.outData.size, fp);
+            if (len != cmdOut_unseal.outData.size) {
+                printf("Error while writing the unsealed data to a file.\n");
+                goto exit;
+            }
+        }
+        printf("Stored unsealed data to file = %s\n", filename);
+        XFCLOSE(fp);
+    }
+#endif
+
+    /* Remove the loaded TPM seal object */
+    wolfTPM2_SetAuthPassword(&dev, 0, NULL);
+    key.handle.hndl = TPM2_DEMO_PERSISTENT_KEY_HANDLE;
+    wolfTPM2_NVDeleteKey(&dev, TPM_RH_OWNER, &key);
+
+exit:
+
+    wolfTPM2_Cleanup(&dev);
+    return rc;
+}
+
+/******************************************************************************/
+/* --- END TPM2.0 Unseal example --- */
+/******************************************************************************/
+
+#endif /* !WOLFTPM2_NO_WRAPPER */
+
+#ifndef NO_MAIN_DRIVER
+int main(int argc, char *argv[])
+{
+    int rc = -1;
+
+#ifndef WOLFTPM2_NO_WRAPPER
+    rc = TPM2_Unseal_Example(NULL, argc, argv);
+#else
+    printf("Wrapper code not compiled in\n");
+    (void)argc;
+    (void)argv;
+#endif /* !WOLFTPM2_NO_WRAPPER */
+
+    return rc;
+}
+#endif

--- a/examples/seal/unseal.c
+++ b/examples/seal/unseal.c
@@ -52,8 +52,10 @@ int TPM2_Unseal_Example(void* userCtx, int argc, char *argv[])
     WOLFTPM2_KEY key;
     TPM2B_AUTH auth;
     const char *filename = "unseal.bin";
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
     XFILE fp = NULL;
     size_t len;
+#endif
     Unseal_In cmdIn_unseal;
     Unseal_Out cmdOut_unseal;
 
@@ -101,7 +103,7 @@ int TPM2_Unseal_Example(void* userCtx, int argc, char *argv[])
     TPM2_PrintBin(cmdOut_unseal.outData.buffer, cmdOut_unseal.outData.size);
 #endif
 
-#if !defined(NO_FILESYSTEM)
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
     /* Output the unsealed data to a file */
     if (filename) {
         fp = XFOPEN(filename, "wb");
@@ -115,6 +117,8 @@ int TPM2_Unseal_Example(void* userCtx, int argc, char *argv[])
         printf("Stored unsealed data to file = %s\n", filename);
         XFCLOSE(fp);
     }
+#else
+    printf("Unable to store unsealed data to a file. Enable wolfcrypt support.\n");
 #endif
 
     /* Remove the loaded TPM seal object */

--- a/examples/seal/unseal.c
+++ b/examples/seal/unseal.c
@@ -119,6 +119,7 @@ int TPM2_Unseal_Example(void* userCtx, int argc, char *argv[])
     }
 #else
     printf("Unable to store unsealed data to a file. Enable wolfcrypt support.\n");
+    (void)filename;
 #endif
 
     /* Remove the loaded TPM seal object */

--- a/examples/tpm_test.h
+++ b/examples/tpm_test.h
@@ -32,6 +32,7 @@
 /* Test Configuration */
 #define TPM2_DEMO_STORAGE_KEY_HANDLE    0x81000200  /* Persistent Storage Key Handle (RSA) */
 #define TPM2_DEMO_STORAGE_EC_KEY_HANDLE 0x81000201  /* Persistent Storage Key Handle (ECC) */
+#define TPM2_DEMO_PERSISTENT_KEY_HANDLE 0x81000202  /* Persistent Key Handle for common use */
 #define TPM2_DEMO_RSA_IDX               0x20        /* offset handle to unused index */
 #define TPM2_DEMO_RSA_KEY_HANDLE        (0x81000000 + TPM2_DEMO_RSA_IDX) /* Persistent Key Handle */
 #define TPM2_DEMO_RSA_CERT_HANDLE       (0x01800000 + TPM2_DEMO_RSA_IDX) /* NV Handle */

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -4008,10 +4008,10 @@ int wolfTPM2_CreateKeySeal(WOLFTPM2_DEV* dev, WOLFTPM2_KEYBLOB* keyBlob,
         return BAD_FUNC_ARG;
 
     /* Seal size is limited to TCG defined MAX_SYM_DATA, which is 128 bytes */
-    if (sealSize < 0 || sealSize > 128) {
-        printf("wolfTPM2_CreateKeySeal failed. Seal size is invalid.\n");
+    if (sealSize < 0 || sealSize > MAX_SYM_DATA) {
 #ifdef DEBUG_WOLFTPM
-        printf("Seal size %d should not be larger than 128 bytes\n", sealSize);
+        printf("Seal size %d should not be larger than %d bytes\n",
+            sealSize, MAX_SYM_DATA);
 #endif
         return BAD_FUNC_ARG;
     }

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -4007,6 +4007,15 @@ int wolfTPM2_CreateKeySeal(WOLFTPM2_DEV* dev, WOLFTPM2_KEYBLOB* keyBlob,
     if (dev == NULL || keyBlob == NULL || parent == NULL || publicTemplate == NULL)
         return BAD_FUNC_ARG;
 
+    /* Seal size is limited to TCG defined MAX_SYM_DATA, which is 128 bytes */
+    if (sealSize < 0 || sealSize > 128) {
+        printf("wolfTPM2_CreateKeySeal failed. Seal size is invalid.\n");
+#ifdef DEBUG_WOLFTPM
+        printf("Seal size %d should not be larger than 128 bytes\n", sealSize);
+#endif
+        return BAD_FUNC_ARG;
+    }
+
     /* clear output key buffer */
     XMEMSET(keyBlob, 0, sizeof(WOLFTPM2_KEYBLOB));
     XMEMSET(&createOut, 0, sizeof(createOut)); /* make sure pub struct is zero init */
@@ -4031,13 +4040,13 @@ int wolfTPM2_CreateKeySeal(WOLFTPM2_DEV* dev, WOLFTPM2_KEYBLOB* keyBlob,
     rc = TPM2_Create(&createIn, &createOut);
     if (rc != TPM_RC_SUCCESS) {
     #ifdef DEBUG_WOLFTPM
-        printf("TPM2_Create key failed %d: %s\n", rc, wolfTPM2_GetRCString(rc));
+        printf("wolfTPM2_CreateKeySeal failed %d: %s\n", rc, wolfTPM2_GetRCString(rc));
     #endif
         return rc;
     }
 
 #ifdef DEBUG_WOLFTPM
-    printf("TPM2_Create key: pub %d, priv %d\n",
+    printf("wolfTPM2_CreateKeySeal generated key with: pub %d, priv %d\n",
         createOut.outPublic.size, createOut.outPrivate.size);
     TPM2_PrintPublicArea(&createOut.outPublic);
 #endif

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -3790,16 +3790,16 @@ int wolfTPM2_GetKeyTemplate_KeyedHash(TPMT_PUBLIC* publicTemplate,
     return TPM_RC_SUCCESS;
 }
 
-int wolfTPM2_GetKeyTemplate_KeySeal(TPMT_PUBLIC* publicTemplate)
+int wolfTPM2_GetKeyTemplate_KeySeal(TPMT_PUBLIC* publicTemplate, TPM_ALG_ID nameAlg)
 {
     if (publicTemplate == NULL)
         return BAD_FUNC_ARG;
     /* Seal Object can be only of type KEYEDHASH and can not be used for
-     * signing or encryption. SHA256 is chosen as common hash algorithm.
+     * signing or encryption. Hash algorithm can be chosen by the developer.
      */
     XMEMSET(publicTemplate, 0, sizeof(TPMT_PUBLIC));
     publicTemplate->type = TPM_ALG_KEYEDHASH;
-    publicTemplate->nameAlg = TPM_ALG_SHA256;
+    publicTemplate->nameAlg = nameAlg;
     publicTemplate->objectAttributes = (
         TPMA_OBJECT_fixedTPM | TPMA_OBJECT_fixedParent |
         TPMA_OBJECT_userWithAuth | TPMA_OBJECT_noDA);

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -200,6 +200,10 @@ WOLFTPM_API int wolfTPM2_LoadEccPrivateKey(WOLFTPM2_DEV* dev,
     const byte* eccPriv, word32 eccPrivSz);
 WOLFTPM_API int wolfTPM2_ReadPublicKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const TPM_HANDLE handle);
+WOLFTPM_API int wolfTPM2_CreateKeySeal(WOLFTPM2_DEV* dev,
+    WOLFTPM2_KEYBLOB* keyBlob, WOLFTPM2_HANDLE* parent,
+    TPMT_PUBLIC* publicTemplate, const byte* auth, int authSz,
+    const byte* sealData, int sealSize);
 
 WOLFTPM_API int wolfTPM2_ComputeName(const TPM2B_PUBLIC* pub, TPM2B_NAME* out);
 WOLFTPM_API int wolfTPM2_SensitiveToPrivate(TPM2B_SENSITIVE* sens, TPM2B_PRIVATE* priv,
@@ -348,6 +352,7 @@ WOLFTPM_API int wolfTPM2_GetKeyTemplate_Symmetric(TPMT_PUBLIC* publicTemplate,
     int keyBits, TPM_ALG_ID algMode, int isSign, int isDecrypt);
 WOLFTPM_API int wolfTPM2_GetKeyTemplate_KeyedHash(TPMT_PUBLIC* publicTemplate,
     TPM_ALG_ID hashAlg, int isSign, int isDecrypt);
+WOLFTPM_API int wolfTPM2_GetKeyTemplate_KeySeal(TPMT_PUBLIC* publicTemplate);
 WOLFTPM_API int wolfTPM2_GetKeyTemplate_RSA_EK(TPMT_PUBLIC* publicTemplate);
 WOLFTPM_API int wolfTPM2_GetKeyTemplate_ECC_EK(TPMT_PUBLIC* publicTemplate);
 WOLFTPM_API int wolfTPM2_GetKeyTemplate_RSA_SRK(TPMT_PUBLIC* publicTemplate);

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -352,7 +352,7 @@ WOLFTPM_API int wolfTPM2_GetKeyTemplate_Symmetric(TPMT_PUBLIC* publicTemplate,
     int keyBits, TPM_ALG_ID algMode, int isSign, int isDecrypt);
 WOLFTPM_API int wolfTPM2_GetKeyTemplate_KeyedHash(TPMT_PUBLIC* publicTemplate,
     TPM_ALG_ID hashAlg, int isSign, int isDecrypt);
-WOLFTPM_API int wolfTPM2_GetKeyTemplate_KeySeal(TPMT_PUBLIC* publicTemplate);
+WOLFTPM_API int wolfTPM2_GetKeyTemplate_KeySeal(TPMT_PUBLIC* publicTemplate, TPM_ALG_ID nameAlg);
 WOLFTPM_API int wolfTPM2_GetKeyTemplate_RSA_EK(TPMT_PUBLIC* publicTemplate);
 WOLFTPM_API int wolfTPM2_GetKeyTemplate_ECC_EK(TPMT_PUBLIC* publicTemplate);
 WOLFTPM_API int wolfTPM2_GetKeyTemplate_RSA_SRK(TPMT_PUBLIC* publicTemplate);


### PR DESCRIPTION
This PR adds a seal example using a TPM 2.0 key

It makes use of the keygen/keyload example.

```
$ ./examples/seal/seal keyblob.bin mySecretMessage
TPM2.0 Simple Seal example
	Key Blob: keyblob.bin
	Use Parameter Encryption: NULL
Loading SRK: Storage 0x81000200 (282 bytes)
Sealing the user secret into a new TPM key
Created new TPM seal key (pub 46, priv 141 bytes)
Wrote 193 bytes to keyblob.bin
Key Public Blob 46
Key Private Blob 141
$ ./examples/keygen/keyload -persistent           
TPM2.0 Key load example
	Key Blob: keyblob.bin
	Use Parameter Encryption: NULL
Loading SRK: Storage 0x81000200 (282 bytes)
Reading 193 bytes from keyblob.bin
Reading the private part of the key
Loaded key to 0x80000001
Key was made persistent at 0x81000202
$ ./examples/seal/unseal message.raw
Example how to unseal data using TPM2.0
wolfTPM2_Init: success
Unsealing succeeded
Stored unsealed data to file = message.raw
$ cat message.raw 
mySecretMessage
```                        