### PR TITLE
Added option to create keys under the EK in keygen example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,10 @@ src/.deps
 src/.libs
 RemoteSystemsTempFiles
 *.o
+*.dep
 *.deps
 *.libs
+IDE/IAR-EWARM/settings
 wolftpm/options.h
 
 examples/wrap/wrap_test
@@ -75,12 +77,16 @@ certs/server-*.pem
 certs/client-*.der
 certs/client-*.pem
 certs/serial.old
-*.dep
-IDE/IAR-EWARM/settings
+
+# Test files
 quote.blob
 keyblob.bin
 ecc_test_blob.raw
 rsa_test_blob.raw
+ak.name
+cred.blob
+ek.pub
+srk.pub
 
 # Generated Documentation
 docs/html

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,6 +44,15 @@ More information about how to test and use PCR attestation can be found in the i
 `./examples/pcr/extend`
 `./examples/pcr/reset`
 
+### Remote Attestation challenge
+
+Demonstrates how to create Remote Attestation challenge using the TPM 2.0 and afterwards prepare a response.
+
+Detailed information about using these examples can be found in  [examples/attestation/README.md](./examples/attestation/README.md)
+
+`./examples/attestation/make_credential`
+`./examples/attestation/activate_credential`
+
 ## Parameter Encryption
 
 ### Key generation with encrypted authorization

--- a/examples/attestation/README.md
+++ b/examples/attestation/README.md
@@ -12,6 +12,8 @@ Complete list of the required examples is shown below:
 * `./examples/attestation/activate_credential`: Used by a client to decrypt the challenge and respond
 * `./examples/keygen/keygen`: Used to create a primary key(PK) and attestation key(AK)
 
+Note: All of these example allow the use of the Endorsement Key and Attestation Key under the Endorsement Hierarchy. This is done by adding the `-eh` option when executing any of the three examples above. The advantage of using EK/EH is that the private key material of the EK never leaves the TPM. Anything encrypted using the public part of the EK can be encrypted only internally by the TPM owner of the EK, and EK is unique for every TPM chip. Therefore, creating challenges for Remote Attestation using the EK/EH has greater value in some scenarios. One drawback is that by using the EK the identity of the host under attestation is always known, because the EK private-public key pair identifies the TPM and in some scenarios this might rise privacy concerns. Our remote attestation examples support both AK under SRK and AK under EK. It is up to the developer to decide which one to use.
+
 ## Technology introduction
 
 Remote Attestation is the process of a client providing an evidence to an attestation server that verifies if the client is in a known state.

--- a/examples/attestation/README.md
+++ b/examples/attestation/README.md
@@ -43,7 +43,6 @@ Note:
 Using the `keygen` example we can create the necessary TPM 2.0 Attestation Key and TPM 2.0 Primary Storage Key that will be used as a Primary Attestation Key(PAK).
 
 ```
-
 $ ./examples/keygen/keygen -rsa
 TPM2.0 Key generation example
 	Key Blob: keyblob.bin
@@ -55,7 +54,6 @@ RSA AIK template
 Creating new RSA key...
 Created new key (pub 280, priv 222 bytes)
 Wrote 508 bytes to keyblob.bin
-
 ```
 
 ### Make Credential Example Usage
@@ -63,7 +61,6 @@ Wrote 508 bytes to keyblob.bin
 Using the `make_credential` example an attestation server can generate remote attestation challenge. The secret is 32 bytes of randomly generated seed that could be used for a symmetric key in some remote attestation schemes.
 
 ```
-
 $ ./examples/attestation/make_credential
 Using default values
 Demo how to create a credential blob for remote attestation
@@ -74,7 +71,6 @@ Reading the private part of the key
 AK loaded at 0x80000001
 TPM2_MakeCredential success
 Wrote credential blob and secret to cred.blob, 514 bytes
-
 ```
 
 The transfer of the PAK and AK public parts between the client and attestation server is not part of the `make_credential` example, because the exchange is implementation specific.
@@ -84,7 +80,6 @@ The transfer of the PAK and AK public parts between the client and attestation s
 Using the `activate_credential` example a client can decrypt the remote attestation challenge. The secret will be exposed in plain and can be exchanged with the attestation server.
 
 ```
-
 $ ./examples/attestation/activate_credential
 Using default values
 Demo how to create a credential blob for remote attestation
@@ -99,7 +94,6 @@ TPM2_StartAuthSession: sessionHandle 0x3000000
 TPM2_policyCommandCode success
 Read credential blob and secret from cred.blob, 514 bytes
 TPM2_ActivateCredential success
-
 ```
 
 The transfer of the challenge response containing the secret in plain (or used as a symmetric key seed) is not part of the `activate_credential` example, because the exchange is also implementation specific.

--- a/examples/attestation/activate_credential.c
+++ b/examples/attestation/activate_credential.c
@@ -182,7 +182,8 @@ int TPM2_ActivateCredential_Example(void* userCtx, int argc, char *argv[])
                                 sizeof(cmdIn.activCred.secret), fp);
         XFCLOSE(fp);
     }
-    printf("Read credential blob and secret from %s, %d bytes\n", input, dataSize);
+    printf("Read credential blob and secret from %s, %d bytes\n",
+        input, dataSize);
 #else
     printf("Can not load credential. File support not enabled\n");
     goto exit;

