### PR TITLE
Fix failure when running examples

### DIFF
--- a/docs/SWTPM.md
+++ b/docs/SWTPM.md
@@ -18,7 +18,7 @@ Two implementations were used in testing:
 ## Building with SW TPM support
 
 ```
-./configure --enable-swtpm
+./configure --enable-swtpm --enable-debug
 make
 ```
 
@@ -35,7 +35,7 @@ make
 
 Running:
 ```
-./tpm_server --rm
+./tpm_server -rm
 ```
 
 The rm switch is optional and remove the cache file


### PR DESCRIPTION
1. Add ```--enable-debug``` option to build example binaries
To run ```./examples/pcr/extend``` and ```./examples/wrap/wrap_test```, we need this option.

2. Fix ```ibmswtpm2``` server option
Previous option causes trailing failure.
```
$ ./tpm_server --rm

--rm is not a valid option
TPM Reference Simulator.
Copyright Microsoft Corp.
Usage:
./tpm_server         - Starts the TPM server listening on port 2321, 2322
./tpm_server -port PortNum - Starts the TPM server listening on port PortNum, PortNum+1
./tpm_server -rm remanufacture the TPM before starting
./tpm_server -h       - This message
```

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>