### PR TITLE
Initial cmake build file and fixes for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ RemoteSystemsTempFiles
 IDE/IAR-EWARM/settings
 wolftpm/options.h
 
+# common cmake build location
+build/
+
 examples/wrap/wrap_test
 examples/native/native_test
 examples/bench/bench

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project(wolfTPM VERSION 1.1.1 LANGUAGES C)
 
-set(WOLFSSL_TPM "yes" CACHE STRING "")
-add_subdirectory(lib/wolfssl)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set(TPM_SOURCES
     src/tpm2.c
@@ -36,6 +35,35 @@ set(TPM_SOURCES
     src/tpm2_winapi.c
     src/tpm2_wrap.c
     )
+
+add_library(wolftpm SHARED ${TPM_SOURCES})
+target_compile_definitions(wolftpm PRIVATE
+    "BUILDING_WOLFTPM"
+    )
+
+if (WITH_WOLFSSL)
+    target_link_libraries(wolftpm wolfssl)
+    target_include_directories(wolftpm PUBLIC ${WITH_WOLFSSL}/include)
+    target_link_directories(wolftpm PUBLIC ${WITH_WOLFSSL}/lib)
+elseif (WITH_WOLFSSL_TREE)
+    set(WOLFSSL_TPM "yes" CACHE STRING "")
+    add_subdirectory(${WITH_WOLFSSL_TREE} wolfssl)
+    target_link_libraries(wolftpm wolfssl)
+else()
+    find_package(PkgConfig)
+    pkg_check_modules(WOLFSSL wolfssl)
+
+    if (WOLFSSL_FOUND)
+        target_link_libraries(wolftpm ${WOLFSSL_LIBRARIES})
+        target_include_directories(wolftpm PUBLIC ${WOLFSSL_INCLUDE_DIRS})
+        target_link_directories(wolftpm PUBLIC ${WOLFSSL_LIBRARY_DIRS})
+        target_compile_options(wolftpm PUBLIC ${WOLFSSL_CFLAGS_OTHER})
+    else()
+        target_compile_definitions(wolftpm PUBLIC
+            "WOLFTPM2_NO_WOLFCRYPT"
+            )
+    endif()
+endif()
 
 # TODO
 # * Debug/logging
@@ -68,16 +96,6 @@ if("${WOLFTPM_INTERFACE}" STREQUAL "auto")
     endif(WIN32 OR MINGW OR MSYS)
 endif("${WOLFTPM_INTERFACE}" STREQUAL "auto")
 
-add_library(wolftpm ${TPM_SOURCES})
-target_link_libraries(wolftpm wolfssl)
-target_compile_definitions(wolftpm PRIVATE
-    "BUILDING_WOLFTPM"
-    )
-
-# TODO: remove when options file generation is added
-target_compile_definitions(wolftpm PUBLIC
-    "WOLFTPM_USER_SETTINGS"
-    )
 
 if(WIN32)
     target_compile_definitions(wolftpm PRIVATE
@@ -107,6 +125,7 @@ endif("${WOLFTPM_INTERFACE}" STREQUAL "SWTPM")
 
 target_include_directories(wolftpm
     PUBLIC
+    ${CMAKE_CURRENT_BINARY_DIR}
     $<INSTALL_INTERFACE:wolftpm>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     )
@@ -125,6 +144,8 @@ function(add_tpm_example name src)
 endfunction()
 
 #TODO generate options file
+configure_file(wolftpm/options.h.in wolftpm/options.h)
+
 
 add_tpm_example(activate_credential attestation/activate_credential.c)
 add_tpm_example(make_credential attestation/make_credential.c)
@@ -154,6 +175,7 @@ add_tpm_example(tls_client_notpm tls/tls_client_notpm.c)
 add_tpm_example(tls_server tls/tls_server.c)
 add_tpm_example(wrap_test wrap/wrap_test.c)
 
+include(GNUInstallDirs)
 
 install(TARGETS wolftpm
         DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,154 @@
+# CMakeList.txt
+#
+# Copyright (C) 2006-2022 wolfSSL Inc.
+#
+# This file is part of wolfSSL. (formerly known as CyaSSL)
+#
+# Usage:
+# $ mkdir build
+# $ cd build
+# $ cmake ..
+# $ cmake --build .
+#
+# To build with debugging use:
+# $ cmake .. -DCMAKE_BUILD_TYPE=Debug
+#
+# See "Building with CMake" in INSTALL for more.
+
+####################################################
+# Project
+####################################################
+
+cmake_minimum_required(VERSION 3.16)
+
+project(wolfTPM VERSION 1.1.1 LANGUAGES C)
+
+set(WOLFSSL_TPM "yes" CACHE STRING "")
+add_subdirectory(lib/wolfssl)
+
+set(TPM_SOURCES
+    src/tpm2.c
+    src/tpm2_linux.c
+    src/tpm2_packet.c
+    src/tpm2_param_enc.c
+    src/tpm2_swtpm.c
+    src/tpm2_tis.c
+    src/tpm2_winapi.c
+    src/tpm2_wrap.c
+    )
+
+# TODO
+# * Debug/logging
+# * EXAMPLES
+# * wrapper
+# * wolfcrypt
+# * I2C
+# * Advanced IO
+# * Device specific (ST33, ATTPM20, NPCT, SLB, automatic)
+# * wait state
+# * small stack
+
+set(WOLFTPM_INTERFACE "auto" CACHE STRING
+    "Select interface to TPM")
+set_property(CACHE WOLFTPM_INTERFACE
+    PROPERTY STRINGS "auto;SWTPM;WINAPI;DEVTPM")
+
+# automatically set
+message("INTERFACE ${WOLFTPM_INTERFACE}")
+if("${WOLFTPM_INTERFACE}" STREQUAL "auto")
+    message("auto")
+    if(WIN32 OR MINGW OR MSYS)
+        message("Detected windows, using WIN TBS API")
+        set_property(CACHE WOLFTPM_INTERFACE PROPERTY VALUE "WINAPI")
+    elseif(UNIX)
+        message("Detected *nix. using kernel device for interface")
+        set_property(CACHE WOLFTPM_INTERFACE PROPERTY VALUE "DEVTPM")
+    else()
+        set_property(CACHE WOLFTPM_INTERFACE PROPERTY VALUE "SWTPM")
+    endif(WIN32 OR MINGW OR MSYS)
+endif("${WOLFTPM_INTERFACE}" STREQUAL "auto")
+
+add_library(wolftpm ${TPM_SOURCES})
+target_link_libraries(wolftpm wolfssl)
+target_compile_definitions(wolftpm PRIVATE
+    "BUILDING_WOLFTPM"
+    )
+
+# TODO: remove when options file generation is added
+target_compile_definitions(wolftpm PUBLIC
+    "WOLFTPM_USER_SETTINGS"
+    )
+
+if(WIN32)
+    # TODO: fix benchmark to compile with WIN API TBS
+    target_compile_definitions(wolftpm PRIVATE
+        "_WINDLL"
+        PUBLIC
+        "NO_TPM_BENCH"
+        )
+endif(WIN32)
+
+if("${WOLFTPM_INTERFACE}" STREQUAL "SWTPM")
+    target_compile_definitions(wolftpm PUBLIC
+        "WOLFTPM_SWTPM"
+        )
+elseif("${WOLFTPM_INTERFACE}" STREQUAL "DEVTPM")
+    target_compile_definitions(wolftpm PUBLIC
+        "WOLFTPM_LINUX_DEV"
+        )
+elseif("${WOLFTPM_INTERFACE}" STREQUAL "WINAPI")
+    target_compile_definitions(wolftpm PUBLIC
+        "WOLFTPM_WINAPI"
+        )
+    target_link_libraries(wolftpm tbs)
+endif("${WOLFTPM_INTERFACE}" STREQUAL "SWTPM")
+
+target_include_directories(wolftpm
+    PUBLIC
+    $<INSTALL_INTERFACE:wolfssl>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    )
+
+add_library(tpm_test_lib STATIC
+    examples/tpm_io.c
+    examples/tpm_test_keys.c
+    )
+target_link_libraries(tpm_test_lib wolftpm)
+
+function(add_tpm_example name src)
+    add_executable(${name}
+        examples/${src}
+        )
+    target_link_libraries(${name} wolftpm tpm_test_lib)
+endfunction()
+
+#TODO generate options file
+
+add_tpm_example(activate_credential attestation/activate_credential.c)
+add_tpm_example(make_credential attestation/make_credential.c)
+add_tpm_example(bench bench/bench.c)
+add_tpm_example(csr csr/csr.c)
+add_tpm_example(gpio_config gpio/gpio_config.c)
+add_tpm_example(gpio_read gpio/gpio_read.c)
+add_tpm_example(gpio_set gpio/gpio_set.c)
+add_tpm_example(keygen keygen/keygen.c)
+add_tpm_example(keyimport keygen/keyimport.c)
+add_tpm_example(keyload keygen/keyload.c)
+add_tpm_example(flush management/flush.c)
+add_tpm_example(native_test native/native_test.c)
+add_tpm_example(read nvram/read.c)
+add_tpm_example(store nvram/store.c)
+add_tpm_example(extend pcr/extend.c)
+add_tpm_example(quote pcr/quote.c)
+add_tpm_example(read_pcr pcr/read_pcr.c)
+add_tpm_example(reset pcr/reset.c)
+add_tpm_example(pkcs7 pkcs7/pkcs7.c)
+add_tpm_example(seal seal/seal.c)
+add_tpm_example(unseal seal/unseal.c)
+add_tpm_example(clock_set timestamp/clock_set.c)
+add_tpm_example(signed_timestamp timestamp/signed_timestamp.c)
+add_tpm_example(tls_client tls/tls_client.c)
+add_tpm_example(tls_client_notpm tls/tls_client_notpm.c)
+add_tpm_example(tls_server tls/tls_server.c)
+add_tpm_example(wrap_test wrap/wrap_test.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,11 +80,8 @@ target_compile_definitions(wolftpm PUBLIC
     )
 
 if(WIN32)
-    # TODO: fix benchmark to compile with WIN API TBS
     target_compile_definitions(wolftpm PRIVATE
         "_WINDLL"
-        PUBLIC
-        "NO_TPM_BENCH"
         )
 endif(WIN32)
 
@@ -101,13 +98,17 @@ elseif("${WOLFTPM_INTERFACE}" STREQUAL "WINAPI")
         "WOLFTPM_WINAPI"
         )
     target_link_libraries(wolftpm tbs)
+else()
+    get_property(INTERFACE_OPTS CACHE WOLFTPM_INTERFACE
+        PROPERTY STRINGS)
+    message(FATAL_ERROR "\"${WOLFTPM_INTERFACE}\" is not known WOLFTPM_INTERFACE:"
+        " ${INTERFACE_OPTS}")
 endif("${WOLFTPM_INTERFACE}" STREQUAL "SWTPM")
 
 target_include_directories(wolftpm
     PUBLIC
-    $<INSTALL_INTERFACE:wolfssl>
+    $<INSTALL_INTERFACE:wolftpm>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     )
 
 add_library(tpm_test_lib STATIC
@@ -152,3 +153,12 @@ add_tpm_example(tls_client tls/tls_client.c)
 add_tpm_example(tls_client_notpm tls/tls_client_notpm.c)
 add_tpm_example(tls_server tls/tls_server.c)
 add_tpm_example(wrap_test wrap/wrap_test.c)
+
+
+install(TARGETS wolftpm
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY)
+# Install the headers
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/wolftpm/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/wolftpm
+        FILES_MATCHING PATTERN "*.h")

--- a/README.md
+++ b/README.md
@@ -311,6 +311,23 @@ See `docs/SWTPM.md`
 
 See `docs/WindowTBS.md`
 
+## Building using CMake
+
+CMake supports compiling in many environments including Visual Studio
+if CMake support is installed. The commands below can be run in
+`Developer Command Prompt`.
+
+```
+mkdir build
+cd build
+# to use installed wolfSSL location (library and headers)
+cmake .. -DWITH_WOLFSSL=/prefix/to/wolfssl/install/
+# OR to use a wolfSSL source tree
+cmake .. -DWITH_WOLFSSL_TREE=/path/to/wolfssl/
+# build
+cmake --build .
+```
+
 ## Running Examples
 
 These examples demonstrate features of a TPM 2.0 module. The examples create RSA and ECC keys in NV for testing using handles defined in `./examples/tpm_io.h`. The PKCS #7 and TLS examples require generating CSR's and signing them using a test script. See `examples/README.md` for details on using the examples. To run the TLS sever and client on same machine you must build with `WOLFTPM_TIS_LOCK` to enable concurrent access protection.

--- a/examples/bench/bench.c
+++ b/examples/bench/bench.c
@@ -172,6 +172,10 @@ static int bench_sym_aes(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* storageKey,
     do {
         rc = wolfTPM2_EncryptDecrypt(dev, &aesKey, in, out, inOutSz, NULL, 0,
             isDecrypt);
+        if (WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) {
+            printf("Encrypt/Decrypt unavailble\n");
+            break;
+        }
         if (rc != 0) goto exit;
     } while (bench_stats_check(start, &count, TPM2_BENCH_DURATION_SEC));
     bench_stats_sym_finish(desc, count, inOutSz, start);
@@ -275,44 +279,44 @@ int TPM2_Wrapper_BenchArgs(void* userCtx, int argc, char *argv[])
     /* AES CBC */
     rc = bench_sym_aes(&dev, &storageKey, "AES-128-CBC-enc", TPM_ALG_CBC, 128,
         message.buffer, cipher.buffer, sizeof(message.buffer), WOLFTPM2_ENCRYPT);
-    if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
+    if (rc != 0 && !WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) goto exit;
     rc = bench_sym_aes(&dev, &storageKey, "AES-128-CBC-dec", TPM_ALG_CBC, 128,
         message.buffer, cipher.buffer, sizeof(message.buffer), WOLFTPM2_DECRYPT);
-    if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
+    if (rc != 0 && !WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) goto exit;
     rc = bench_sym_aes(&dev, &storageKey, "AES-256-CBC-enc", TPM_ALG_CBC, 256,
         message.buffer, cipher.buffer, sizeof(message.buffer), WOLFTPM2_ENCRYPT);
-    if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
+    if (rc != 0 && !WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) goto exit;
     rc = bench_sym_aes(&dev, &storageKey, "AES-256-CBC-dec", TPM_ALG_CBC, 256,
         message.buffer, cipher.buffer, sizeof(message.buffer), WOLFTPM2_DECRYPT);
-    if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
+    if (rc != 0 && !WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) goto exit;
 
     /* AES CTR */
     rc = bench_sym_aes(&dev, &storageKey, "AES-128-CTR-enc", TPM_ALG_CTR, 128,
         message.buffer, cipher.buffer, sizeof(message.buffer), WOLFTPM2_ENCRYPT);
-    if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
+    if (rc != 0 && !WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) goto exit;
     rc = bench_sym_aes(&dev, &storageKey, "AES-128-CTR-dec", TPM_ALG_CTR, 128,
         message.buffer, cipher.buffer, sizeof(message.buffer), WOLFTPM2_DECRYPT);
-    if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
+    if (rc != 0 && !WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) goto exit;
     rc = bench_sym_aes(&dev, &storageKey, "AES-256-CTR-enc", TPM_ALG_CTR, 256,
         message.buffer, cipher.buffer, sizeof(message.buffer), WOLFTPM2_ENCRYPT);
-    if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
+    if (rc != 0 && !WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) goto exit;
     rc = bench_sym_aes(&dev, &storageKey, "AES-256-CTR-dec", TPM_ALG_CTR, 256,
         message.buffer, cipher.buffer, sizeof(message.buffer), WOLFTPM2_DECRYPT);
-    if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
+    if (rc != 0 && !WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) goto exit;
 
     /* AES CFB */
     rc = bench_sym_aes(&dev, &storageKey, "AES-128-CFB-enc", TPM_ALG_CFB, 128,
         message.buffer, cipher.buffer, sizeof(message.buffer), WOLFTPM2_ENCRYPT);
-    if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
+    if (rc != 0 && !WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) goto exit;
     rc = bench_sym_aes(&dev, &storageKey, "AES-128-CFB-dec", TPM_ALG_CFB, 128,
         message.buffer, cipher.buffer, sizeof(message.buffer), WOLFTPM2_DECRYPT);
-    if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
+    if (rc != 0 && !WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) goto exit;
     rc = bench_sym_aes(&dev, &storageKey, "AES-256-CFB-enc", TPM_ALG_CFB, 256,
         message.buffer, cipher.buffer, sizeof(message.buffer), WOLFTPM2_ENCRYPT);
-    if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
+    if (rc != 0 && !WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) goto exit;
     rc = bench_sym_aes(&dev, &storageKey, "AES-256-CFB-dec", TPM_ALG_CFB, 256,
         message.buffer, cipher.buffer, sizeof(message.buffer), WOLFTPM2_DECRYPT);
-    if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
+    if (rc != 0 && !WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) goto exit;
 
     /* Hashing Benchmarks */
     /* SHA1 */

--- a/examples/keygen/keygen.c
+++ b/examples/keygen/keygen.c
@@ -303,10 +303,16 @@ int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[])
     if (rc != 0) goto exit;
 
     printf("Creating new %s key...\n", TPM2_GetAlgName(alg));
-    rc = wolfTPM2_CreateLoadedKey(&dev, &newKeyBlob, &primary->handle,
+
+    rc = wolfTPM2_CreateKey(&dev, &newKeyBlob, &primary->handle,
                             &publicTemplate, auth.buffer, auth.size);
     if (rc != TPM_RC_SUCCESS) {
-        printf("wolfTPM2_CreateLoadedKey failed\n");
+        printf("wolfTPM2_CreateKey failed\n");
+        goto exit;
+    }
+    rc = wolfTPM2_LoadKey(&dev, &newKeyBlob, &primary->handle);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("wolfTPM2_LoadKey failed\n");
         goto exit;
     }
     printf("New key created and loaded (pub %d, priv %d bytes)\n",

--- a/examples/native/native_test.c
+++ b/examples/native/native_test.c
@@ -353,9 +353,7 @@ int TPM2_Native_TestArgs(void* userCtx, int argc, char *argv[])
         i = MAX_RNG_REQ_SIZE;
         cmdIn.getRand.bytesRequested = (UINT16)i;
         rc = TPM2_GetRandom(&cmdIn.getRand, &cmdOut.getRand);
-#if defined(WOLFTPM_ST33) || defined(WOLFTPM_AUTODETECT)
     }
-#endif
     if (rc != TPM_RC_SUCCESS) {
         printf("TPM2_GetRandom failed 0x%x: %s\n", rc,
             TPM2_GetRCString(rc));

--- a/examples/seal/include.am
+++ b/examples/seal/include.am
@@ -14,6 +14,7 @@ examples_seal_seal_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_seal_seal_DEPENDENCIES = src/libwolftpm.la
 
 examples_seal_unseal_SOURCES      = examples/seal/unseal.c \
+                                    examples/tpm_test_keys.c \
                                     examples/tpm_io.c
 examples_seal_unseal_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_seal_unseal_DEPENDENCIES = src/libwolftpm.la

--- a/examples/seal/seal.c
+++ b/examples/seal/seal.c
@@ -132,6 +132,7 @@ int TPM2_Seal_Example(void* userCtx, int argc, char *argv[])
     }
     printf("Created new TPM seal key (pub %d, priv %d bytes)\n",
         newKey.pub.size, newKey.priv.size);
+    printf("0x%x\n", newKey.handle.hndl);
 
     /* Save key as encrypted blob to the disk */
 #if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)

--- a/examples/seal/unseal.c
+++ b/examples/seal/unseal.c
@@ -28,6 +28,7 @@
 #include <examples/seal/seal.h>
 #include <examples/tpm_io.h>
 #include <examples/tpm_test.h>
+#include <examples/tpm_test_keys.h>
 
 #include <stdio.h>
 #include <stdlib.h> /* atoi */

--- a/examples/seal/unseal.c
+++ b/examples/seal/unseal.c
@@ -151,6 +151,8 @@ int TPM2_Unseal_Example(void* userCtx, int argc, char *argv[])
     wolfTPM2_SetAuthPassword(&dev, 0, NULL);
 
 exit:
+    wolfTPM2_UnloadHandle(&dev, &storage.handle);
+    wolfTPM2_UnloadHandle(&dev, &newKey.handle);
 
     wolfTPM2_Cleanup(&dev);
     return rc;

--- a/examples/seal/unseal.c
+++ b/examples/seal/unseal.c
@@ -40,7 +40,7 @@
 static void usage(void)
 {
     printf("Expected usage:\n");
-    printf("./examples/seal/unseal [filename]\n");
+    printf("./examples/seal/unseal [filename] [inkey_filename]\n");
     printf("* filename - File contaning a TPM seal key\n");
     printf("Demo usage, without arguments, uses keyblob.bin file input.\n");
 }
@@ -52,12 +52,17 @@ int TPM2_Unseal_Example(void* userCtx, int argc, char *argv[])
     WOLFTPM2_KEY key;
     TPM2B_AUTH auth;
     const char *filename = "unseal.bin";
+    const char *inkeyfilename = "keyblob.bin";
 #if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
     XFILE fp = NULL;
     size_t len;
 #endif
     Unseal_In cmdIn_unseal;
     Unseal_Out cmdOut_unseal;
+
+    WOLFTPM2_KEYBLOB newKey;
+    WOLFTPM2_KEY storage; /* SRK */
+
 
     XMEMSET(&cmdIn_unseal, 0, sizeof(cmdIn_unseal));
     XMEMSET(&cmdOut_unseal, 0, sizeof(cmdOut_unseal));
@@ -75,6 +80,10 @@ int TPM2_Unseal_Example(void* userCtx, int argc, char *argv[])
         if (argv[1][0] != '-') {
             filename = argv[1];
         }
+
+        if (argc >= 3 && argv[2][0] != '-') {
+           inkeyfilename = argv[2];
+        }
     }
 
     printf("Example how to unseal data using TPM2.0\n");
@@ -85,12 +94,27 @@ int TPM2_Unseal_Example(void* userCtx, int argc, char *argv[])
     }
     printf("wolfTPM2_Init: success\n");
 
+    rc = getPrimaryStoragekey(&dev, &storage, TPM_ALG_RSA);
+    if (rc != 0) goto exit;
+
+    rc = readKeyBlob(inkeyfilename, &newKey);
+    if (rc != 0) goto exit;
+
+    rc = wolfTPM2_LoadKey(&dev, &newKey, &storage.handle);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("wolfTPM2_LoadKey failed\n");
+        goto exit;
+    }
+    printf("Loaded key to 0x%x\n",
+        (word32)newKey.handle.hndl);
+
     /* Set authorization for using the seal key */