--- a/examples/attestation/make_credential.c
+++ b/examples/attestation/make_credential.c
@@ -129,7 +129,8 @@ int TPM2_MakeCredential_Example(void* userCtx, int argc, char *argv[])
         goto exit;
     }
     /* Prepare the key for use by the TPM */
-    XMEMCPY(&cmdIn.loadExtIn.inPublic, &primary.pub, sizeof(cmdIn.loadExtIn.inPublic));
+    XMEMCPY(&cmdIn.loadExtIn.inPublic, &primary.pub,
+        sizeof(cmdIn.loadExtIn.inPublic));
     cmdIn.loadExtIn.hierarchy = TPM_RH_NULL;
     rc = TPM2_LoadExternal(&cmdIn.loadExtIn, &cmdOut.loadExtOut);
     if (rc != TPM_RC_SUCCESS) {
@@ -175,7 +176,8 @@ int TPM2_MakeCredential_Example(void* userCtx, int argc, char *argv[])
                                 sizeof(cmdOut.makeCred.secret), fp);
         XFCLOSE(fp);
     }
-    printf("Wrote credential blob and secret to %s, %d bytes\n", output, dataSize);
+    printf("Wrote credential blob and secret to %s, %d bytes\n",
+        output, dataSize);
 #else
     printf("Can not store credential. File support not enabled\n");
 #endif

--- a/examples/csr/csr.c
+++ b/examples/csr/csr.c
@@ -166,6 +166,7 @@ int TPM2_CSR_ExampleArgs(void* userCtx, int argc, char *argv[])
     /* Init the TPM2 device */
     rc = wolfTPM2_Init(&dev, TPM2_IoCb, userCtx);
     if (rc != 0) return rc;
+    XMEMSET(&storageKey, 0, sizeof(storageKey));
 
     /* Setup the wolf crypto device callback */
     XMEMSET(&tpmCtx, 0, sizeof(tpmCtx));

--- a/examples/keygen/keygen.c
+++ b/examples/keygen/keygen.c
@@ -46,7 +46,11 @@
 static void usage(void)
 {
     printf("Expected usage:\n");
-    printf("./examples/keygen/keygen [keyblob.bin] [-ecc/-rsa/-sym] [-t] [-aes/xor]\n");
+    printf("./examples/keygen/keygen [keyblob.bin] [-ecc/-rsa/-sym] [-t] [-aes/xor] [-eh] [-pem]\n");
+    printf("* -pem: Store the primary and child public keys as PEM formated files\n");
+    printf("\t child public key filename: ak.pem or key.pem\n");
+    printf("\t primary public key filename: ek.pem or srk.pem\n");
+    printf("* -eh: Create keys under the Endorsement Hierarchy (EK)\n");
     printf("* -rsa: Use RSA for asymmetric key generation (DEFAULT)\n");
     printf("* -ecc: Use ECC for asymmetric key generation \n");
     printf("* -sym: Use Symmetric Cypher for key generation\n");
@@ -108,20 +112,32 @@ int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[])
 {
     int rc;
     WOLFTPM2_DEV dev;
+    WOLFTPM2_KEY endorse; /* EK */
     WOLFTPM2_KEY storage; /* SRK */
+    WOLFTPM2_KEY *primary = NULL;
     WOLFTPM2_KEY aesKey; /* Symmetric key */
-    WOLFTPM2_KEYBLOB newKey;
+    WOLFTPM2_KEY newKey; /* child or attestation key */
+    WOLFTPM2_KEYBLOB newKeyBlob; /* newKey as WOLFTPM2_KEYBLOB */
+    WOLFTPM2_KEYBLOB primaryBlob; /* Primary key as WOLFTPM2_KEYBLOB */
     TPMT_PUBLIC publicTemplate;
     TPMI_ALG_PUBLIC alg = TPM_ALG_RSA; /* default, see usage() for options */
     TPM_ALG_ID algSym = TPM_ALG_CTR; /* default Symmetric Cypher, see usage */
     TPM_ALG_ID paramEncAlg = TPM_ALG_NULL;
     WOLFTPM2_SESSION tpmSession;
     TPM2B_AUTH auth;
+    int endorseKey = 0;
+    int pemFiles = 0;
     int bAIK = 1;
     int keyBits = 256;
-    const char* outputFile = "keyblob.bin";
+    const char *outputFile = "keyblob.bin";
+    const char *nameFile = "ak.name"; /* Name Digest for attestation purposes */
+    const char *ekPubFile = "ek.pub";
+    const char *srkPubFile = "srk.pub";
+    const char *pubFilename = NULL;
+    const char *pemFilename = NULL;
     size_t len = 0;
     char symMode[] = "aesctr";
+    FILE *fp;
 
     if (argc >= 2) {
         if (XSTRNCMP(argv[1], "-?", 2) == 0 ||
@@ -160,6 +176,12 @@ int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[])
         if (XSTRNCMP(argv[argc-1], "-t", 2) == 0) {
             bAIK = 0;
         }
+        if (XSTRNCMP(argv[argc-1], "-eh", 3) == 0) {
+            endorseKey = 1;
+        }
+        if (XSTRNCMP(argv[argc-1], "-pem", 4) == 0) {
+            pemFiles = 1;
+        }
         if (XSTRNCMP(argv[argc-1], "-aes", 4) == 0) {
             paramEncAlg = TPM_ALG_CFB;
         }
@@ -169,9 +191,12 @@ int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[])
         argc--;
     }
 
