### PR TITLE
v2.4.0 release preparation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(wolfTPM VERSION 2.3.1 LANGUAGES C)
+project(wolfTPM VERSION 2.4.0 LANGUAGES C)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,25 @@ Fix for `make install`
 
 * Fix for installing example code on linux builds (PR #196)
 
+## wolfTPM Release 2.4 (05/06/2022)
+
+**Summary**
+
+Add CMake support. Add C# wrappers. Add ST33 GetRandom2. Improve
+`TPM2_SetupPCRSel`. Fixes for C++ compilers, example install and writing PEM.
+
+**Detail**
+
+* Fixes for c++ compiler (PR #206)
+* Adding a C# wrappers (PR #203)
+* CMake support (PR #202, #204, #205)
+* Add support for ST33 vendor specific command `TPM_CC_GetRandom2` (PR #200)
+* Fix writing PEM in `wolfTPM2_RsaKey_TpmToPemPub` (PR #201)
+* Improve `TPM2_SetupPCRSel` (multiple calls) (PR #198)
+* Fix for a few spelling errors and whitespace cleanup (PR #199)
+* v2.3.1 updates (PR #197)
+* Fix make install by renaming pcr example read.c (PR #196)
+
 ## wolfTPM Release 2.3 (11/08/2021)
 
 **Summary**

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 # All right reserved.
 
 AC_COPYRIGHT([Copyright (C) 2014-2021 wolfSSL Inc.])
-AC_INIT([wolftpm],[2.3.1],[https://github.com/wolfssl/wolfTPM/issues],[wolftpm],[http://www.wolfssl.com])
+AC_INIT([wolftpm],[2.4.0],[https://github.com/wolfssl/wolfTPM/issues],[wolftpm],[http://www.wolfssl.com])
 
 AC_PREREQ([2.63])
 AC_CONFIG_AUX_DIR([build-aux])
@@ -23,7 +23,7 @@ AC_ARG_PROGRAM
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([src/config.h])
 
-WOLFTPM_LIBRARY_VERSION=12:1:0
+WOLFTPM_LIBRARY_VERSION=13:0:0
 #                        | | |
 #                 +------+ | +---+
 #                 |        |     |

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -442,7 +442,6 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
     wc_FreeRsaKey(&wolfRsaPrivKey);
     rc = wolfTPM2_UnloadHandle(&dev, &rsaKey.handle);
     if (rc != 0) goto exit;
-#endif /* !WOLFTPM2_NO_WOLFCRYPT && !NO_RSA */
 
     /* Load raw RSA private key into TPM */
     rc = wolfTPM2_LoadRsaPrivateKey(&dev, &storageKey, &rsaKey,
@@ -455,11 +454,11 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
         (word32)rsaKey.handle.hndl);
     rc = wolfTPM2_UnloadHandle(&dev, &rsaKey.handle);
     if (rc != 0) goto exit;
+#endif /* !WOLFTPM2_NO_WOLFCRYPT && !NO_RSA */
 
     /* Close TPM session based on RSA storage key */
     wolfTPM2_UnloadHandle(&dev, &tpmSession.handle);
     wolfTPM2_SetAuthSession(&dev, 1, NULL, 0); /* clear auth session */
-
 
     /*------------------------------------------------------------------------*/
     /* ECC TESTS */
@@ -662,7 +661,6 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
     wc_ecc_free(&wolfEccPrivKey);
     rc = wolfTPM2_UnloadHandle(&dev, &eccKey.handle);
     if (rc != 0) goto exit;
-#endif /* !WOLFTPM2_NO_WOLFCRYPT && HAVE_ECC */
 
     /* Load raw ECC private key into TPM */
     rc = wolfTPM2_LoadEccPrivateKey(&dev, &storageKey, &eccKey, TPM_ECC_NIST_P256,
@@ -675,6 +673,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
         (word32)eccKey.handle.hndl);
     rc = wolfTPM2_UnloadHandle(&dev, &eccKey.handle);
     if (rc != 0) goto exit;
+#endif /* !WOLFTPM2_NO_WOLFCRYPT && HAVE_ECC */
 
 #if 0 /* disabled until ECC Encrypted salt is added */
     /* Close TPM session based on ECC storage key */
@@ -841,6 +840,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
     /*------------------------------------------------------------------------*/
     /* ENCRYPT/DECRYPT TESTS */
     /*------------------------------------------------------------------------*/
+#ifndef WOLFTPM2_NO_WOLFCRYPT
     rc = wolfTPM2_LoadSymmetricKey(&dev, &aesKey, TEST_AES_MODE,
         TEST_AES_KEY, (word32)sizeof(TEST_AES_KEY));
     if (rc != 0) goto exit;
@@ -878,7 +878,9 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
         goto exit;
     }
     if (rc != 0) goto exit;
-
+#else
+    (void)aesIv;
+#endif /* !WOLFTPM2_NO_WOLFCRYPT */
 
     rc = wolfTPM2_GetKeyTemplate_Symmetric(&publicTemplate, 128, TEST_AES_MODE,
         YES, YES);

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -287,7 +287,7 @@ int wolfTPM2_FreeSession(WOLFTPM2_SESSION* session)
     }
     return TPM_RC_SUCCESS;
 }
-#endif /* WOLFTPM2_NO_HEAP */
+#endif /* !WOLFTPM2_NO_HEAP */
 
 WOLFTPM2_HANDLE* wolfTPM2_GetHandleRefFromKey(WOLFTPM2_KEY* key)
 {

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -274,15 +274,21 @@ static void test_TPM2_KDFa(void)
         .size = 8,
         .buffer = {0xDA, 0x50, 0x40, 0x31, 0xDD, 0xF1, 0x2E, 0x83}
     };
+    byte key[TEST_KDFA_KEYSZ];
+
+#ifndef WOLFTPM2_NO_WOLFCRYPT
     const byte keyExp[TEST_KDFA_KEYSZ] = {
         0xbb, 0x02, 0x59, 0xe1, 0xc8, 0xba, 0x60, 0x7e, 0x6a, 0x2c,
         0xd7, 0x04, 0xb6, 0x9a, 0x90, 0x2e, 0x9a, 0xde, 0x84, 0xc4};
-    byte key[TEST_KDFA_KEYSZ];
+#endif
 
     rc = TPM2_KDFa(TPM_ALG_SHA256, &keyIn, label, &contextU, &contextV, key, keyIn.size);
+#ifdef WOLFTPM2_NO_WOLFCRYPT
+    AssertIntEQ(NOT_COMPILED_IN, rc);
+#else
     AssertIntEQ(sizeof(keyExp), rc);
-
     AssertIntEQ(XMEMCMP(key, keyExp, sizeof(keyExp)), 0);
+#endif
 }
 
 #endif /* !WOLFTPM2_NO_WRAPPER */

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -119,6 +119,7 @@ typedef int64_t  INT64;
 #else
 
     #include <stdio.h>
+    #include <stdlib.h>
     #include <string.h>
 
     typedef uint8_t  byte;
@@ -137,6 +138,8 @@ typedef int64_t  INT64;
     #define SOCKET_ERROR_E        -308  /* error state on socket    */
 
 #ifndef WOLFTPM_CUSTOM_TYPES
+    #define XMALLOC(s, h, t)     malloc((size_t)(s))
+    #define XFREE(p, h, t)       free(p)
     #define XMEMCPY(d,s,l)    memcpy((d),(s),(l))
     #define XMEMSET(b,c,l)    memset((b),(c),(l))
     #define XMEMCMP(s1,s2,n)  memcmp((s1),(s2),(n))

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -2349,24 +2349,187 @@ WOLFTPM_API int wolfTPM2_ClearCryptoDevCb(WOLFTPM2_DEV* dev, int devId);
 #endif /* WOLF_CRYPTO_CB */
 
 #ifndef WOLFTPM2_NO_HEAP
-WOLFTPM_API WOLFTPM2_DEV *wolfTPM2_New(void);
-WOLFTPM_API int wolfTPM2_Free(WOLFTPM2_DEV *dev);
-WOLFTPM_API WOLFTPM2_KEYBLOB* wolfTPM2_NewKeyBlob(void);
-WOLFTPM_API int wolfTPM2_FreeKeyBlob(WOLFTPM2_KEYBLOB* blob);
-WOLFTPM_API TPMT_PUBLIC* wolfTPM2_NewPublicTemplate(void);
-WOLFTPM_API int wolfTPM2_FreePublicTemplate(TPMT_PUBLIC* PublicTemplate);
-WOLFTPM_API WOLFTPM2_KEY* wolfTPM2_NewKey(void);
-WOLFTPM_API int wolfTPM2_FreeKey(WOLFTPM2_KEY* key);
-WOLFTPM_API WOLFTPM2_SESSION* wolfTPM2_NewSession(void);
-WOLFTPM_API int wolfTPM2_FreeSession(WOLFTPM2_SESSION* session);
-#endif
 
-WOLFTPM_API int wolfTPM2_OpenExistingDev(WOLFTPM2_DEV* dev);
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Allocate and initiaze a WOLFTPM2_DEV
+
+    \return pointer to new device struct
+    \return NULL: on any error
+
+    \sa wolfTPM2_Free
+*/
+WOLFTPM_API WOLFTPM2_DEV *wolfTPM2_New(void);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Cleanup and Free a WOLFTPM2_DEV that was allocated by wolfTPM2_New
+
+    \return TPM_RC_SUCCESS: successful
+
+    \param dev pointer to a TPM2_DEV struct
+
+    \sa wolfTPM2_New
+*/
+WOLFTPM_API int wolfTPM2_Free(WOLFTPM2_DEV *dev);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Allocate and initialize a WOLFTPM2_KEYBLOB
+
+    \return pointer to newly initialized WOLFTPM2_KEYBLOB
+    \return NULL on any error
+
+    \sa wolfTPM2_FreeKeyBlob
+*/
+WOLFTPM_API WOLFTPM2_KEYBLOB* wolfTPM2_NewKeyBlob(void);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Free a WOLFTPM2_KEYBLOB that was allocated with wolfTPM2_NewKeyBlob
+
+    \return TPM_RC_SUCCESS: successful
+
+    \param blob pointer to a WOLFTPM2_KEYBLOB that was allocated by wolfTPM2_NewKeyBlob
+
+    \sa wolfTPM2_NewKeyBlob
+*/
+WOLFTPM_API int wolfTPM2_FreeKeyBlob(WOLFTPM2_KEYBLOB* blob);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Allocate and initialize a TPMT_PUBLIC
+
+    \return pointer to newly initialized
+    \return NULL on any error
+
+    \sa wolfTPM2_FreePublicTemplate
+*/
+WOLFTPM_API TPMT_PUBLIC* wolfTPM2_NewPublicTemplate(void);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Free a TPMT_PUBLIC that was allocated with wolfTPM2_NewPublicTemplate
+
+    \return TPM_RC_SUCCESS: successful
+
+    \param PublicTemplate pointer to a TPMT_PUBLIC that was allocated with wolfTPM2_NewPublicTemplate
+
+    \sa wolfTPM2_NewPublicTemplate
+*/
+WOLFTPM_API int wolfTPM2_FreePublicTemplate(TPMT_PUBLIC* PublicTemplate);
+
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Allocate and initialize a WOLFTPM2_KEY
+
+    \return pointer to newly initialized WOLFTPM2_KEY
+    \return NULL on any error
+
+    \sa wolfTPM2_FreeKey
+*/
+WOLFTPM_API WOLFTPM2_KEY* wolfTPM2_NewKey(void);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Free a WOLFTPM2_KEY that was allocated with wolfTPM2_NewKey
+
+    \return TPM_RC_SUCCESS: successful
+
+    \param key pointer to a WOLFTPM2_KEY that was allocated by wolfTPM2_NewKey
+
+    \sa wolfTPM2_NewKey
+*/
+WOLFTPM_API int wolfTPM2_FreeKey(WOLFTPM2_KEY* key);
+
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Allocate and initialize a WOLFTPM2_SESSION
+
+    \return pointer to newly initialized WOLFTPM2_SESSION
+    \return NULL on any error
+
+    \sa wolfTPM2_FreeSession
+*/
+WOLFTPM_API WOLFTPM2_SESSION* wolfTPM2_NewSession(void);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Free a WOLFTPM2_SESSION that was allocated with wolfTPM2_NewSession
+
+    \return TPM_RC_SUCCESS: successful
+
+    \param blob pointer to a WOLFTPM2_KEYBLOB that was allocated by wolfTPM2_NewSession
+
+    \sa wolfTPM2_NewSession
+*/
+WOLFTPM_API int wolfTPM2_FreeSession(WOLFTPM2_SESSION* session);
+#endif /* !WOLFTPM2_NO_HEAP */
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Retrieve the WOLFTPM2_HANDLE from a WOLFTPM2_KEY
+
+    \return pointer to handle in the key structure
+    \return NULL if key pointer is NULL
+
+    \param key pointer to a WOLFTPM2_KEY struct
+*/
 WOLFTPM_API WOLFTPM2_HANDLE* wolfTPM2_GetHandleRefFromKey(WOLFTPM2_KEY* key);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Set the authentication data for a key
+
+    \return TPM_RC_SUCCESS: successful
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a TPM2_DEV struct
+    \param auth pointer to auth data
+    \param authSz length in bytes of auth data
+*/
 WOLFTPM_API int wolfTPM2_SetKeyAuthPassword(WOLFTPM2_KEY *key, const byte* auth,
     int authSz);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+
+    \brief Marshal data from a keyblob to a binary buffer. This can be
+    stored to disk for loading in a separate process or after power
+    cycling.
+
+    \return TPM_RC_SUCCESS: successful
+    \return BUFFER_E: insufficient space in provided buffer
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param buffer pointer to buffer in which to store marshaled keyblob
+    \param bufferSz size of the above buffer
+    \param key pointer to keyblob to marshal
+
+    \sa wolfTPM2_SetKeyBlobFromBuffer
+*/
 WOLFTPM_API int wolfTPM2_GetKeyBlobAsBuffer(byte *buffer, word32 bufferSz,
     WOLFTPM2_KEYBLOB* key);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+
+    \brief Unmarshal data into a WOLFTPM2_KEYBLOB struct. This can be
+    used to load a keyblob that was previously marshaled by
+    wolfTPM2_GetKeyBlobAsBuffer
+
+    \return TPM_RC_SUCCESS: successful
+    \return BUFFER_E: buffer is too small or there is extra data remaining and not unmarshalled
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param key pointer to keyblob to load and unmarshall data into
+    \param buffer pointer to buffer containing marshalled keyblob to load from
+    \param bufferSz size of the above buffer
+
+    \sa wolfTPM2_GetKeyBlobAsBuffer
+*/
 WOLFTPM_API int wolfTPM2_SetKeyBlobFromBuffer(WOLFTPM2_KEYBLOB* key,
     byte *buffer, word32 bufferSz);
 

--- a/wolftpm/version.h
+++ b/wolftpm/version.h
@@ -34,8 +34,8 @@
 extern "C" {
 #endif
 
-#define LIBWOLFTPM_VERSION_STRING "2.3.1"
-#define LIBWOLFTPM_VERSION_HEX 0x02003001
+#define LIBWOLFTPM_VERSION_STRING "2.4.0"
+#define LIBWOLFTPM_VERSION_HEX 0x02004000
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Update ChangeLog
- Update Version in configure and cmake
- Fix wrap_test and unit_test with `WOLFTPM2_NO_WOLFCRYPT` is set
- Cleanup `scan-build` reports from recent PRs
- Add docstrings for new APIs
- define `XMALLOC` and `XFREE` defaults when `WOLFTPM2_NO_WOLFCRYPT` is set