### PR TITLE
Fixes for nonce from TPM hardware

### DIFF
--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -72,11 +72,12 @@ static TPM_RC TPM2_AcquireLock(TPM2_CTX* ctx)
         ctx->lockCount = 0;
     }
 
-    if (++ctx->lockCount == 1) {
+    if (ctx->lockCount == 0) {
         ret = wc_LockMutex(&ctx->hwLock);
         if (ret != 0)
             return TPM_RC_FAILURE;
     }
+    ctx->lockCount++;
 #endif
     return TPM_RC_SUCCESS;
 }
@@ -86,7 +87,8 @@ static void TPM2_ReleaseLock(TPM2_CTX* ctx)
 #if defined(WOLFTPM2_NO_WOLFCRYPT) || defined(SINGLE_THREADED)
     (void)ctx;
 #else
-    if (--ctx->lockCount == 0) {
+    ctx->lockCount--;
+    if (ctx->lockCount == 0) {
         wc_UnLockMutex(&ctx->hwLock);
     }
     

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -69,11 +69,14 @@ static TPM_RC TPM2_AcquireLock(TPM2_CTX* ctx)
             return TPM_RC_FAILURE;
         }
         ctx->hwLockInit = 1;
+        ctx->lockCount = 0;
     }
 
-    ret = wc_LockMutex(&ctx->hwLock);
-    if (ret != 0)
-        return TPM_RC_FAILURE;
+    if (++ctx->lockCount == 1) {
+        ret = wc_LockMutex(&ctx->hwLock);
+        if (ret != 0)
+            return TPM_RC_FAILURE;
+    }
 #endif
     return TPM_RC_SUCCESS;
 }
@@ -83,7 +86,10 @@ static void TPM2_ReleaseLock(TPM2_CTX* ctx)
 #if defined(WOLFTPM2_NO_WOLFCRYPT) || defined(SINGLE_THREADED)
     (void)ctx;
 #else
-    wc_UnLockMutex(&ctx->hwLock);
+    if (--ctx->lockCount == 0) {
+        wc_UnLockMutex(&ctx->hwLock);
+    }
+    
 #endif
 }
 
@@ -108,11 +114,15 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
     CmdInfo_t* info, TPM_CC cmdCode, UINT32 cmdSz)
 {
     int rc = TPM_RC_SUCCESS;
-    UINT32 authSz, handleValue;
+    UINT32 authSz;
     BYTE *param, *encParam = NULL;
     int paramSz, encParamSz = 0;
-    int i, authPos, handlePos;
+    int i, authPos;
     int tmpSz = 0; /* Used to calculate the new total size of the Auth Area */
+#ifndef WOLFTPM2_NO_WOLFCRYPT
+    UINT32 handleValue;
+    int handlePos;
+#endif
 
     /* Skip the header and handles area */
     packet->pos = TPM2_HEADER_SIZE + (info->inHandleCnt * sizeof(TPM_HANDLE));
@@ -149,6 +159,14 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
         info->authCnt, info->inHandleCnt, cmdSz, authSz, paramSz, encParamSz);
 #else
     (void)paramSz;
+#endif
+
+    /* Get Handle */
+#ifndef WOLFTPM2_NO_WOLFCRYPT
+    handlePos = packet->pos;
+    packet->pos = TPM2_HEADER_SIZE; /* Handles are right after header */
+    TPM2_Packet_ParseU32(packet, &handleValue);
+    packet->pos = handlePos;
 #endif
 
     for (i=0; i<info->authCnt; i++) {
@@ -196,11 +214,6 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
             }
 
         #ifndef WOLFTPM2_NO_WOLFCRYPT
-            handlePos = packet->pos;
-            packet->pos = TPM2_HEADER_SIZE; /* Handles are right after header */
-            TPM2_Packet_ParseU32(packet, &handleValue);
-            packet->pos = handlePos;
-
             rc =  TPM2_GetName(ctx, handleValue, info->inHandleCnt, 0, &name1);
             rc |= TPM2_GetName(ctx, handleValue, info->inHandleCnt, 1, &name2);
             rc |= TPM2_GetName(ctx, handleValue, info->inHandleCnt, 2, &name3);
@@ -231,10 +244,7 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
             #endif
                 return rc;
             }
-        #else
-            (void)handleValue;
-            (void)handlePos;
-        #endif
+        #endif /* !WOLFTPM2_NO_WOLFCRYPT */
         }
 
         /* Replace auth in session */
@@ -654,7 +664,7 @@ TPM_RC TPM2_Cleanup(TPM2_CTX* ctx)
     }
 
 #ifndef WOLFTPM2_NO_WOLFCRYPT
-    #ifndef WC_NO_RNG
+    #ifdef WOLFTPM2_USE_WOLF_RNG
     if (ctx->rngInit) {
         ctx->rngInit = 0;
         wc_FreeRng(&ctx->rng);
@@ -5331,21 +5341,27 @@ int TPM2_GetHashType(TPMI_ALG_HASH hashAlg)
     return 0;
 }
 
