### PR TITLE
Add support for ST33 vendor specific command `TPM_CC_GetRandom2`

### DIFF
--- a/examples/native/native_test.c
+++ b/examples/native/native_test.c
@@ -330,22 +330,35 @@ int TPM2_Native_TestArgs(void* userCtx, int argc, char *argv[])
     if (TPM2_GetVendorID() == TPM_VENDOR_STM) {
         XMEMSET(&cmdIn.getRand, 0, sizeof(cmdIn.getRand));
         i = (int)sizeof(cmdOut.getRand2.randomBytes);
+        if (i > (MAX_RESPONSE_SIZE-(int)sizeof(UINT16))) {
+            i = (MAX_RESPONSE_SIZE-(int)sizeof(UINT16));
+        }
         cmdIn.getRand.bytesRequested = (UINT16)i;
         rc = TPM2_GetRandom2(&cmdIn.getRand, &cmdOut.getRand2);
+        if (rc == TPM_RC_COMMAND_CODE) {
+            printf("TPM2_GetRandom2: Command not supported on this hardware\n");
+        }
     }
-    else
+    else {
+        rc = TPM_RC_COMMAND_CODE;
+    }
+#else
+    rc = TPM_RC_COMMAND_CODE;
 #endif
-    {
+    if (rc == TPM_RC_COMMAND_CODE) {
         XMEMSET(&cmdIn.getRand, 0, sizeof(cmdIn.getRand));
         i = MAX_RNG_REQ_SIZE;
         cmdIn.getRand.bytesRequested = (UINT16)i;
         rc = TPM2_GetRandom(&cmdIn.getRand, &cmdOut.getRand);
+#if defined(WOLFTPM_ST33) || defined(WOLFTPM_AUTODETECT)
     }
+#endif
     if (rc != TPM_RC_SUCCESS) {
         printf("TPM2_GetRandom failed 0x%x: %s\n", rc,
             TPM2_GetRCString(rc));
         goto exit;
     }
+    /* the getRand and getRand2 have same return size header in cmdOut union */
     if (cmdOut.getRand.randomBytes.size != i) {
         printf("TPM2_GetRandom length mismatch %d != %d\n",
             cmdOut.getRand.randomBytes.size, MAX_RNG_REQ_SIZE);

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -5248,6 +5248,34 @@ int TPM2_SetMode(SetMode_In* in)
     }
     return rc;
 }
+
+TPM_RC TPM2_GetRandom2(GetRandom2_In* in, GetRandom2_Out* out)
+{
+    TPM_RC rc;
+    TPM2_CTX* ctx = TPM2_GetActiveCtx();
+
+    if (ctx == NULL || in == NULL || out == NULL)
+        return BAD_FUNC_ARG;
+
+    rc = TPM2_AcquireLock(ctx);
+    if (rc == TPM_RC_SUCCESS) {
+        TPM2_Packet packet;
+        TPM2_Packet_Init(ctx, &packet);
+        TPM2_Packet_AppendU16(&packet, in->bytesRequested);
+        TPM2_Packet_Finalize(&packet, TPM_ST_NO_SESSIONS, TPM_CC_GetRandom2);
+
+        /* send command */
+        rc = TPM2_SendCommand(ctx, &packet);
+        if (rc == TPM_RC_SUCCESS) {
+            TPM2_Packet_ParseU16(&packet, &out->randomBytes.size);
+            TPM2_Packet_ParseBytes(&packet, out->randomBytes.buffer,
+                out->randomBytes.size);
+        }
+
+        TPM2_ReleaseLock(ctx);
+    }
+    return rc;
+}
 #endif /* WOLFTPM_ST33 || WOLFTPM_AUTODETECT */
 
 /* GPIO Vendor Specific API's */

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -252,6 +252,7 @@ typedef enum {
 #if defined(WOLFTPM_ST33) || defined(WOLFTPM_AUTODETECT)
     TPM_CC_SetMode                  = CC_VEND + 0x0307,
     TPM_CC_SetCommandSet            = CC_VEND + 0x0309,
+    TPM_CC_GetRandom2               = CC_VEND + 0x030E,
 #endif
 #ifdef WOLFTPM_ST33
     TPM_CC_RestoreEK                = CC_VEND + 0x030A,
@@ -2791,6 +2792,16 @@ WOLFTPM_API TPM_RC TPM2_NV_Certify(NV_Certify_In* in, NV_Certify_Out* out);
         TPM_MODE_SET modeSet;
     } SetMode_In;
     WOLFTPM_API int TPM2_SetMode(SetMode_In* in);
+
+    /* The TPM2_GetRandom2 command does not require any authorization */
+    typedef GetRandom_In GetRandom2_In; /* same input */
+    typedef struct {
+        TPM2B_MAX_BUFFER randomBytes;
+    } GetRandom2_Out;
+    /* If bytesRequested is longer than TPM2B_MAX_BUFFER can accommodate, no 
+     * error is returned, but the TPM returns as much data as a TPM2B_DATA
+     * buffer can contain. */
+    WOLFTPM_API TPM_RC TPM2_GetRandom2(GetRandom2_In* in, GetRandom2_Out* out);
 #endif
 
 /* Vendor Specific GPIO */


### PR DESCRIPTION
Allows getting DRBG data up to `TPM2B_MAX_BUFFER` in size. ZD13545