### PR TITLE
Quickfix of invalid pcrIndex number

### DIFF
--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -2462,9 +2462,9 @@ int wolfTPM2_ReadPCR(WOLFTPM2_DEV* dev, int pcrIndex, int hashAlg, byte* digest,
     int rc;
     PCR_Read_In  pcrReadIn;
     PCR_Read_Out pcrReadOut;
-    int digestLen;
+    int digestLen = 0;
 
-    if (dev == NULL)
+    if (dev == NULL || pcrIndex < PCR_FIRST || pcrIndex > PCR_LAST)
         return BAD_FUNC_ARG;
 
     /* set session auth to blank */


### PR DESCRIPTION
Typical TPM 2.0 implementations have only 24 PCR registers.

Before, wolfTPM2_ReadPCR would fail with TPM_RC_VALUE if invalid value is given.

Per a user request, we modify wolfTPM2_ReadPCR, so it does not accept invalid values.

Signed-off-by: Dimitar Tomov <dimi@wolfssl.com>