+    XMEMSET(&endorse, 0, sizeof(endorse));
     XMEMSET(&storage, 0, sizeof(storage));
-    XMEMSET(&newKey, 0, sizeof(newKey));
     XMEMSET(&aesKey, 0, sizeof(aesKey));
+    XMEMSET(&newKey, 0, sizeof(newKey));
+    XMEMSET(&newKeyBlob, 0, sizeof(newKeyBlob));
+    XMEMSET(&primaryBlob, 0, sizeof(primaryBlob));
     XMEMSET(&tpmSession, 0, sizeof(tpmSession));
     XMEMSET(&auth, 0, sizeof(auth));
 
@@ -190,22 +215,39 @@ int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[])
         goto exit;
     }
 
-    /* get SRK */
-    rc = getPrimaryStoragekey(&dev, &storage, TPM_ALG_RSA);
+    if(endorseKey) {
+        rc = wolfTPM2_CreateEK(&dev, &endorse, TPM_ALG_RSA);
+        endorse.handle.policyAuth = 1; /* EK requires Policy auth, not Password */
+        pubFilename = ekPubFile;
+        primary = &endorse;
+    }
+    else {
+        /* get SRK */
+        rc = getPrimaryStoragekey(&dev, &storage, TPM_ALG_RSA);
+        pubFilename = srkPubFile;
+        primary = &storage;
+    }
     if (rc != 0) goto exit;
 
     if (paramEncAlg != TPM_ALG_NULL) {
         /* Start an authenticated session (salted / unbound) with parameter encryption */
-        rc = wolfTPM2_StartSession(&dev, &tpmSession, &storage, NULL,
+        rc = wolfTPM2_StartSession(&dev, &tpmSession, primary, NULL,
             TPM_SE_HMAC, paramEncAlg);
         if (rc != 0) goto exit;
         printf("TPM2_StartAuthSession: sessionHandle 0x%x\n",
             (word32)tpmSession.handle.hndl);
 
-        /* set session for authorization of the storage key */
+        /* set session for authorization of the primary key */
         rc = wolfTPM2_SetAuthSession(&dev, 1, &tpmSession,
             (TPMA_SESSION_decrypt | TPMA_SESSION_encrypt | TPMA_SESSION_continueSession));
         if (rc != 0) goto exit;
+    }
+
+    if (endorseKey) {
+        /* Endorsement Key requires authorization with Policy */
+        wolfTPM2_CreateAuthSession_EkPolicy(&dev, &tpmSession);
+        /* Set the created Policy Session for use in next operation */
+        wolfTPM2_SetAuthSession(&dev, 0, &tpmSession, 0);
     }
 
     /* Create new key */
@@ -261,26 +303,73 @@ int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[])
     if (rc != 0) goto exit;
 
     printf("Creating new %s key...\n", TPM2_GetAlgName(alg));
-    rc = wolfTPM2_CreateKey(&dev, &newKey, &storage.handle,
+    rc = wolfTPM2_CreateLoadedKey(&dev, &newKeyBlob, &primary->handle,
                             &publicTemplate, auth.buffer, auth.size);
     if (rc != TPM_RC_SUCCESS) {
-        printf("wolfTPM2_CreateKey failed\n");
+        printf("wolfTPM2_CreateLoadedKey failed\n");
         goto exit;
     }
-    printf("Created new key (pub %d, priv %d bytes)\n",
-        newKey.pub.size, newKey.priv.size);
+    printf("New key created and loaded (pub %d, priv %d bytes)\n",
+        newKeyBlob.pub.size, newKeyBlob.priv.size);
 
     /* Save key as encrypted blob to the disk */
 #if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
-    rc = writeKeyBlob(outputFile, &newKey);
+    rc = writeKeyBlob(outputFile, &newKeyBlob);
+    /* Generate key artifacts needed for remote attestation */
+    if (bAIK) {
+        /* Store primary public key */
+        XMEMCPY(&primaryBlob.pub, &primary->pub, sizeof(primaryBlob.pub));
+        rc |= writeKeyBlob(pubFilename, &primaryBlob);
+        /* Write AK's Name digest */
+        fp = XFOPEN(nameFile, "wb");
+        if (fp != XBADFILE) {
+            XFWRITE((BYTE*)&newKeyBlob.name, 1, sizeof(newKeyBlob.name), fp);
+            printf("Wrote AK Name digest\n");
+            XFCLOSE(fp);
+        }
+    }
 #else
     if(alg == TPM_ALG_SYMCIPHER) {
         printf("The Public Part of a symmetric key contains only meta data\n");
     }
-    printf("Key Public Blob %d\n", newKey.pub.size);
-    TPM2_PrintBin((const byte*)&newKey.pub.publicArea, newKey.pub.size);
-    printf("Key Private Blob %d\n", newKey.priv.size);
-    TPM2_PrintBin(newKey.priv.buffer, newKey.priv.size);
+    printf("Key Public Blob %d\n", newKeyBlob.pub.size);
+    TPM2_PrintBin((const byte*)&newKeyBlob.pub.publicArea, newKeyBlob.pub.size);
+    printf("Key Private Blob %d\n", newKeyBlob.priv.size);
+    TPM2_PrintBin(newKeyBlob.priv.buffer, newKeyBlob.priv.size);
+#endif
+
+    /* Save EK public key as PEM format file to the disk */
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
+    if (pemFiles) {
+        byte pem[MAX_RSA_KEY_BYTES], tempBuf[MAX_RSA_KEY_BYTES];
+        int pemSz, tempSz = sizeof(tempBuf);
+
+        if (endorseKey) {
+            pemFilename = pemFileEk;
+        }
+        else {
+            pemFilename = pemFileSrk;
+        }
+
+        rc = wolfTPM2_RsaKey_TpmToPem(&dev, primary, pem, &pemSz, tempBuf, tempSz);
+        if (rc == 0) {
+            rc = writeKeyPubPem(pemFilename, pem, (word32)pemSz);
+        }
+
+        if (bAIK) {
+            pemFilename = pemFileAk;
+        }
+        else {
+            pemFilename = pemFileKey;
+        }
+
+        rc = wolfTPM2_RsaKey_TpmToPem(&dev, &newKey, pem, &pemSz, tempBuf, tempSz);
+        if (rc == 0) {
+            rc = writeKeyPubPem(pemFilename, pem, (word32)pemSz);
+        }
+    }
+#else
+    printf("Unable to store EK pub as PEM file. Lack of file support\n");
 #endif
 
 exit:
@@ -290,9 +379,12 @@ exit:
     }
 
     /* Close handles */