-/* Can optionally define WOLFTPM2_USE_HW_RNG to force using TPM hardware for RNG source */
+/* Can optionally define WOLFTPM2_USE_HW_RNG to force using TPM hardware for
+ * RNG source */
 int TPM2_GetNonce(byte* nonceBuf, int nonceSz)
 {
-    int rc = 0;
+    int rc;
     TPM2_CTX* ctx = TPM2_GetActiveCtx();
 #ifdef WOLFTPM2_USE_WOLF_RNG
     WC_RNG* rng = NULL;
 #else
-    GetRandom_In in;
-    GetRandom_Out out;
+    TPM2_Packet packet;
+    byte buffer[TPM2_HEADER_SIZE + sizeof(GetRandom_Out)];
     int randSz = 0;
 #endif
 
-    if (ctx == NULL || nonceBuf == NULL)
+    if (ctx == NULL || nonceBuf == NULL) {
         return BAD_FUNC_ARG;
+    }
+
+#ifdef WOLFTPM_DEBUG_VERBOSE
+    printf("TPM2_GetNonce (%d bytes)\n", nonceSz);
+#endif
 
 #ifdef WOLFTPM2_USE_WOLF_RNG
     rc = TPM2_GetWolfRng(&rng);
@@ -5354,19 +5370,40 @@ int TPM2_GetNonce(byte* nonceBuf, int nonceSz)
         rc = wc_RNG_GenerateBlock(rng, nonceBuf, nonceSz);
     }
 #else
-    /* Use TPM GetRandom */
-    XMEMSET(&in, 0, sizeof(in));
-    while (randSz < nonceSz) {
-        in.bytesRequested = nonceSz - randSz;
-        if (in.bytesRequested > sizeof(out.randomBytes.buffer))
-            in.bytesRequested = sizeof(out.randomBytes.buffer);
+    /* Call GetRandom directly, so a custom packet buffer can be used.
+     * This won't conflict when being called from TPM2_CommandProcess. */
+    rc = TPM2_AcquireLock(ctx);
+    if (rc == TPM_RC_SUCCESS) {
+        while (randSz < nonceSz) {
+            UINT16 inSz = nonceSz - randSz, outSz = 0;
+            if (inSz > MAX_RNG_REQ_SIZE) {
+                inSz = MAX_RNG_REQ_SIZE;
+            }
 
-        rc = TPM2_GetRandom(&in, &out);
-        if (rc != TPM_RC_SUCCESS)
-            break;
+            TPM2_Packet_InitBuf(&packet, buffer, (int)sizeof(buffer));
+            TPM2_Packet_AppendU16(&packet, inSz);
+            TPM2_Packet_Finalize(&packet, TPM_ST_NO_SESSIONS, TPM_CC_GetRandom);
+            rc = TPM2_SendCommand(ctx, &packet);
+        #ifdef WOLFTPM_DEBUG_VERBOSE
+            printf("TPM2_GetNonce (%d bytes at %d): %d (%s)\n",
+                inSz, randSz, rc, TPM2_GetRCString(rc));
+        #endif
+            if (rc != TPM_RC_SUCCESS) {
+                break;
+            }
 
-        XMEMCPY(&nonceBuf[randSz], out.randomBytes.buffer, out.randomBytes.size);
-        randSz += out.randomBytes.size;
+            TPM2_Packet_ParseU16(&packet, &outSz);
+            if (outSz > MAX_RNG_REQ_SIZE) {
+            #ifdef DEBUG_WOLFTPM
+                printf("TPM2_GetNonce out size error\n");
+            #endif
+                rc = BAD_FUNC_ARG;
+                break;
+            }
+            TPM2_Packet_ParseBytes(&packet, &nonceBuf[randSz], outSz);
+            randSz += outSz;
+        }
+        TPM2_ReleaseLock(ctx);
     }
 #endif
 

--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -69,22 +69,32 @@ void TPM2_Packet_U32ToByteArray(UINT32 val, BYTE* b)
         c32toa(val, b);
 }
 
