### PR TITLE
Quickfix in TPM2_SetupPCRSel, allow only valid pcrIndex values

### DIFF
--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -5349,7 +5349,7 @@ int TPM2_GetName(TPM2_CTX* ctx, UINT32 handleValue, int handleCnt, int idx, TPM2
 
 void TPM2_SetupPCRSel(TPML_PCR_SELECTION* pcr, TPM_ALG_ID alg, int pcrIndex)
 {
-    if (pcr) {
+    if (pcr && pcrIndex >= PCR_FIRST && pcrIndex <= PCR_LAST) {
         pcr->count = 1;
         pcr->pcrSelections[0].hash = alg;
         pcr->pcrSelections[0].sizeofSelect = PCR_SELECT_MIN;


### PR DESCRIPTION
One-liner fix, thanks to feedback from Hadrien in the wolfSSL forum.

https://www.wolfssl.com/forums/topic1735-identity-attestation.html

Signed-off-by: Dimitar Tomov <dimi@wolfssl.com>