-    auth.size = (int)sizeof(gKeyAuth)-1;
+    auth.size = (int)sizeof(gKeyAuth) - 1;
     XMEMCPY(auth.buffer, gKeyAuth, auth.size);
     wolfTPM2_SetAuthPassword(&dev, 0, &auth);
 
-    cmdIn_unseal.itemHandle = TPM2_DEMO_PERSISTENT_KEY_HANDLE;
+    cmdIn_unseal.itemHandle = newKey.handle.hndl;
+
     rc = TPM2_Unseal(&cmdIn_unseal, &cmdOut_unseal);
     if (rc != TPM_RC_SUCCESS) {
         printf("TPM2_Unseal failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
@@ -124,8 +148,6 @@ int TPM2_Unseal_Example(void* userCtx, int argc, char *argv[])
 
     /* Remove the loaded TPM seal object */
     wolfTPM2_SetAuthPassword(&dev, 0, NULL);
-    key.handle.hndl = TPM2_DEMO_PERSISTENT_KEY_HANDLE;
-    wolfTPM2_NVDeleteKey(&dev, TPM_RH_OWNER, &key);
 
 exit:
 

--- a/examples/tpm_test.h
+++ b/examples/tpm_test.h
@@ -88,16 +88,21 @@ static const char pemFileKey[] = "key.pem";
     #define TEST_WRAP_DIGEST TPM_ALG_SHA256
 #endif
 
-
 #ifndef NO_TPM_BENCH
     #ifndef WOLFSSL_USER_CURRTIME
+#ifdef _WIN32
+        #include <time.h>
+#else
         #include <sys/time.h>
+#endif
     #endif
     static inline double gettime_secs(int reset)
     {
     #ifdef WOLFSSL_USER_CURRTIME
         extern double current_time(int reset);
         return current_time(reset);
+    #elif defined(_WIN32)
+        return ((double)GetTickCount64())/1000.0;
     #else
         struct timeval tv;
         gettimeofday(&tv, 0);

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -233,7 +233,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
         /* Move this key into persistent storage */
         rc = wolfTPM2_NVStoreKey(&dev, TPM_RH_OWNER, &storageKey,
             TPM2_DEMO_STORAGE_KEY_HANDLE);
-        if (rc != 0) goto exit;
+        if (!WOLFTPM_IS_COMMAND_UNAVAILABLE(rc) && rc != 0) goto exit;
 
         printf("Created new RSA Primary Storage Key at 0x%x\n",
             TPM2_DEMO_STORAGE_KEY_HANDLE);
@@ -270,7 +270,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
         printf("Creating a loaded new TPM 2.0 key Test Passed\n");
         wolfTPM2_UnloadHandle(&dev, &testKey.handle);
     }
-    else if (rc == TPM_RC_COMMAND_CODE) {
+    else if (WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) {
         printf("CreateLoadedKey: Feature is not suppored on this hardware\n");
     }
     else {
@@ -494,7 +494,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
         /* Move this key into persistent storage */
         rc = wolfTPM2_NVStoreKey(&dev, TPM_RH_OWNER, &storageKey,
             TPM2_DEMO_STORAGE_EC_KEY_HANDLE);
-        if (rc != 0) goto exit;
+        if (!WOLFTPM_IS_COMMAND_UNAVAILABLE(rc) && rc != 0) goto exit;
 
         printf("Created new ECC Primary Storage Key at 0x%x\n",
             TPM2_DEMO_STORAGE_EC_KEY_HANDLE);
@@ -686,6 +686,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
     /* NV TESTS */
     /*------------------------------------------------------------------------*/
     /* NV with Auth (preferred API's) */
+#ifndef WOLFTPM_WINAPI
     {
         WOLFTPM2_HANDLE parent;
         WOLFTPM2_NV nv;
@@ -756,7 +757,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
 
     printf("NV Test on index 0x%x with %d bytes passed\n",
         TPM2_DEMO_NV_TEST_INDEX, TPM2_DEMO_NV_TEST_SIZE);
-
+#endif
 
     /*------------------------------------------------------------------------*/
     /* RANDOM TESTS */
@@ -851,7 +852,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
     XMEMCPY(aesIv, TEST_AES_IV, (word32)sizeof(TEST_AES_IV));
     rc = wolfTPM2_EncryptDecrypt(&dev, &aesKey, message.buffer, cipher.buffer,
         message.size, aesIv, (word32)sizeof(aesIv), WOLFTPM2_ENCRYPT);
-    if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
+    if (rc != 0 && !WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) goto exit;
 
     XMEMSET(plain.buffer, 0, sizeof(plain.buffer));
     plain.size = message.size;
@@ -868,7 +869,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
          XMEMCMP(cipher.buffer, TEST_AES_VERIFY, cipher.size) == 0) {
         printf("Encrypt/Decrypt (known key) test success\n");
     }
-    else if (rc == TPM_RC_COMMAND_CODE) {
+    else if (WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) {
         printf("Encrypt/Decrypt: Is not a supported feature due to export controls\n");
         rc = TPM_RC_SUCCESS; /* clear error code */
     }
@@ -896,7 +897,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
     cipher.size = message.size;
     rc = wolfTPM2_EncryptDecrypt(&dev, &aesKey, message.buffer, cipher.buffer,
         message.size, NULL, 0, WOLFTPM2_ENCRYPT);
-    if (rc != 0 && rc != TPM_RC_COMMAND_CODE) goto exit;
+    if (rc != 0 && !WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) goto exit;
 
     XMEMSET(plain.buffer, 0, sizeof(plain.buffer));
     plain.size = message.size;
@@ -910,7 +911,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
          XMEMCMP(message.buffer, plain.buffer, message.size) == 0) {
         printf("Encrypt/Decrypt test success\n");
     }
-    else if (rc == TPM_RC_COMMAND_CODE) {
+    else if (WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) {
         printf("Encrypt/Decrypt: Is not a supported feature due to export controls\n");
     }
     else {
@@ -932,7 +933,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
         hashBuf[i] = i;
     }
     rc = wolfTPM2_ExtendPCR(&dev, 0, TEST_WRAP_DIGEST, hashBuf, hashSz);
-    if (rc != 0) goto exit;
+    if (rc != 0 && !WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) goto exit;
 
     /* Read PCR Index 0 */
     rc = wolfTPM2_ReadPCR(&dev, 0, TEST_WRAP_DIGEST, hashBuf, &hashSz);

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1660,10 +1660,14 @@ struct wolfTPM_tcpContext {
 
 #ifdef WOLFTPM_WINAPI
 #include <tbs.h>
+#include <winerror.h>
 
 struct wolfTPM_winContext {
   TBS_HCONTEXT tbs_context;
 };
+#define WOLFTPM_IS_COMMAND_UNAVAILABLE(code) ((code) == TPM_RC_COMMAND_CODE || (code) == TPM_E_COMMAND_BLOCKED)
+#else
+#define WOLFTPM_IS_COMMAND_UNAVAILABLE(code) (code == TPM_RC_COMMAND_CODE)
 #endif /* WOLFTPM_WINAPI */
 
 /* make sure advanced IO is enabled for I2C */

--- a/wolftpm/tpm2_socket.h
+++ b/wolftpm/tpm2_socket.h
@@ -30,7 +30,7 @@
 
 /* socket includes */
 #if defined(_WIN32)
-    #include <winsock2.h>
+
     #define SOCKET_T SOCKET
 
     /* TODO: HACKY for win32 */

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -39,7 +39,10 @@
 #endif
 
 #ifdef WOLFTPM_WINAPI
-#include <minwindef.h>
+    #ifdef _WIN32
+        #include <winsock2.h>
+    #endif
+    #include <windows.h>
 #endif
 
 /* ---------------------------------------------------------------------------*/

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -575,7 +575,7 @@ WOLFTPM_API int wolfTPM2_CreateKey(WOLFTPM2_DEV* dev,
 /*!
     \ingroup wolfTPM2_Wrappers
     \brief Single function to load a TPM 2.0 key
-    \note To load a TPM 2.0 key its parent(Primary Key) should also be loaded prior to this operation. Primary Keys are laoded when they are created.
+    \note To load a TPM 2.0 key its parent(Primary Key) should also be loaded prior to this operation. Primary Keys are loaded when they are created.
 
     \return TPM_RC_SUCCESS: successful
     \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)


### PR DESCRIPTION
Add cmake support and Windows improvements
* Examples working on Windows and SWTPM
  * Check command availability (including for windows blocking it).
  * update unseal to work without persistent NV storage
* fix a few spelling mistakes