-    wolfTPM2_UnloadHandle(&dev, &storage.handle);
-    wolfTPM2_UnloadHandle(&dev, &newKey.handle);
-    wolfTPM2_UnloadHandle(&dev, &tpmSession.handle);
+    wolfTPM2_UnloadHandle(&dev, &primary->handle);
+    wolfTPM2_UnloadHandle(&dev, &newKeyBlob.handle);
+    /* EK policy is destroyed after use, flush parameter encryption session */
+    if(!endorseKey) {
+        wolfTPM2_UnloadHandle(&dev, &tpmSession.handle);
+    }
 
     wolfTPM2_Cleanup(&dev);
     return rc;

--- a/examples/management/flush.c
+++ b/examples/management/flush.c
@@ -41,7 +41,10 @@ static void usage(void)
     printf("./tool/management/flush [handle]\n");
     printf("* handle is a valid TPM2.0 handle index\n");
     printf("Note: Default behavior, without parameters, the tool flushes\n"
-           "\tall transient TPM2.0 objects (0x8000000x, 0x300000x)\n");
+           "\tcommon transient TPM2.0 objects, including:\n"
+           "- Transient Key handles 0x8000000\n"
+           "- Transient Policy sessions 0x0300000x\n"
+           "- Transient HMAC sessions 0x0200000x\n");
 }
 
 int TPM2_Flush_Tool(void* userCtx, int argc, char *argv[])
