### PR TITLE
Add credential examples for remote attestation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ examples/gpio/gpio_set
 examples/gpio/gpio_read
 examples/seal/seal
 examples/seal/unseal
+examples/attestation/make_credential
+examples/attestation/activate_credential
 
 # Generated Cert Files
 certs/ca-*.pem

--- a/examples/attestation/README.md
+++ b/examples/attestation/README.md
@@ -1,0 +1,50 @@
+# Remote Attestatino Demo
+
+This folder contains examples for performing remote attestation. You will learn how to perform a challenge-response between an end node and attestation server.
+
+## List of examples
+
+The `./examples/attestation/` folder contains examples related specifically to remote attestation. However, the demonstration requires the use of other examples included in wolfTPM. Complete list can be found below:
+
+* `./examples/attestation/make_credential`: Used
+* `./examples/attestation/activate_credential`: Used to
+* `./examples/random/get`: Used to generate a random seed for attestation/make_credential
+* `./examples/keygen/keygen`: Used to create a primary key(PK) and attestation key(AK)
+* `./examples/keygen/keyload`: Used to load the generated keys
+
+Scripts:
+
+TODO: * `./examples/attestation/provisioning.sh` - Using the above examples, creates the necessary TPM objects for remote attestation, emulating provisioning between an end node and attestation server.
+
+
+## Technology introduction
+
+### Make Credential
+
+TODO: Add explanation
+
+### Activate Credential
+
+TODO: Add explanation
+
+## Example usage
+
+### Make Credential Example Usage
+
+```
+TODO
+```
+
+### Activate Credential Example Usage
+
+```
+TODO
+```
+
+### Provisioning
+
+TODO
+
+## Typical demo output
+
+TODO

--- a/examples/attestation/README.md
+++ b/examples/attestation/README.md
@@ -1,50 +1,107 @@
-# Remote Attestatino Demo
+# Remote Attestatino Examples
 
 This folder contains examples for performing remote attestation. You will learn how to perform a challenge-response between an end node and attestation server.
 
 ## List of examples
 
-The `./examples/attestation/` folder contains examples related specifically to remote attestation. However, the demonstration requires the use of other examples included in wolfTPM. Complete list can be found below:
+The `./examples/attestation/` folder contains examples related specifically to remote attestation. However, the demonstration requires the creation of TPM 2.0 keys using the `keygen` example also included in wolfTPM's source code.
 
-* `./examples/attestation/make_credential`: Used
-* `./examples/attestation/activate_credential`: Used to
-* `./examples/random/get`: Used to generate a random seed for attestation/make_credential
+Complete list of the required examples is shown below:
+
+* `./examples/attestation/make_credential`: Used by a server to create a remote attestation challenge
+* `./examples/attestation/activate_credential`: Used by a client to decrypt the challenge and respond
 * `./examples/keygen/keygen`: Used to create a primary key(PK) and attestation key(AK)
-* `./examples/keygen/keyload`: Used to load the generated keys
-
-Scripts:
-
-TODO: * `./examples/attestation/provisioning.sh` - Using the above examples, creates the necessary TPM objects for remote attestation, emulating provisioning between an end node and attestation server.
-
 
 ## Technology introduction
 
-### Make Credential
+Remote Attestation is the process of a client providing an evidence to an attestation server that verifies if the client is in a known state.
 
-TODO: Add explanation
+For this process to take place, the client and server must establish initial trust. This is achieved using the standard TPM 2.0 commands MakeCredential and ActivateCredential.
 
-### Activate Credential
+1. The client transfers the public parts of a TPM 2.0 Primary Attestation Key(PAK) and quote signing Attestation Key(AK).
 
-TODO: Add explanation
+2. MakeCredential uses the public part of the PAK to encrypt a challenge(secret). Typically, the challenge is a digest of the public part of an Attestation Key(AK).
+
+This way the challenge can only be decrypted by the TPM that can load the private part of the PAK and AK. Because the PAK and AK are bound to the TPM using a fixedTPM key attribute, the only TPM that can load these keys is the TPM where they were originally created.
+
+3. After the challenge is created, it is transfered from the server to the client.
+
+4. ActivateCredential uses the TPM 2.0 loaded PAK and AK to decrypt the challenge and retrieve the secret. Once retrieved, the client can respond to the server challenge.
+
+This way the client confirms to the server it posesses the expected TPM 2.0 System Identity and Attestation Key.
+
+Note:
+
+* The transport protocol to exchange the challenge and response are up to the developer to choose, because this is implementation specific. One approach could be the use of TLS1.3 client-server connection using wolfSSL.
 
 ## Example usage
 
