### PR TITLE
Added option to create TPM keys with OAEP scheme for SSH protocol

### DIFF
--- a/examples/keygen/keygen.c
+++ b/examples/keygen/keygen.c
@@ -240,7 +240,7 @@ int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[])
     else if (bSSH) {
         if (alg == TPM_ALG_RSA) {
             printf("SSH template for RSA key\n");
-            rc = wolfTPM2_GetKeyTemplate_RSA_SSH(&publicTemplate);
+            rc = wolfTPM2_GetKeyTemplate_RSA_SSH(&publicTemplate, TPM_ALG_SHA1);
 
             /* set session for authorization key */
             auth.size = (int)sizeof(gKeyAuth)-1;

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -3901,6 +3901,25 @@ int wolfTPM2_GetKeyTemplate_ECC_AIK(TPMT_PUBLIC* publicTemplate)
     return ret;
 }
 
+int wolfTPM2_GetKeyTemplate_RSA_SSH(TPMT_PUBLIC* publicTemplate)
+{
+    int ret;
+    TPMA_OBJECT objectAttributes = (
+        TPMA_OBJECT_fixedTPM | TPMA_OBJECT_fixedParent |
+        TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
+        TPMA_OBJECT_decrypt | TPMA_OBJECT_noDA);
+
+    /* "ssh-rsa" requires RSA key be:
+     * at least 2048 bits
+     * OAEP signature scheme with SHA1 hash algorithm */
+    ret = GetKeyTemplateRSA(publicTemplate, TPM_ALG_SHA256,
+        objectAttributes, 2048, 0, TPM_ALG_OAEP, TPM_ALG_SHA1);
+    if (ret == 0) {
+        publicTemplate->parameters.rsaDetail.symmetric.algorithm = TPM_ALG_NULL;
+    }
+    return ret;
+}
+
 int wolfTPM2_GetNvAttributesTemplate(TPM_HANDLE auth, word32* nvAttributes)
 {
     if (nvAttributes == NULL)

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -3901,7 +3901,7 @@ int wolfTPM2_GetKeyTemplate_ECC_AIK(TPMT_PUBLIC* publicTemplate)
     return ret;
 }
 
-int wolfTPM2_GetKeyTemplate_RSA_SSH(TPMT_PUBLIC* publicTemplate)
+int wolfTPM2_GetKeyTemplate_RSA_SSH(TPMT_PUBLIC* publicTemplate, TPM_ALG_ID hashAlg)
 {
     int ret;
     TPMA_OBJECT objectAttributes = (
@@ -3913,7 +3913,7 @@ int wolfTPM2_GetKeyTemplate_RSA_SSH(TPMT_PUBLIC* publicTemplate)
      * at least 2048 bits
      * OAEP signature scheme with SHA1 hash algorithm */
     ret = GetKeyTemplateRSA(publicTemplate, TPM_ALG_SHA256,
-        objectAttributes, 2048, 0, TPM_ALG_OAEP, TPM_ALG_SHA1);
+        objectAttributes, 2048, 0, TPM_ALG_OAEP, hashAlg);
     if (ret == 0) {
         publicTemplate->parameters.rsaDetail.symmetric.algorithm = TPM_ALG_NULL;
     }

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -2080,6 +2080,20 @@ WOLFTPM_API int wolfTPM2_GetKeyTemplate_ECC_AIK(TPMT_PUBLIC* publicTemplate);
 
 /*!
     \ingroup wolfTPM2_Wrappers
+    \brief Prepares a TPM public template for generating a new TPM key that can be used with the SSH protocol
+
+    \return TPM_RC_SUCCESS: successful
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param publicTemplate pointer to an empty structure of TPMT_PUBLIC type, to store the new template
+
+    \sa wolfTPM2_GetKeyTemplate_RSA
+    \sa wolfTPM2_GetKeyTemplate_RSA_AIK
+*/
+WOLFTPM_API int wolfTPM2_GetKeyTemplate_RSA_SSH(TPMT_PUBLIC* publicTemplate);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
     \brief Prepares a TPM NV Index template
 
     \return TPM_RC_SUCCESS: successful

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -2081,16 +2081,18 @@ WOLFTPM_API int wolfTPM2_GetKeyTemplate_ECC_AIK(TPMT_PUBLIC* publicTemplate);
 /*!
     \ingroup wolfTPM2_Wrappers
     \brief Prepares a TPM public template for generating a new TPM key that can be used with the SSH protocol
+    Note: Choose the hashing algorithm carefully, SSH servers could require SHA-256 or even SHA-512
 
     \return TPM_RC_SUCCESS: successful
     \return BAD_FUNC_ARG: check the provided arguments
 
     \param publicTemplate pointer to an empty structure of TPMT_PUBLIC type, to store the new template
+    \param hashAlg integer value of TPM_ALG_ID type, specify the hashing algorithm used by ssh-rsa
 
     \sa wolfTPM2_GetKeyTemplate_RSA
     \sa wolfTPM2_GetKeyTemplate_RSA_AIK
 */
-WOLFTPM_API int wolfTPM2_GetKeyTemplate_RSA_SSH(TPMT_PUBLIC* publicTemplate);
+WOLFTPM_API int wolfTPM2_GetKeyTemplate_RSA_SSH(TPMT_PUBLIC* publicTemplate, TPM_ALG_ID hashAlg);
 
 /*!
     \ingroup wolfTPM2_Wrappers


### PR DESCRIPTION
@dgarske please take a look at this addition

OAEP with SHA1 is used by SSH and supported by TPM 2.0 (as it was by TPM 1.2 too)

For some reason, the TPM does not like the Key attributes. I tried with and without fixedTPM.

Note: the new helper Template_SSH sets SHA256 for TPM key Name computation and SHA1 for the signature scheme. 

```
Failure 0x2c2: TPM_RC_ATTRIBUTES: Inconsistent attributes
```

Signed-off-by: Dimitar Tomov <dimi@wolfssl.com>