@@ -79,12 +82,18 @@ int TPM2_Flush_Tool(void* userCtx, int argc, char *argv[])
 
     if (allTransientObjects) {
         /* Flush key objects */
-        for (handle=0x80000000; handle < (int)0x8000000A; handle+=4) {
+        for (handle=0x80000000; handle < (int)0x8000000A; handle++) {
             flushCtx.flushHandle = handle;
             printf("Freeing %X object\n", handle);
             TPM2_FlushContext(&flushCtx);
         }
-        /* Flush auth sessions */
+        /* Flush policy sessions */
+        for (handle=0x3000000; handle < (int)0x3000004; handle++) {
+            flushCtx.flushHandle = handle;
+            printf("Freeing %X object\n", handle);
+            TPM2_FlushContext(&flushCtx);
+        }
+        /* Flush hmac sessions */
         for (handle=0x3000000; handle < (int)0x3000004; handle++) {
             flushCtx.flushHandle = handle;
             printf("Freeing %X object\n", handle);

--- a/examples/pkcs7/pkcs7.c
+++ b/examples/pkcs7/pkcs7.c
@@ -317,6 +317,7 @@ int TPM2_PKCS7_ExampleArgs(void* userCtx, int argc, char *argv[])
 
     XMEMSET(&der, 0, sizeof(der));
     XMEMSET(&rsaKey, 0, sizeof(rsaKey));
+    XMEMSET(&storageKey, 0, sizeof(storageKey));
 
     /* Init the TPM2 device */
     rc = wolfTPM2_Init(&dev, TPM2_IoCb, userCtx);

--- a/examples/tpm_test.h
+++ b/examples/tpm_test.h
@@ -54,6 +54,11 @@ static const char gUsageAuth[] =      "ThisIsASecretUsageAuth";
 static const char gNvAuth[] =         "ThisIsMyNvAuth";
 static const char gXorAuth[] =        "ThisIsMyXorAuth";
 
+static const char pemFileAk[] = "ak.pem";
+static const char pemFileEk[] = "ek.pem";
+static const char pemFileSrk[] = "srk.pem";
+static const char pemFileKey[] = "key.pem";
+
 /* Default Test PCR */
 /* PCR16 is for DEBUG purposes, thus safe to use */
 #define TPM2_TEST_PCR 16

--- a/examples/tpm_test_keys.c
+++ b/examples/tpm_test_keys.c
@@ -35,6 +35,35 @@
 
 #ifndef WOLFTPM2_NO_WRAPPER
 
+int writeKeyPubPem(const char* filename, byte *buf, int bufSz)
+{
+    int rc = TPM_RC_FAILURE;
+
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
+    XFILE fp = NULL;
+    size_t fileSz = 0;
+
+    if (filename == NULL || buf == NULL)
+        return BAD_FUNC_ARG;
+
+    fp = XFOPEN(filename, "wt");
+    if (fp != XBADFILE) {
+        fileSz = XFWRITE(buf, 1, bufSz, fp);
+        /* sanity check */
+        if (fileSz == (word32)bufSz) {
+            rc = TPM_RC_SUCCESS;
+        }
+#ifdef DEBUG_WOLFTPM
+        printf("Public PEM file size = %zu\n", fileSz);
+        TPM2_PrintBin(buf, bufSz);
+#endif
+        XFCLOSE(fp);
+    }
+#endif
+    return rc;
+}
+
+
 int writeKeyBlob(const char* filename,
                         WOLFTPM2_KEYBLOB* key)
 {

--- a/examples/tpm_test_keys.h
+++ b/examples/tpm_test_keys.h
@@ -28,7 +28,7 @@
 
 WOLFTPM_LOCAL int readKeyBlob(const char* filename, WOLFTPM2_KEYBLOB* key);
 WOLFTPM_LOCAL int writeKeyBlob(const char* filename, WOLFTPM2_KEYBLOB* key);
-
+WOLFTPM_LOCAL int writeKeyPubPem(const char* filename, byte *buf, int bufSz);
 
 WOLFTPM_LOCAL int readAndLoadKey(WOLFTPM2_DEV* pDev,
                           WOLFTPM2_KEY* key,

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -112,13 +112,18 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
     BYTE *param, *encParam = NULL;
     int paramSz, encParamSz = 0;
     int i, authPos, handlePos;
+    int tmpSz = 0; /* Used to calculate the new total size of the Auth Area */
 
     /* Skip the header and handles area */
     packet->pos = TPM2_HEADER_SIZE + (info->inHandleCnt * sizeof(TPM_HANDLE));
 
     /* Parse Auth */
     TPM2_Packet_ParseU32(packet, &authSz);
-    authPos = packet->pos; /* mark position for start of auth */
+    packet->pos -= sizeof(authSz);
+    /* Later Auth Area size is updated */
+    TPM2_Packet_MarkU32(packet, &tmpSz);
+    /* Mark the position of the Auth Area data */
+    authPos = packet->pos;
     packet->pos += authSz;
 
     /* Mark parameter data */
@@ -162,7 +167,8 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
         /* Note: Copy between TPM2_AUTH_SESSION and TPMS_AUTH_COMMAND is allowed */
         XMEMCPY(&authCmd, session, sizeof(TPMS_AUTH_COMMAND));
 
-        if (session->sessionHandle != TPM_RS_PW) {
+        /* Skip Policy session, because Enhanced Authorization is not yet implemented */
+        if (TPM2_IS_HMAC_SESSION(session->sessionHandle)) {
         #ifndef WOLFTPM2_NO_WOLFCRYPT
             TPM2B_NAME name1, name2, name3;
             TPM2B_DIGEST hash;
@@ -236,6 +242,10 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
         TPM2_Packet_AppendAuthCmd(packet, &authCmd);
         authPos = packet->pos; /* update auth position */
     }
+
+    /* Update the Auth Area size in the command packet */
+    TPM2_Packet_PlaceU32(packet, tmpSz);
+
     (void)cmdCode;
     return rc;
 }
@@ -1061,6 +1071,51 @@ TPM_RC TPM2_Create(Create_In* in, Create_Out* out)
             TPM2_Packet_ParseBytes(&packet,
                         out->creationTicket.digest.buffer,
                         out->creationTicket.digest.size);
+        }
+
+        TPM2_ReleaseLock(ctx);
+    }
+    return rc;
+}
+
+TPM_RC TPM2_CreateLoaded(CreateLoaded_In* in, CreateLoaded_Out* out)
+{
+    TPM_RC rc;
+    TPM2_CTX* ctx = TPM2_GetActiveCtx();
+
+    if (ctx == NULL || in == NULL || out == NULL || ctx->session == NULL)
+        return BAD_FUNC_ARG;
+
+    rc = TPM2_AcquireLock(ctx);
+    if (rc == TPM_RC_SUCCESS) {
+        CmdInfo_t info = {
+            .inHandleCnt = 1,
+            .flags = (CMD_FLAG_ENC2 | CMD_FLAG_DEC2),
+        };
+        TPM2_Packet packet;
+        TPM2_Packet_Init(ctx, &packet);
+        TPM2_Packet_AppendU32(&packet, in->parentHandle);
+        info.authCnt = TPM2_Packet_AppendAuth(&packet, ctx);
+        TPM2_Packet_AppendSensitiveCreate(&packet, &in->inSensitive);
+        TPM2_Packet_AppendPublic(&packet, &in->inPublic);
+        TPM2_Packet_Finalize(&packet, TPM_ST_SESSIONS, TPM_CC_CreateLoaded);
+
+        /* send command */
+        rc = TPM2_SendCommandAuth(ctx, &packet, &info);
+        if (rc == TPM_RC_SUCCESS) {
+            UINT32 paramSz = 0;
+
+            TPM2_Packet_ParseU32(&packet, &out->objectHandle);
+            TPM2_Packet_ParseU32(&packet, &paramSz);
+
+            TPM2_Packet_ParseU16(&packet, &out->outPrivate.size);
+            TPM2_Packet_ParseBytes(&packet, out->outPrivate.buffer,
+                out->outPrivate.size);
+
+            TPM2_Packet_ParsePublic(&packet, &out->outPublic);
+
+            TPM2_Packet_ParseU16(&packet, &out->name.size);
+            TPM2_Packet_ParseBytes(&packet, out->name.name, out->name.size);
         }
 
         TPM2_ReleaseLock(ctx);

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -501,6 +501,35 @@ int wolfTPM2_SetAuthSession(WOLFTPM2_DEV* dev, int index,
     return rc;
 }
 
+int wolfTPM2_CreateAuthSession_EkPolicy(WOLFTPM2_DEV* dev,
+                                        WOLFTPM2_SESSION* tpmSession)
+{
+    int rc = TPM_RC_FAILURE;
+    PolicySecret_In policySecretIn;
+    PolicySecret_Out policySecretOut;
+
+    /* Endorsement Key requires authorization with Policy */
+    rc = wolfTPM2_StartSession(dev, tpmSession, NULL, NULL,
+                               TPM_SE_POLICY, TPM_ALG_NULL);
+    if (rc == TPM_RC_SUCCESS) {
+        #ifdef DEBUG_WOLFTPM
+        printf("TPM2_StartAuthSession: sessionHandle 0x%x\n",
+                (word32)tpmSession->handle.hndl);
+        #endif
+        /* Provide Endorsement Auth using PolicySecret */
+        XMEMSET(&policySecretIn, 0, sizeof(policySecretIn));
+        policySecretIn.authHandle = TPM_RH_ENDORSEMENT;
+        policySecretIn.policySession = tpmSession->handle.hndl;
+        rc = TPM2_PolicySecret(&policySecretIn, &policySecretOut);
+        #ifdef DEBUG_WOLFTPM
+        if (rc == TPM_RC_SUCCESS) {
+            printf("policySecret applied on session\n");
+        }
+        #endif
+    }
+    return rc;
+}
+
 int wolfTPM2_Cleanup_ex(WOLFTPM2_DEV* dev, int doShutdown)
 {
     int rc = 0;
@@ -884,7 +913,6 @@ int wolfTPM2_ChangeAuthKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     if (dev == NULL || key == NULL || parent == NULL)
         return BAD_FUNC_ARG;
 
-    /* set session auth for key */
     wolfTPM2_SetAuthHandle(dev, 0, &key->handle);
 
     XMEMSET(&changeIn, 0, sizeof(changeIn));
@@ -954,7 +982,9 @@ int wolfTPM2_CreateKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEYBLOB* keyBlob,
     XMEMSET(&createOut, 0, sizeof(createOut)); /* make sure pub struct is zero init */
 
     /* set session auth for parent key */
-    wolfTPM2_SetAuthHandle(dev, 0, parent);
+    if (!parent->policyAuth) {
+        wolfTPM2_SetAuthHandle(dev, 0, parent);
+    }
 
     XMEMSET(&createIn, 0, sizeof(createIn));
     createIn.parentHandle = parent->hndl;
@@ -1006,7 +1036,7 @@ int wolfTPM2_LoadKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEYBLOB* keyBlob,
         return BAD_FUNC_ARG;
 
     /* set session auth for parent key */
-    if (dev->ctx.session) {
+    if (dev->ctx.session && !parent->policyAuth) {
         wolfTPM2_SetAuthHandle(dev, 0, parent);
     }
 
@@ -1049,6 +1079,60 @@ int wolfTPM2_CreateAndLoadKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 
     /* return loaded key */
     XMEMCPY(key, &keyBlob, sizeof(WOLFTPM2_KEY));
+
+    return rc;
+}
+
+int wolfTPM2_CreateLoadedKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEYBLOB* keyBlob,
+    WOLFTPM2_HANDLE* parent, TPMT_PUBLIC* publicTemplate,
+    const byte* auth, int authSz)
+{
+    int rc;
+    CreateLoaded_In  createLoadedIn;
+    CreateLoaded_Out createLoadedOut;
+
+    if (dev == NULL || keyBlob == NULL || parent == NULL || publicTemplate == NULL)
+        return BAD_FUNC_ARG;
+
+    /* clear output key buffer */
+    XMEMSET(keyBlob, 0, sizeof(WOLFTPM2_KEYBLOB));
+    XMEMSET(&createLoadedOut, 0, sizeof(createLoadedOut)); /* make sure pub struct is zero init */
+
+    /* set session auth for parent key */
+    if (!parent->policyAuth) {
+        wolfTPM2_SetAuthHandle(dev, 0, parent);
+    }
+
+    XMEMSET(&createLoadedIn, 0, sizeof(createLoadedIn));
+    createLoadedIn.parentHandle = parent->hndl;
+    if (auth) {
+        createLoadedIn.inSensitive.sensitive.userAuth.size = authSz;
+        XMEMCPY(createLoadedIn.inSensitive.sensitive.userAuth.buffer, auth,
+            createLoadedIn.inSensitive.sensitive.userAuth.size);
+    }
+    XMEMCPY(&createLoadedIn.inPublic.publicArea, publicTemplate, sizeof(TPMT_PUBLIC));
+
+    rc = TPM2_CreateLoaded(&createLoadedIn, &createLoadedOut);
+    if (rc != TPM_RC_SUCCESS) {
+    #ifdef DEBUG_WOLFTPM
+        printf("TPM2_CreateLoaded key failed %d: %s\n", rc, wolfTPM2_GetRCString(rc));
+    #endif
+        return rc;
+    }
+
+#ifdef DEBUG_WOLFTPM
+    printf("TPM2_CreateLoaded key: pub %d, priv %d\n",
+        createLoadedOut.outPublic.size, createLoadedOut.outPrivate.size);
+    TPM2_PrintPublicArea(&createLoadedOut.outPublic);
+#endif
+
+    keyBlob->handle.auth = createLoadedIn.inSensitive.sensitive.userAuth;
+    keyBlob->handle.symmetric = createLoadedOut.outPublic.publicArea.parameters.asymDetail.symmetric;
+
+    keyBlob->handle.hndl = createLoadedOut.objectHandle;
+    keyBlob->pub = createLoadedOut.outPublic;
+    keyBlob->priv = createLoadedOut.outPrivate;
+    keyBlob->name = createLoadedOut.name;
 
     return rc;
 }
@@ -1697,6 +1781,33 @@ int wolfTPM2_RsaKey_TpmToWolf(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
     return rc;
 }
 
+int wolfTPM2_RsaKey_TpmToPem(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
+                             byte* pem, int* pemSz, byte* tempBuf, int tempSz)
+{
+    int rc = TPM_RC_FAILURE;
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && defined(WOLFSSL_DER_TO_PEM)
+    int derSz;
+    RsaKey rsaKey;
+
+    /* Prepare wolfCrypt key structure */
+    rc = wc_InitRsaKey(&rsaKey, NULL);
+    if (rc != 0) return rc;
+    /* Convert the wolfTPM key to wolfCrypt format */
+    rc = wolfTPM2_RsaKey_TpmToWolf(dev, tpmKey, &rsaKey);
+    if (rc != 0) return rc;
+    /* Convert the wolfCrypt key to DER format */
+    rc = wc_RsaKeyToPublicDer(&rsaKey, tempBuf, tempSz);
+    if (rc <= 0) return rc;
+    derSz = rc;
+    /* Convert the DER key to PEM format */
+    rc = wc_DerToPem(tempBuf, derSz, pem, tempSz, PUBLICKEY_TYPE);
+    if (rc <= 0) return rc;
+    *pemSz = rc;
+    rc = TPM_RC_SUCCESS;
+#endif
+    return rc;
+}
+
 static word32 wolfTPM2_RsaKey_Exponent(byte* e, word32 eSz)
 {
     word32 exponent = 0, i;
@@ -1761,6 +1872,31 @@ int wolfTPM2_RsaKey_WolfToTpm(WOLFTPM2_DEV* dev, RsaKey* wolfKey,
     WOLFTPM2_KEY* tpmKey)
 {
     return wolfTPM2_RsaKey_WolfToTpm_ex(dev, NULL, wolfKey, tpmKey);
+}
+
+int wolfTPM2_RsaKey_PemToTpm(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
+                             byte *tempBuf, int tempSz, const char *filename)
+{
+    int rc = TPM_RC_FAILURE;
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && defined(WOLFSSL_CERT_EXT) && \
+    defined(WOLFSSL_PUB_PEM_TO_DER) && defined(WOLFSSL_PEM_TO_DER)
+    word32 idx;
+    RsaKey rsaKey;
+
+    /* Prepare wolfCrypt key structure */
+    rc = wc_InitRsaKey(&rsaKey, NULL);
+    if (rc != 0) return rc;
+    /* Convert PEM format key from file to DER */
+    rc = wc_PemPubKeyToDer(filename, tempBuf, tempSz);
+    if (rc != 0) return rc;
+    /* Convert DER to wolfCrypt file */
+    idx = 0;
+    rc = wc_RsaPublicKeyDecode(tempBuf, &idx, &rsaKey, tempSz);
+    if (rc != 0) return rc;
+    /* Load into the TPM */
+    rc = wolfTPM2_RsaKey_WolfToTpm(dev, &rsaKey, tpmKey);
+#endif
+    return rc;
 }
 #endif /* !NO_RSA */
 
@@ -3712,6 +3848,7 @@ int wolfTPM2_UnloadHandles_AllTransient(WOLFTPM2_DEV* dev)
 {
     return wolfTPM2_UnloadHandles(dev, TRANSIENT_FIRST, MAX_HANDLE_NUM);
 }
+
 
 
 /******************************************************************************/

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1621,7 +1621,10 @@ typedef struct TPM2_AUTH_SESSION {
     TPM2B_NAME name;
 } TPM2_AUTH_SESSION;
 
-
+/* Macros to determine TPM 2.0 Session type */
+#define TPM2_IS_PWD_SESSION(sessionHandle) ((sessionHandle) == TPM_RS_PW)
+#define TPM2_IS_HMAC_SESSION(sessionHandle) ((sessionHandle & 0xFF000000) == HMAC_SESSION_FIRST)
+#define TPM2_IS_POLICY_SESSION(sessionHandle) ((sessionHandle & 0xFF000000) == POLICY_SESSION_FIRST)
 
 /* Predetermined TPM 2.0 Indexes */
 #define TPM_20_TPM_MFG_NV_SPACE        ((TPM_HT_NV_INDEX << 24) | (0x00 << 22))

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -1042,16 +1042,13 @@ WOLFTPM_API int wolfTPM2_RsaKey_TpmToWolf(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKe
     \param keyBlob pointer to a struct of WOLFTPM2_KEY type, holding a TPM key
     \param pem pointer to an array of byte type, used as temporary storage for PEM conversation
     \param pemSz pointer to integer variable, to store the used buffer size
-    \param tempBuf pointer to an array of byte type, used as temporary storage for conversation
-    \param tempSz integer, specifying the size of the tempSz
 
     \sa wolfTPM2_RsaKey_TpmToWolf
     \sa wolfTPM2_RsaKey_WolfToTpm
 */
-WOLFTPM_API int wolfTPM2_RsaKey_TpmToPem(WOLFTPM2_DEV* dev,
+WOLFTPM_API int wolfTPM2_RsaKey_TpmToPemPub(WOLFTPM2_DEV* dev,
                                          WOLFTPM2_KEY* keyBlob,
-                                         byte* pem, int* pemSz,
-                                         byte* tempBuf, int tempSz);
+                                         byte* pem, word32* pemSz);
 
 /*!
     \ingroup wolfTPM2_Wrappers
@@ -1102,15 +1099,13 @@ WOLFTPM_API int wolfTPM2_RsaKey_WolfToTpm_ex(WOLFTPM2_DEV* dev,
     \param tpmKey pointer to an empty struct of WOLFTPM2_KEY type, to hold the imported TPM key
     \param pem pointer to an array of byte type, containing a PEM formated public key material
     \param pemSz pointer to integer variable, specifying the size of PEM key data
-    \param tempBuf pointer to an array of byte type, to be used as temporary storage
-    \param tempSz integer variable, specifying the size of the buffer
 
     \sa wolfTPM2_RsaKey_WolfToTpm
     \sa wolfTPM2_RsaKey_TpmToPem
     \sa wolfTPM2_RsaKey_TpmToWolf
 */
-int wolfTPM2_RsaKey_PubPemToTpm(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
-                                byte* pem, int pemSz, byte* tempBuf, int tempSz);
+WOLFTPM_API int wolfTPM2_RsaKey_PubPemToTpm(WOLFTPM2_DEV* dev,
+    WOLFTPM2_KEY* tpmKey, const byte* pem, word32 pemSz);
 #endif
 #ifdef HAVE_ECC
 /*!

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -1100,16 +1100,17 @@ WOLFTPM_API int wolfTPM2_RsaKey_WolfToTpm_ex(WOLFTPM2_DEV* dev,
 
     \param dev pointer to a TPM2_DEV struct
     \param tpmKey pointer to an empty struct of WOLFTPM2_KEY type, to hold the imported TPM key
+    \param pem pointer to an array of byte type, containing a PEM formated public key material
+    \param pemSz pointer to integer variable, specifying the size of PEM key data
     \param tempBuf pointer to an array of byte type, to be used as temporary storage
     \param tempSz integer variable, specifying the size of the buffer
-    \param filename pointer to a const string, specifying the name of the PEM file
 
     \sa wolfTPM2_RsaKey_WolfToTpm
     \sa wolfTPM2_RsaKey_TpmToPem
     \sa wolfTPM2_RsaKey_TpmToWolf
 */
-int wolfTPM2_RsaKey_PemToTpm(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
-                             byte *tempBuf, int tempSz, const char *filename);
+int wolfTPM2_RsaKey_PubPemToTpm(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
+                                byte* pem, int pemSz, byte* tempBuf, int tempSz);
 #endif
 #ifdef HAVE_ECC
 /*!


### PR DESCRIPTION
This PR adds creation of keys under the Endorsement Hierarchy. For this purpose, keygen can now create either:
- primary under Endorsement Hierarchy
or
- primary under Storage Hierarchy

Surprisingly, the creation of the attestation key fails with , although EK auth is empty(default) and set.
```
Creating new RSA key...
TPM2_Create key failed 303: TPM_RC_AUTH_UNAVAILABLE: The authValue or authPolicy is not available for selected entity
wolfTPM2_CreateKey failed

Failure 0x12f: TPM_RC_AUTH_UNAVAILABLE: The authValue or authPolicy is not available for selected entity
```

It could be that some auth slots get overwritten or maybe there is Admin flag set somewhere. To be investigated.

ps: This is needed to extend the Make/ActivateCredential examples 

Signed-off-by: Dimitar Tomov <dimi@wolfssl.com>