### PR TITLE
Updated gitignore (Seal & GPIO examples)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,11 @@ examples/keygen/keygen
 examples/keygen/keyimport
 examples/nvram/store
 examples/nvram/read
+examples/gpio/gpio_config
+examples/gpio/gpio_set
+examples/gpio/gpio_read
+examples/seal/seal
+examples/seal/unseal
 
 # Generated Cert Files
 certs/ca-*.pem


### PR DESCRIPTION
I know this is a minor change, but it makes a difference.

The two newest wolfTPM examples added 5 new binaries that are showing up in `git status`:
- TPM 2.0 Seal (2 binaries)
- Extra GPIO (3 binaries)

Signed-off-by: Dimitar Tomov <dimi@wolfssl.com>