### PR TITLE
Fix for building GPIO example and IO HAL cleanup

### DIFF
--- a/examples/gpio/gpio.h
+++ b/examples/gpio/gpio.h
@@ -26,8 +26,10 @@
     extern "C" {
 #endif
 
+#if defined(WOLFTPM_ST33) || defined(WOLFTPM_AUTODETECT)
 #define GPIO_NUM_MIN TPM_GPIO_A
 #define GPIO_NUM_MAX (TPM_GPIO_COUNT-1) /* see wolftpm/tpm2.h */
+#endif
 
 int TPM2_GPIO_Config_Example(void* userCtx, int argc, char *argv[]);
 int TPM2_GPIO_Read_Example(void* userCtx, int argc, char *argv[]);

--- a/examples/gpio/gpio_read.c
+++ b/examples/gpio/gpio_read.c
@@ -35,7 +35,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifndef WOLFTPM2_NO_WRAPPER
+#if !defined(WOLFTPM2_NO_WRAPPER) && \
+    (defined(WOLFTPM_ST33) || defined(WOLFTPM_AUTODETECT))
 
 /******************************************************************************/
 /* --- BEGIN TPM GPIO Read Example -- */
@@ -117,14 +118,15 @@ exit:
 /******************************************************************************/
 /* --- END TPM GPIO Store Example -- */
 /******************************************************************************/
-#endif /* !WOLFTPM2_NO_WRAPPER */
+#endif /* !WOLFTPM2_NO_WRAPPER && (WOLFTPM_ST33 || WOLFTPM_AUTODETECT) */
 
 #ifndef NO_MAIN_DRIVER
 int main(int argc, char *argv[])
 {
     int rc = NOT_COMPILED_IN;
 
-#ifndef WOLFTPM2_NO_WRAPPER
+#if !defined(WOLFTPM2_NO_WRAPPER) && \
+    (defined(WOLFTPM_ST33) || defined(WOLFTPM_AUTODETECT))
     rc = TPM2_GPIO_Read_Example(NULL, argc, argv);
 #else
     printf("GPIO code not compiled in\n");

--- a/examples/gpio/gpio_set.c
+++ b/examples/gpio/gpio_set.c
@@ -34,7 +34,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifndef WOLFTPM2_NO_WRAPPER
+#if !defined(WOLFTPM2_NO_WRAPPER) && \
+    (defined(WOLFTPM_ST33) || defined(WOLFTPM_AUTODETECT))
 
 /******************************************************************************/
 /* --- BEGIN TPM GPIO Set Example -- */
@@ -122,14 +123,15 @@ exit:
 /******************************************************************************/
 /* --- END TPM GPIO Set Example -- */
 /******************************************************************************/
-#endif /* !WOLFTPM2_NO_WRAPPER */
+#endif /* !WOLFTPM2_NO_WRAPPER && (WOLFTPM_ST33 || WOLFTPM_AUTODETECT) */
 
 #ifndef NO_MAIN_DRIVER
 int main(int argc, char *argv[])
 {
     int rc = NOT_COMPILED_IN;
 
-#ifndef WOLFTPM2_NO_WRAPPER
+#if !defined(WOLFTPM2_NO_WRAPPER) && \
+    (defined(WOLFTPM_ST33) || defined(WOLFTPM_AUTODETECT))
     rc = TPM2_GPIO_Set_Example(NULL, argc, argv);
 #else
     printf("GPIO code not compiled in\n");

--- a/examples/tpm_io.c
+++ b/examples/tpm_io.c
@@ -872,23 +872,19 @@ int TPM2_IoCb(TPM2_CTX* ctx, int isRead, word32 addr, byte* buf, word16 size,
         (void)userCtx;
     #endif
 #else
-    /* Build SPI format buffer */
+    /* Build TPM header */
+    txBuf[1] = (addr>>16) & 0xFF;
+    txBuf[2] = (addr>>8)  & 0xFF;
+    txBuf[3] = (addr)     & 0xFF;
     if (isRead) {
         txBuf[0] = TPM_TIS_READ | ((size & 0xFF) - 1);
-        txBuf[1] = (addr>>16) & 0xFF;
-        txBuf[2] = (addr>>8)  & 0xFF;
-        txBuf[3] = (addr)     & 0xFF;
-        txBuf[4] = 0x00;
         XMEMSET(&txBuf[TPM_TIS_HEADER_SZ], 0, size);
     }
     else {
         txBuf[0] = TPM_TIS_WRITE | ((size & 0xFF) - 1);
-        txBuf[1] = (addr>>16) & 0xFF;
-        txBuf[2] = (addr>>8)  & 0xFF;
-        txBuf[3] = (addr)     & 0xFF;
-        txBuf[4] = 0x00;
         XMEMCPY(&txBuf[TPM_TIS_HEADER_SZ], buf, size);
     }
+    XMEMSET(rxBuf, 0, sizeof(rxBuf));
 
     ret = TPM2_IoCb_SPI(ctx, txBuf, rxBuf, size + TPM_TIS_HEADER_SZ, userCtx);
 

--- a/src/tpm2_tis.c
+++ b/src/tpm2_tis.c
@@ -194,7 +194,6 @@ int TPM2_TIS_Read(TPM2_CTX* ctx, word32 addr, byte* result,
     txBuf[1] = (addr>>16) & 0xFF;
     txBuf[2] = (addr>>8)  & 0xFF;
     txBuf[3] = (addr)     & 0xFF;
-    txBuf[4] = 0x00;
     XMEMSET(&txBuf[TPM_TIS_HEADER_SZ], 0, len);
     XMEMSET(rxBuf, 0, sizeof(rxBuf));
 
@@ -230,7 +229,6 @@ int TPM2_TIS_Write(TPM2_CTX* ctx, word32 addr, const byte* value,
     txBuf[1] = (addr>>16) & 0xFF;
     txBuf[2] = (addr>>8)  & 0xFF;
     txBuf[3] = (addr)     & 0xFF;
-    txBuf[4] = 0x00;
     XMEMCPY(&txBuf[TPM_TIS_HEADER_SZ], value, len);
     XMEMSET(rxBuf, 0, sizeof(rxBuf));
 


### PR DESCRIPTION
* Fix for building GPIO example without ST/auto-detect.
* Cleanup obsolete `txBuf[4] = 0x00;` replaced with SPI check wait state logic. The `TPM_TIS_HEADER_SZ` is always 4.