-### Make Credential Example Usage
+### Creating TPM 2.0 keys for Remote Attestation
+
+Using the `keygen` example we can create the necessary TPM 2.0 Attestation Key and TPM 2.0 Primary Storage Key that will be used as a Primary Attestation Key(PAK).
 
 ```
-TODO
+
+$ ./examples/keygen/keygen -rsa
+TPM2.0 Key generation example
+	Key Blob: keyblob.bin
+	Algorithm: RSA
+	Template: AIK
+	Use Parameter Encryption: NULL
+Loading SRK: Storage 0x81000200 (282 bytes)
+RSA AIK template
+Creating new RSA key...
+Created new key (pub 280, priv 222 bytes)
+Wrote 508 bytes to keyblob.bin
+
 ```
+
+### Make Credential Example Usage
+
+Using the `make_credential` example an attestation server can generate remote attestation challenge. The secret is 32 bytes of randomly generated seed that could be used for a symmetric key in some remote attestation schemes.
+
+```
+
+$ ./examples/attestation/make_credential
+Using default values
+Demo how to create a credential blob for remote attestation
+wolfTPM2_Init: success
+Credential will be stored in cred.blob
+Reading 508 bytes from keyblob.bin
+Reading the private part of the key
+AK loaded at 0x80000001
+TPM2_MakeCredential success
+Wrote credential blob and secret to cred.blob, 514 bytes
+
+```
+
+The transfer of the PAK and AK public parts between the client and attestation server is not part of the `make_credential` example, because the exchange is implementation specific.
 
 ### Activate Credential Example Usage
 
+Using the `activate_credential` example a client can decrypt the remote attestation challenge. The secret will be exposed in plain and can be exchanged with the attestation server.
+
 ```
-TODO
+
+$ ./examples/attestation/activate_credential
+Using default values
+Demo how to create a credential blob for remote attestation
+wolfTPM2_Init: success
+Credential will be read from cred.blob
+Loading SRK: Storage 0x81000200 (282 bytes)
+SRK loaded
+Reading 508 bytes from keyblob.bin
+Reading the private part of the key
+AK loaded at 0x80000001
+TPM2_StartAuthSession: sessionHandle 0x3000000
+TPM2_policyCommandCode success
+Read credential blob and secret from cred.blob, 514 bytes
+TPM2_ActivateCredential success
+
 ```
 
-### Provisioning
+The transfer of the challenge response containing the secret in plain (or used as a symmetric key seed) is not part of the `activate_credential` example, because the exchange is also implementation specific.
 
-TODO
+## More information
 
-## Typical demo output
-
-TODO
+Please contact us at facts@wolfssl.com if you are interested in more information about Remote Attestation using wolfTPM.

--- a/examples/attestation/README.md
+++ b/examples/attestation/README.md
@@ -1,4 +1,4 @@
-# Remote Attestatino Examples
+# Remote Attestation Examples
 
 This folder contains examples for performing remote attestation. You will learn how to perform a challenge-response between an end node and attestation server.
 
@@ -24,11 +24,11 @@ For this process to take place, the client and server must establish initial tru
 
 This way the challenge can only be decrypted by the TPM that can load the private part of the PAK and AK. Because the PAK and AK are bound to the TPM using a fixedTPM key attribute, the only TPM that can load these keys is the TPM where they were originally created.
 
-3. After the challenge is created, it is transfered from the server to the client.
+3. After the challenge is created, it is transferred from the server to the client.
 
 4. ActivateCredential uses the TPM 2.0 loaded PAK and AK to decrypt the challenge and retrieve the secret. Once retrieved, the client can respond to the server challenge.
 
-This way the client confirms to the server it posesses the expected TPM 2.0 System Identity and Attestation Key.
+This way the client confirms to the server it possesses the expected TPM 2.0 System Identity and Attestation Key.
 
 Note:
 

--- a/examples/attestation/activate_credential.c
+++ b/examples/attestation/activate_credential.c
@@ -157,7 +157,7 @@ int TPM2_ActivateCredential_Example(void* userCtx, int argc, char *argv[])
     XMEMSET(&cmdOut.activCred, 0, sizeof(cmdOut.activCred));
     cmdIn.activCred.activateHandle = akKey.handle.hndl;
     cmdIn.activCred.keyHandle = TPM2_DEMO_STORAGE_KEY_HANDLE;
