### PR TITLE
RSA_Encrypt: Fix for RSAES padding

### DIFF
--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -360,6 +360,24 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
     }
     printf("RSA Encrypt/Decrypt OAEP Test Passed\n");
 
+    /* Perform RSA encrypt / decrypt (RSAES pad) */
+    message.size = TPM_SHA256_DIGEST_SIZE; /* test message 0x11,0x11,etc */
+    XMEMSET(message.buffer, 0x11, message.size);
+    cipher.size = sizeof(cipher.buffer); /* encrypted data */
+    rc = wolfTPM2_RsaEncrypt(&dev, &rsaKey, TPM_ALG_RSAES,
+        message.buffer, message.size, cipher.buffer, &cipher.size);
+    if (rc != 0) goto exit;
+    plain.size = sizeof(plain.buffer);
+    rc = wolfTPM2_RsaDecrypt(&dev, &rsaKey, TPM_ALG_RSAES,
+        cipher.buffer, cipher.size, plain.buffer, &plain.size);
+    if (rc != 0) goto exit;
+    /* Validate encrypt / decrypt */
+    if (message.size != plain.size ||
+                    XMEMCMP(message.buffer, plain.buffer, message.size) != 0) {
+        rc = TPM_RC_TESTING; goto exit;
+    }
+    printf("RSA Encrypt/Decrypt RSAES Test Passed\n");
+
 
     /*------------------------------------------------------------------------*/
     /* RSA KEY LOADING TESTS */

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -1801,7 +1801,8 @@ TPM_RC TPM2_RSA_Encrypt(RSA_Encrypt_In* in, RSA_Encrypt_Out* out)
         TPM2_Packet_AppendBytes(&packet, in->message.buffer, in->message.size);
 
         TPM2_Packet_AppendU16(&packet, in->inScheme.scheme);
-        if (in->inScheme.scheme != TPM_ALG_NULL)
+        if (in->inScheme.scheme != TPM_ALG_NULL &&
+            in->inScheme.scheme != TPM_ALG_RSAES)
             TPM2_Packet_AppendU16(&packet, in->inScheme.details.anySig.hashAlg);
 
         TPM2_Packet_AppendU16(&packet, in->label.size);
@@ -1853,7 +1854,8 @@ TPM_RC TPM2_RSA_Decrypt(RSA_Decrypt_In* in, RSA_Decrypt_Out* out)
             in->cipherText.size);
 
         TPM2_Packet_AppendU16(&packet, in->inScheme.scheme);
-        if (in->inScheme.scheme != TPM_ALG_NULL)
+        if (in->inScheme.scheme != TPM_ALG_NULL &&
+            in->inScheme.scheme != TPM_ALG_RSAES)
             TPM2_Packet_AppendU16(&packet, in->inScheme.details.anySig.hashAlg);
 
         TPM2_Packet_AppendU16(&packet, in->label.size);


### PR DESCRIPTION
Added test and excluding hash for `RSAES` as well as `NULL`

Ref Forum: https://www.wolfssl.com/forums/topic1810-cryptographic-operations-with-wolftpm.html