### PR TITLE
Do not use `WOLFSSL_MSG`

### DIFF
--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -63,7 +63,9 @@ static TPM_RC TPM2_AcquireLock(TPM2_CTX* ctx)
 
     if (!ctx->hwLockInit) {
         if (wc_InitMutex(&ctx->hwLock) != 0) {
-            WOLFSSL_MSG("TPM Mutex Init failed");
+        #ifdef DEBUG_WOLFTPM
+            printf("TPM Mutex Init failed\n");
+        #endif
             return TPM_RC_FAILURE;
         }
         ctx->hwLockInit = 1;


### PR DESCRIPTION
Fixes:
```
/usr/bin/ld: src/.libs/libwolftpm.a(libwolftpm_la-tpm2.o): in function `TPM2_AcquireLock':
/home/pi/wolftpm/src/tpm2.c:66: undefined reference to `WOLFSSL_MSG'
```