-    /* Read credeitnail from the user file */
+    /* Read credential from the user file */
 #if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
     fp = XFOPEN(input, "rb");
     if (fp != XBADFILE) {

--- a/examples/attestation/activate_credential.c
+++ b/examples/attestation/activate_credential.c
@@ -1,0 +1,215 @@
+/* activate_credential.c
+ *
+ * Copyright (C) 2006-2021 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/* This example shows how to decrypt a credential for Remote Attestation
+ * and extract the secret for challenge response to an attestation server
+ */
+
+#include <wolftpm/tpm2_wrap.h>
+
+#ifndef WOLFTPM2_NO_WRAPPER
+
+#include <examples/attestation/credential.h>
+#include <examples/tpm_io.h>
+#include <examples/tpm_test.h>
+#include <examples/tpm_test_keys.h>
+
+#include <stdio.h>
+
+
+/******************************************************************************/
+/* --- BEGIN TPM2.0 Activate Credential example tool  -- */
+/******************************************************************************/
+
+static void usage(void)
+{
+    printf("Expected usage:\n");
+    printf("./examples/attestation/activate_credential [cred.blob]\n");
+    printf("* cred.blob is a input file holding the generated credential.\n");
+    printf("Demo usage without parameters, uses \"cred.blob\" filename.\n");
+}
+
+int TPM2_ActivateCredential_Example(void* userCtx, int argc, char *argv[])
+{
+    int rc = -1;
+    WOLFTPM2_DEV dev;
+    WOLFTPM2_KEY storage;
+    WOLFTPM2_KEYBLOB akKey;
+    WOLFTPM2_SESSION tpmSession;
+    FILE *fp;
+    const char *input = "cred.blob";
+    const char *keyblob = "keyblob.bin";
+    int dataSize = 0;
+
+    union {
+        ActivateCredential_In activCred;
+        PolicyCommandCode_In policyCommandCode;
+        byte maxInput[MAX_COMMAND_SIZE];
+    } cmdIn;
+    union {
+        ActivateCredential_Out activCred;
+        byte maxOutput[MAX_RESPONSE_SIZE];
+    } cmdOut;
+
+    if (argc == 1) {
+        printf("Using default values\n");
+    }
+    else if (argc == 2) {
+        if (XSTRNCMP(argv[1], "-?", 2) == 0 ||
+            XSTRNCMP(argv[1], "-h", 2) == 0 ||
+            XSTRNCMP(argv[1], "--help", 6) == 0) {
+            usage();
+            return 0;
+        }
+        if (argv[1][0] != '-') {
+            input = argv[1];
+        }
+    }
+    else {
+        printf("Incorrect arguments\n");
+        usage();
+        goto exit_badargs;
+    }
+
+    XMEMSET(&storage, 0, sizeof(storage));
+    XMEMSET(&akKey, 0, sizeof(akKey));
+
+    printf("Demo how to create a credential blob for remote attestation\n");
+    rc = wolfTPM2_Init(&dev, TPM2_IoCb, userCtx);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("wolfTPM2_Init failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("wolfTPM2_Init: success\n");
+
+    printf("Credential will be read from %s\n", input);
+
+    /* Load SRK, required to unwrap credential */
+    rc = getPrimaryStoragekey(&dev, &storage, TPM_ALG_RSA);
+    if (rc != 0) goto exit;
+    printf("SRK loaded\n");
+    /* Prepare the auth password for the Storage Key */
+    storage.handle.auth.size = sizeof(gStorageKeyAuth)-1;
+    XMEMCPY(storage.handle.auth.buffer, gStorageKeyAuth,
+            storage.handle.auth.size);
+    wolfTPM2_SetAuthHandle(&dev, 0, &storage.handle);
+
+    /* Load AK, required to verify the Key Attributes in the credential */
+    rc = readKeyBlob(keyblob, &akKey);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("Failure to read keyblob.\n");
+    }
+    storage.handle.hndl = TPM2_DEMO_STORAGE_KEY_HANDLE;
+    rc = wolfTPM2_LoadKey(&dev, &akKey, &storage.handle);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("Failure to load the AK and read its Name.\n");
+        goto exit;
+    }
+    printf("AK loaded at 0x%x\n", (word32)akKey.handle.hndl);
+    /* Prepare the auth password for the Attestation Key */
+    akKey.handle.auth.size = sizeof(gAiKeyAuth)-1;
+    XMEMCPY(akKey.handle.auth.buffer, gAiKeyAuth,
+            akKey.handle.auth.size);
+    wolfTPM2_SetAuthHandle(&dev, 0, &akKey.handle);
+
+    /* Start an authenticated session (salted / unbound) */
+    rc = wolfTPM2_StartSession(&dev, &tpmSession, NULL, NULL,
+        TPM_SE_POLICY, TPM_ALG_NULL);
+    if (rc != 0) goto exit;
+    printf("TPM2_StartAuthSession: sessionHandle 0x%x\n",
+        (word32)tpmSession.handle.hndl);
+
+    /* ADMIN role required for Activate Credential command */
+    XMEMSET(&cmdIn.policyCommandCode, 0, sizeof(cmdIn.policyCommandCode));
+    cmdIn.policyCommandCode.policySession = tpmSession.handle.hndl;
+    cmdIn.policyCommandCode.code = TPM_CC_ActivateCredential;
+    rc = TPM2_PolicyCommandCode(&cmdIn.policyCommandCode);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("policyCommandCode failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("TPM2_policyCommandCode success\n"); /* No command response payload */
+
+    /* Prepare Key Auths in correct order for ActivateCredential */
+    wolfTPM2_SetAuthHandle(&dev, 0, &akKey.handle);
+    wolfTPM2_SetAuthHandle(&dev, 1, &storage.handle);
+
+    /* Prepare the Activate Credential command */
+    XMEMSET(&cmdIn.activCred, 0, sizeof(cmdIn.activCred));
+    XMEMSET(&cmdOut.activCred, 0, sizeof(cmdOut.activCred));
+    cmdIn.activCred.activateHandle = akKey.handle.hndl;
+    cmdIn.activCred.keyHandle = TPM2_DEMO_STORAGE_KEY_HANDLE;
+    /* Read credeitnail from the user file */
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
+    fp = XFOPEN(input, "rb");
+    if (fp != XBADFILE) {
+        dataSize = (int)XFREAD((BYTE*)&cmdIn.activCred.credentialBlob, 1,
+                                sizeof(cmdIn.activCred.credentialBlob), fp);
+        dataSize = (int)XFREAD((BYTE*)&cmdIn.activCred.secret, 1,
+                                sizeof(cmdIn.activCred.secret), fp);
+        XFCLOSE(fp);
+    }
+    printf("Read credential blob and secret from %s, %d bytes\n", input, dataSize);
+#else
+    printf("Can not load credential. File support not enabled\n");
+    goto exit;
+#endif
+    /* All required data to verify the credential is prepared */
+    rc = TPM2_ActivateCredential(&cmdIn.activCred, &cmdOut.activCred);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_ActivateCredentials failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("TPM2_ActivateCredential success\n");
+
+exit:
+
+    wolfTPM2_UnloadHandle(&dev, &tpmSession.handle);
+    wolfTPM2_UnloadHandle(&dev, &akKey.handle);
+    wolfTPM2_Cleanup(&dev);
+
+exit_badargs:
+
+    return rc;
+}
+
+/******************************************************************************/
+/* --- END TPM2.0 Activate Credential example tool -- */
+/******************************************************************************/
+#endif /* !WOLFTPM2_NO_WRAPPER */
+
+#ifndef NO_MAIN_DRIVER
+int main(int argc, char *argv[])
+{
+    int rc = -1;
+
+#ifndef WOLFTPM2_NO_WRAPPER
+    rc = TPM2_ActivateCredential_Example(NULL, argc, argv);
+#else
+    printf("Wrapper code not compiled in\n");
+    (void)argc;
+    (void)argv;
+#endif /* !WOLFTPM2_NO_WRAPPER */
+
+    return rc;
+}
+#endif

--- a/examples/attestation/credential.h
+++ b/examples/attestation/credential.h
@@ -1,0 +1,38 @@
+/* credential.h
+ *
+ * Copyright (C) 2006-2021 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef _CREDENTIAL_H_
+#define _CREDENTIAL_H_
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+#define CRED_SECRET_SIZE 32
+
+int TPM2_MakeCredential_Example(void* userCtx, int argc, char *argv[]);
+int TPM2_ActivateCredential_Example(void* userCtx, int argc, char *argv[]);
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* _CREDENTIAL_H_ */

--- a/examples/attestation/include.am
+++ b/examples/attestation/include.am
@@ -1,0 +1,30 @@
+# vim:ft=automake
+# All paths should be given relative to the root
+
+if BUILD_EXAMPLES
+noinst_PROGRAMS += examples/attestation/make_credential \
+                   examples/attestation/activate_credential
+
+noinst_HEADERS  += examples/attestation/credential.h
+
+examples_attestation_make_credential_SOURCES      = examples/attestation/make_credential.c \
+                                                      examples/tpm_io.c \
+                                                      examples/tpm_test_keys.c
+examples_attestation_make_credential_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
+examples_attestation_make_credential_DEPENDENCIES = src/libwolftpm.la
+
+examples_attestation_activate_credential_SOURCES      = examples/attestation/activate_credential.c \
+                                  examples/tpm_io.c \
+                                  examples/tpm_test_keys.c
+examples_attestation_activate_credential_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
+examples_attestation_activate_credential_DEPENDENCIES = src/libwolftpm.la
+
+endif
+
+dist_example_DATA+= examples/attestation/make_credential.c \
+                    examples/attestation/activate_credential.c
+
+DISTCLEANFILES+= examples/attestation/.libs/make_credential \
+                 examples/attestation/.libs/activate_credential
+
+EXTRA_DIST+= examples/attestation/README.md

--- a/examples/attestation/make_credential.c
+++ b/examples/attestation/make_credential.c
@@ -1,0 +1,184 @@
+/* make_credential.c
+ *
+ * Copyright (C) 2006-2021 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/* This example shows how to create a challenge for Remote Attestation */
+
+#include <wolftpm/tpm2_wrap.h>
+
+#ifndef WOLFTPM2_NO_WRAPPER
+
+#include <examples/attestation/credential.h>
+#include <examples/tpm_io.h>
+#include <examples/tpm_test.h>
+#include <examples/tpm_test_keys.h>
+
+#include <stdio.h>
+
+
+/******************************************************************************/
+/* --- BEGIN TPM2.0 Make Credential example tool  -- */
+/******************************************************************************/
+
+static void usage(void)
+{
+    printf("Expected usage:\n");
+    printf("./examples/attestation/make_credential [cred.blob]\n");
+    printf("* cred.blob is a output file holding the generated credential.\n");
+    printf("Demo usage without parameters, uses \"cred.blob\" filename.\n");
+}
+
+int TPM2_MakeCredential_Example(void* userCtx, int argc, char *argv[])
+{
+    int rc = -1;
+    WOLFTPM2_DEV dev;
+    WOLFTPM2_KEY storage;
+    WOLFTPM2_KEYBLOB akKey;
+    FILE *fp;
+    const char *output = "cred.blob";
+    const char *keyblob = "keyblob.bin";
+    int dataSize = 0;
+
+    union {
+        MakeCredential_In makeCred;
+        byte maxInput[MAX_COMMAND_SIZE];
+    } cmdIn;
+    union {
+        MakeCredential_Out makeCred;
+        byte maxOutput[MAX_RESPONSE_SIZE];
+    } cmdOut;
+
+    if (argc == 1) {
+        printf("Using default values\n");
+    }
+    else if (argc == 2) {
+        if (XSTRNCMP(argv[1], "-?", 2) == 0 ||
+            XSTRNCMP(argv[1], "-h", 2) == 0 ||
+            XSTRNCMP(argv[1], "--help", 6) == 0) {
+            usage();
+            return 0;
+        }
+        if (argv[1][0] != '-') {
+            output = argv[1];
+        }
+    }
+    else {
+        printf("Incorrect arguments\n");
+        usage();
+        goto exit_badargs;
+    }
+
+    XMEMSET(&storage, 0, sizeof(storage));
+    XMEMSET(&akKey, 0, sizeof(akKey));
+
+    printf("Demo how to create a credential blob for remote attestation\n");
+    rc = wolfTPM2_Init(&dev, TPM2_IoCb, userCtx);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("wolfTPM2_Init failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("wolfTPM2_Init: success\n");
+
+    printf("Credential will be stored in %s\n", output);
+
+    /* Prepare the auth password for the storage key */
+    storage.handle.auth.size = sizeof(gStorageKeyAuth)-1;
+    XMEMCPY(storage.handle.auth.buffer, gStorageKeyAuth,
+            storage.handle.auth.size);
+    wolfTPM2_SetAuthPassword(&dev, 0, &storage.handle.auth);
+
+    /* Prepare the Make Credential command */
+    XMEMSET(&cmdIn.makeCred, 0, sizeof(cmdIn.makeCred));
+    XMEMSET(&cmdOut.makeCred, 0, sizeof(cmdOut.makeCred));
+    cmdIn.makeCred.handle = TPM2_DEMO_STORAGE_KEY_HANDLE;
+    /* Create secret for the attestation server - a symmetric key seed */
+    cmdIn.makeCred.credential.size = CRED_SECRET_SIZE;
+    wolfTPM2_GetRandom(&dev, cmdIn.makeCred.credential.buffer,
+                        cmdIn.makeCred.credential.size);
+    /* Acquire the Name of the Attestation Key */
+    rc = readKeyBlob(keyblob, &akKey);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("Failure to read keyblob.\n");
+    }
+    storage.handle.hndl = TPM2_DEMO_STORAGE_KEY_HANDLE;
+    rc = wolfTPM2_LoadKey(&dev, &akKey, &storage.handle);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("Failure to load the AK and read its Name.\n");
+        goto exit;
+    }
+    printf("AK loaded at 0x%x\n", (word32)akKey.handle.hndl);
+    /* Copy the AK name into the command request */
+    cmdIn.makeCred.objectName.size = akKey.handle.name.size;
+    XMEMCPY(cmdIn.makeCred.objectName.name, akKey.handle.name.name,
+                cmdIn.makeCred.objectName.size);
+    /* All required data for a credential is prepared */
+    rc = TPM2_MakeCredential(&cmdIn.makeCred, &cmdOut.makeCred);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_MakeCredentials failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("TPM2_MakeCredential success\n");
+
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
+    fp = XFOPEN(output, "wb");
+    if (fp != XBADFILE) {
+        dataSize = (int)XFWRITE((BYTE*)&cmdOut.makeCred.credentialBlob, 1,
+                                sizeof(cmdOut.makeCred.credentialBlob), fp);
+        dataSize = (int)XFWRITE((BYTE*)&cmdOut.makeCred.secret, 1,
+                                sizeof(cmdOut.makeCred.secret), fp);
+        XFCLOSE(fp);
+    }
+    printf("Wrote credential blob and secret to %s, %d bytes\n", output, dataSize);
+#else
+    printf("Can not store credential. File support not enabled\n");
+#endif
+
+exit:
+
+    wolfTPM2_UnloadHandle(&dev, &akKey.handle);
+    wolfTPM2_Cleanup(&dev);
+
+exit_badargs:
+
+    return rc;
+}
+
+/******************************************************************************/
+/* --- END TPM2.0 Make Credential example tool -- */
+/******************************************************************************/
+#endif /* !WOLFTPM2_NO_WRAPPER */
+
+#ifndef NO_MAIN_DRIVER
+int main(int argc, char *argv[])
+{
+    int rc = -1;
+
+#ifndef WOLFTPM2_NO_WRAPPER
+    rc = TPM2_MakeCredential_Example(NULL, argc, argv);
+#else
+    printf("Wrapper code not compiled in\n");
+    (void)argc;
+    (void)argv;
+#endif /* !WOLFTPM2_NO_WRAPPER */
+
+    return rc;
+}
+#endif