-UINT16 TPM2_Packet_SwapU16(UINT16 data) {
+UINT16 TPM2_Packet_SwapU16(UINT16 data)
+{
     return cpu_to_be16(data);
 }
-UINT32 TPM2_Packet_SwapU32(UINT32 data) {
+UINT32 TPM2_Packet_SwapU32(UINT32 data)
+{
     return cpu_to_be32(data);
 }
-UINT64 TPM2_Packet_SwapU64(UINT64 data) {
+UINT64 TPM2_Packet_SwapU64(UINT64 data)
+{
     return cpu_to_be64(data);
+}
+
+void TPM2_Packet_InitBuf(TPM2_Packet* packet, byte* buf, int size)
+{
+    if (packet) {
+        packet->buf  = buf;
+        packet->pos = TPM2_HEADER_SIZE; /* skip header (fill during finalize) */
+        packet->size = size;
+    }
 }
 
 void TPM2_Packet_Init(TPM2_CTX* ctx, TPM2_Packet* packet)
 {
-    if (ctx && packet) {
-        packet->buf  = ctx->cmdBuf;
-        packet->pos = TPM2_HEADER_SIZE; /* skip header (fill during finalize) */
-        packet->size = sizeof(ctx->cmdBuf);
+    if (ctx) {
+        TPM2_Packet_InitBuf(packet, ctx->cmdBuf, (int)sizeof(ctx->cmdBuf));
     }
 }
 

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -5046,6 +5046,12 @@ int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
         rc = wolfTPM2_GetRandom(tlsCtx->dev, info->rng.out, info->rng.sz);
     #endif /* !WC_NO_RNG */
     }
+    else if (info->algo_type == WC_ALGO_TYPE_SEED) {
+    #ifdef DEBUG_WOLFTPM
+        printf("CryptoDevCb RNG Seed: Sz %d\n", info->seed.sz);
+    #endif
+        rc = wolfTPM2_GetRandom(tlsCtx->dev, info->seed.seed, info->seed.sz);
+    }
 #if !defined(NO_RSA) || defined(HAVE_ECC)
     else if (info->algo_type == WC_ALGO_TYPE_PK) {
     #ifdef DEBUG_WOLFTPM

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1706,6 +1706,7 @@ typedef struct TPM2_CTX {
 #ifndef WOLFTPM2_NO_WOLFCRYPT
 #ifndef SINGLE_THREADED
     wolfSSL_Mutex hwLock;
+    int lockCount;
 #endif
     #ifdef WOLFTPM2_USE_WOLF_RNG
     WC_RNG rng;
@@ -1716,7 +1717,6 @@ typedef struct TPM2_CTX {
     int locality;
     word32 caps;
     word32 did_vid;
-    byte rid;
 
     /* Pointer to current TPM auth sessions */
     TPM2_AUTH_SESSION* session;
@@ -1724,6 +1724,7 @@ typedef struct TPM2_CTX {
     /* Command / Response Buffer */
     byte cmdBuf[MAX_COMMAND_SIZE];
 
+    byte rid;
     /* Informational Bits - use unsigned int for best compiler compatibility */
 #ifndef WOLFTPM2_NO_WOLFCRYPT
     #ifndef SINGLE_THREADED

--- a/wolftpm/tpm2_packet.h
+++ b/wolftpm/tpm2_packet.h
@@ -54,6 +54,7 @@ WOLFTPM_LOCAL UINT16 TPM2_Packet_SwapU16(UINT16 data);
 WOLFTPM_LOCAL UINT32 TPM2_Packet_SwapU32(UINT32 data);
 WOLFTPM_LOCAL UINT64 TPM2_Packet_SwapU64(UINT64 data);
 
+WOLFSSL_LOCAL void TPM2_Packet_InitBuf(TPM2_Packet* packet, byte* buf, int size);
 WOLFTPM_LOCAL void TPM2_Packet_Init(TPM2_CTX* ctx, TPM2_Packet* packet);
 WOLFTPM_LOCAL void TPM2_Packet_AppendU8(TPM2_Packet* packet, UINT8 data);
 WOLFTPM_LOCAL void TPM2_Packet_ParseU8(TPM2_Packet* packet, UINT8* data);

--- a/wolftpm/tpm2_packet.h
+++ b/wolftpm/tpm2_packet.h
@@ -54,7 +54,7 @@ WOLFTPM_LOCAL UINT16 TPM2_Packet_SwapU16(UINT16 data);
 WOLFTPM_LOCAL UINT32 TPM2_Packet_SwapU32(UINT32 data);
 WOLFTPM_LOCAL UINT64 TPM2_Packet_SwapU64(UINT64 data);
 
-WOLFSSL_LOCAL void TPM2_Packet_InitBuf(TPM2_Packet* packet, byte* buf, int size);
+WOLFTPM_LOCAL void TPM2_Packet_InitBuf(TPM2_Packet* packet, byte* buf, int size);
 WOLFTPM_LOCAL void TPM2_Packet_Init(TPM2_CTX* ctx, TPM2_Packet* packet);
 WOLFTPM_LOCAL void TPM2_Packet_AppendU8(TPM2_Packet* packet, UINT8 data);
 WOLFTPM_LOCAL void TPM2_Packet_ParseU8(TPM2_Packet* packet, UINT8* data);


### PR DESCRIPTION
* Fixes for nonce from TPM hardware (when using no wolfCrypt RNG `WOLFTPM2_USE_HW_RNG`).
* Add support for custom packet buffer
* Add lock count tracking
* Add crypto callback support for seeding RNG with TPM.