--- a/examples/include.am
+++ b/examples/include.am
@@ -14,6 +14,7 @@ include examples/keygen/include.am
 include examples/nvram/include.am
 include examples/gpio/include.am
 include examples/seal/include.am
+include examples/attestation/include.am
 
 dist_example_DATA+= examples/README.md \
                     examples/tpm_io.c \

--- a/examples/keygen/keygen.c
+++ b/examples/keygen/keygen.c
@@ -33,7 +33,7 @@
 
 #ifndef WOLFTPM2_NO_WRAPPER
 
-#define SYM_EXTRA_OPTS_LEN 14 /* 5 for "-sym=" and 6 for extra options */
+#define SYM_EXTRA_OPTS_LEN 14 /* 5 chars for "-sym=" and 9 for extra options */
 #define SYM_EXTRA_OPTS_POS 4  /* Array pos of the equal sign for extra opts */
 #define SYM_EXTRA_OPTS_AES_MODE_POS 8
 #define SYM_EXTRA_OPTS_KEY_BITS_POS 11


### PR DESCRIPTION
This PR adds needed examples for remote attestation.

In nutshell, to perform remote attestation, we need a way to establish initial trust between the client and attestation server. For this purpose, the TPM2_MakeCredential and TPM2_ActivateCredential commands exist. This PR adds examples for both of them.

Next step would be the addition of TLS1.3 client/server example performing the challenge* and response**.

* challenge created using examples/make_credential
* response created using examples/activate_credential

The actual transport layer used to transfer the challenge-response sequence is up to the developer.