### PR TITLE
Adding wrappers for CSR Generation

### DIFF
--- a/examples/csr/csr.c
+++ b/examples/csr/csr.c
@@ -23,9 +23,7 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 
-#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
-    defined(WOLFSSL_CERT_REQ) && \
-    (defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB))
+#ifdef WOLFTPM2_CERT_GEN
 
 #include <examples/tpm_io.h>
 #include <examples/tpm_test.h>
@@ -36,105 +34,101 @@
 #include <stdio.h>
 
 #ifndef NO_RSA
-static const char* gClientCertRsaFile = "./certs/tpm-rsa-cert.csr";
+static const char* gClientCsrRsaFile = "./certs/tpm-rsa-cert.csr";
+static const char* gClientCertRsaFile = "./certs/tpm-rsa-cert.pem";
 #endif
 #ifdef HAVE_ECC
-static const char* gClientCertEccFile = "./certs/tpm-ecc-cert.csr";
+static const char* gClientCsrEccFile = "./certs/tpm-ecc-cert.csr";
+static const char* gClientCertEccFile = "./certs/tpm-ecc-cert.pem";
 #endif
 
 /******************************************************************************/
 /* --- BEGIN TPM2 CSR Example -- */
 /******************************************************************************/
 
-static int TPM2_CSR_Generate(WOLFTPM2_DEV* dev, int key_type, void* wolfKey,
-    const char* outputPemFile)
+static int TPM2_CSR_Generate(WOLFTPM2_DEV* dev, int keyType, WOLFTPM2_KEY* key,
+    const char* outputPemFile, int makeSelfSignedCert, int devId)
 {
     int rc;
-    Cert req;
-    const CertName myCertName = {
-        .country = "US",        .countryEnc = CTC_PRINTABLE, /* country */
-        .state = "Oregon",      .stateEnc = CTC_UTF8,        /* state */
-        .locality = "Portland", .localityEnc = CTC_UTF8,     /* locality */
-        .sur = "Test",          .surEnc = CTC_UTF8,          /* sur */
-        .org = "wolfSSL",       .orgEnc = CTC_UTF8,          /* org */
-        .unit = "Development",  .unitEnc = CTC_UTF8,         /* unit */
-        .commonName = "www.wolfssl.com",                     /* commonName */
-        .commonNameEnc = CTC_UTF8,
-        .email = "info@wolfssl.com"                          /* email */
-    };
-    const char* myKeyUsage = "serverAuth,clientAuth,codeSigning,"
-                             "emailProtection,timeStamping,OCSPSigning";
-    WOLFTPM2_BUFFER der;
-#ifdef WOLFSSL_DER_TO_PEM
+    const char* subject = NULL;
+    const char* keyUsage = "serverAuth,clientAuth,codeSigning,"
+                           "emailProtection,timeStamping,OCSPSigning";
+    const char* custOid =    "1.2.3.4.5";
+    const char* custOidVal = "This is NOT a critical extension";
     WOLFTPM2_BUFFER output;
+#ifndef WOLFTPM2_NO_HEAP
+    WOLFTPM2_CSR* csr = wolfTPM2_NewCSR();
+    if (csr == NULL) {
+        return MEMORY_E;
+    }
 #endif
 
-    /* Generate CSR (using TPM key) for certification authority */
-    rc = wc_InitCert(&req);
-    if (rc != 0) goto exit;
-
-    XMEMCPY(&req.subject, &myCertName, sizeof(myCertName));
-
-    /* make sure each common name is unique */
-    if (key_type == RSA_TYPE) {
-        req.sigType = CTC_SHA256wRSA;
-        XSTRNCPY(req.subject.unit, "RSA", sizeof(req.subject.unit));
+    /* make sure each subject is unique */
+    if (keyType == RSA_TYPE) {
+        subject = "/C=US/ST=Oregon/L=Portland/SN=Test/O=wolfSSL"
+                  "/OU=RSA/CN=www.wolfssl.com/emailAddress=info@wolfssl.com";
     }
-    else if (key_type == ECC_TYPE) {
-        req.sigType = CTC_SHA256wECDSA;
-        XSTRNCPY(req.subject.unit, "ECC", sizeof(req.subject.unit));
+    else if (keyType == ECC_TYPE) {
+        subject = "/C=US/ST=Oregon/L=Portland/SN=Test/O=wolfSSL"
+                  "/OU=ECC/CN=www.wolfssl.com/emailAddress=info@wolfssl.com";
     }
 
-#ifdef WOLFSSL_CERT_EXT
-    /* add SKID from the Public Key */
-    rc = wc_SetSubjectKeyIdFromPublicKey_ex(&req, key_type, wolfKey);
-    if (rc != 0) goto exit;
-
-    /* add Extended Key Usage */
-    rc = wc_SetExtKeyUsage(&req, myKeyUsage);
-    if (rc != 0) goto exit;
+    output.size = (int)sizeof(output.buffer);
+#ifdef WOLFTPM2_NO_HEAP
+    /* single shot API for CSR generation */
+    rc = wolfTPM2_CSR_Generate_ex(dev, key, subject, keyUsage,
+        WOLFSSL_FILETYPE_PEM, output.buffer, output.size, 0, makeSelfSignedCert,
+        devId);
+#else
+    rc = wolfTPM2_CSR_SetSubject(dev, csr, subject);
+    if (rc == 0) {
+        rc = wolfTPM2_CSR_SetKeyUsage(dev, csr, keyUsage);
+    }
+    if (rc == 0) {
+        /* sample custom OID for testing */
+        rc = wolfTPM2_CSR_SetCustomExt(dev, csr, 0, custOid,
+            (const byte*)custOidVal, (word32)XSTRLEN(custOidVal));
+        if (rc == NOT_COMPILED_IN) {
+            /* allow error for not compiled in */
+            rc = 0;
+        }
+    }
+    if (rc == 0) {
+        rc = wolfTPM2_CSR_MakeAndSign_ex(dev, csr, key, WOLFSSL_FILETYPE_PEM,
+            output.buffer, output.size, 0, makeSelfSignedCert, devId);
+    }
 #endif
-
-    rc = wc_MakeCertReq_ex(&req, der.buffer, sizeof(der.buffer), key_type,
-        wolfKey);
-    if (rc <= 0) goto exit;
-    der.size = rc;
-
-    rc = wc_SignCert_ex(req.bodySz, req.sigType, der.buffer, sizeof(der.buffer),
-        key_type, wolfKey, wolfTPM2_GetRng(dev));
-    if (rc <= 0) goto exit;
-    der.size = rc;
-
-#ifdef WOLFSSL_DER_TO_PEM
-    /* Convert to PEM */
-    XMEMSET(output.buffer, 0, sizeof(output.buffer));
-    rc = wc_DerToPem(der.buffer, der.size, output.buffer, sizeof(output.buffer),
-        CERTREQ_TYPE);
-    if (rc <= 0) goto exit;
-    output.size = rc;
-
-    printf("Generated/Signed Cert (DER %d, PEM %d)\n", der.size, output.size);
-    printf("%s\n", (char*)output.buffer);
-
-#if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
-    {
+    if (rc >= 0) {
+        output.size = rc;
+        printf("Generated/Signed Cert (PEM %d)\n", output.size);
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         FILE* pemFile = fopen(outputPemFile, "wb");
         if (pemFile) {
             rc = (int)fwrite(output.buffer, 1, output.size, pemFile);
             fclose(pemFile);
-            if (rc != output.size) {
-                rc = -1; goto exit;
+            rc = (rc == output.size) ? 0 : -1;
+            if (rc == 0) {
+                printf("Saved to %s\n", outputPemFile);
             }
         }
+    #endif
+        printf("%s\n", (char*)output.buffer);
     }
-#endif
-#endif /* WOLFSSL_DER_TO_PEM */
     (void)outputPemFile;
 
-    rc = 0; /* success */
+#ifndef WOLFTPM2_NO_HEAP
+    wolfTPM2_FreeCSR(csr);
+#endif
 
-exit:
     return rc;
+}
+
+static void usage(void)
+{
+    printf("Expected usage:\n");
+    printf("./examples/csr/csr [-cert]\n");
+    printf("\t-cert: Make self signed certificate instead of "
+                    "default CSR (Certificate Signing Request)\n");
 }
 
 int TPM2_CSR_Example(void* userCtx)
@@ -146,104 +140,91 @@ int TPM2_CSR_ExampleArgs(void* userCtx, int argc, char *argv[])
     int rc;
     WOLFTPM2_DEV dev;
     WOLFTPM2_KEY storageKey;
-#ifndef NO_RSA
-    WOLFTPM2_KEY rsaKey;
-    RsaKey wolfRsaKey;
-#endif
-#ifdef HAVE_ECC
-    WOLFTPM2_KEY eccKey;
-    ecc_key wolfEccKey;
-#endif
+    WOLFTPM2_KEY key;
     TpmCryptoDevCtx tpmCtx;
     int tpmDevId;
     TPMT_PUBLIC publicTemplate;
+    int makeSelfSignedCert = 0;
 
     printf("TPM2 CSR Example\n");
 
-    (void)argc;
-    (void)argv;
+    if (argc >= 2) {
+        if (XSTRNCMP(argv[1], "-?", 2) == 0 ||
+            XSTRNCMP(argv[1], "-h", 2) == 0 ||
+            XSTRNCMP(argv[1], "--help", 6) == 0) {
+            usage();
+            return 0;
+        }
+    }
+    while (argc > 1) {
+        if (XSTRNCMP(argv[argc-1], "-cert", 5) == 0) {
+            makeSelfSignedCert = 1;
+        }
+        argc--;
+    }
 
     /* Init the TPM2 device */
     rc = wolfTPM2_Init(&dev, TPM2_IoCb, userCtx);
-    if (rc != 0) return rc;
+    if (rc != 0) {
+        return rc;
+    }
+
+    /* initialize variables */
     XMEMSET(&storageKey, 0, sizeof(storageKey));
-
-    /* Setup the wolf crypto device callback */
+    XMEMSET(&key, 0, sizeof(key));
     XMEMSET(&tpmCtx, 0, sizeof(tpmCtx));
-#ifndef NO_RSA
-    XMEMSET(&rsaKey, 0, sizeof(rsaKey));
-    XMEMSET(&wolfRsaKey, 0, sizeof(wolfRsaKey));
-    tpmCtx.rsaKey = &rsaKey;
-#endif
-#ifdef HAVE_ECC
-    XMEMSET(&eccKey, 0, sizeof(eccKey));
-    XMEMSET(&wolfEccKey, 0, sizeof(wolfEccKey));
-    tpmCtx.eccKey = &eccKey;
-#endif
-    rc = wolfTPM2_SetCryptoDevCb(&dev, wolfTPM2_CryptoDevCb, &tpmCtx, &tpmDevId);
-    if (rc != 0) goto exit;
 
-    /* See if primary storage key already exists */
-    rc = getPrimaryStoragekey(&dev, &storageKey, TPM_ALG_RSA);
-    if (rc != 0) goto exit;
+    rc = wolfTPM2_SetCryptoDevCb(&dev, wolfTPM2_CryptoDevCb, &tpmCtx,
+        &tpmDevId);
+    if (rc == 0) {
+        /* See if primary storage key already exists */
+        rc = getPrimaryStoragekey(&dev, &storageKey, TPM_ALG_RSA);
+    }
 
 #ifndef NO_RSA
-    rc = wolfTPM2_GetKeyTemplate_RSA(&publicTemplate,
+    if (rc == 0) {
+        tpmCtx.rsaKey = &key; /* Setup the wolf crypto device callback */
+        rc = wolfTPM2_GetKeyTemplate_RSA(&publicTemplate,
                     TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
                     TPMA_OBJECT_decrypt | TPMA_OBJECT_sign | TPMA_OBJECT_noDA);
-    if (rc != 0) goto exit;
-
-    rc = getRSAkey(&dev,
-                   &storageKey,
-                   &rsaKey,
-                   &wolfRsaKey,
-                   tpmDevId,
-                   (byte*)gKeyAuth, sizeof(gKeyAuth)-1,
-                   &publicTemplate);
-    if (rc != 0) goto exit;
-
-    rc = TPM2_CSR_Generate(&dev, RSA_TYPE, &wolfRsaKey, gClientCertRsaFile);
-    if (rc != 0) goto exit;
+        if (rc == 0) {
+            rc = getRSAkey(&dev, &storageKey, &key, NULL, tpmDevId,
+                (byte*)gKeyAuth, sizeof(gKeyAuth)-1, &publicTemplate);
+        }
+        if (rc == 0) {
+            rc = TPM2_CSR_Generate(&dev, RSA_TYPE, &key,
+                makeSelfSignedCert ? gClientCertRsaFile : gClientCsrRsaFile,
+                makeSelfSignedCert, tpmDevId);
+        }
+        wolfTPM2_UnloadHandle(&dev, &key.handle);
+    }
 #endif /* !NO_RSA */
 
-
 #ifdef HAVE_ECC
-    rc = wolfTPM2_GetKeyTemplate_ECC(&publicTemplate,
+    if (rc == 0) {
+        tpmCtx.eccKey = &key;
+        rc = wolfTPM2_GetKeyTemplate_ECC(&publicTemplate,
                 TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
                 TPMA_OBJECT_sign | TPMA_OBJECT_noDA,
                 TPM_ECC_NIST_P256, TPM_ALG_ECDSA);
-    if (rc != 0) goto exit;
-    rc = getECCkey(&dev,
-                  &storageKey,
-                  &eccKey,
-                  &wolfEccKey,
-                  tpmDevId,
-                  (byte*)gKeyAuth, sizeof(gKeyAuth)-1,
-                  &publicTemplate);
-    if (rc != 0) goto exit;
-
-    rc = TPM2_CSR_Generate(&dev, ECC_TYPE, &wolfEccKey, gClientCertEccFile);
-    if (rc != 0) goto exit;
+        if (rc == 0) {
+            rc = getECCkey(&dev, &storageKey, &key, NULL, tpmDevId,
+                  (byte*)gKeyAuth, sizeof(gKeyAuth)-1, &publicTemplate);
+        }
+        if (rc == 0) {
+            rc = TPM2_CSR_Generate(&dev, ECC_TYPE, &key,
+                makeSelfSignedCert ? gClientCertEccFile : gClientCsrEccFile,
+                makeSelfSignedCert, tpmDevId);
+        }
+        wolfTPM2_UnloadHandle(&dev, &key.handle);
+    }
 #endif /* HAVE_ECC */
-
-exit:
 
     if (rc != 0) {
         printf("Failure 0x%x: %s\n", rc, wolfTPM2_GetRCString(rc));
     }
 
-
     wolfTPM2_UnloadHandle(&dev, &storageKey.handle);
-
-#ifndef NO_RSA
-    wc_FreeRsaKey(&wolfRsaKey);
-    wolfTPM2_UnloadHandle(&dev, &rsaKey.handle);
-#endif
-#ifdef HAVE_ECC
-    wc_ecc_free(&wolfEccKey);
-    wolfTPM2_UnloadHandle(&dev, &eccKey.handle);
-#endif
-
     wolfTPM2_Cleanup(&dev);
 
     return rc;
@@ -253,23 +234,22 @@ exit:
 /* --- END TPM2 CSR Example -- */
 /******************************************************************************/
 
-#endif /* !WOLFTPM2_NO_WRAPPER && WOLFSSL_CERT_REQ && WOLF_CRYPTO_DEV */
+#endif /* WOLFTPM2_CERT_GEN */
 
 #ifndef NO_MAIN_DRIVER
 int main(int argc, char *argv[])
 {
     int rc = -1;
 
-#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
-    defined(WOLFSSL_CERT_REQ) && \
-    (defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB))
+#ifdef WOLFTPM2_CERT_GEN
     rc = TPM2_CSR_ExampleArgs(NULL, argc, argv);
 #else
     (void)argc;
     (void)argv;
 
-    printf("Wrapper/CertReq/CryptoDev code not compiled in\n");
-    printf("Build wolfssl with ./configure --enable-certgen --enable-certreq --enable-certext --enable-cryptocb\n");
+    printf("Wrapper/CertReq/CryptoCb code not compiled in\n");
+    printf("Build wolfssl with ./configure --enable-certgen --enable-certreq "
+                                        "--enable-certext --enable-cryptocb\n");
 #endif
 
     return rc;

--- a/examples/pkcs7/pkcs7.c
+++ b/examples/pkcs7/pkcs7.c
@@ -23,9 +23,8 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 
-#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
-	defined(HAVE_PKCS7) && \
-	(defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB))
+#if !defined(WOLFTPM2_NO_WRAPPER) && defined(WOLFTPM_CRYPTOCB) && \
+    defined(HAVE_PKCS7)
 
 #include <examples/tpm_io.h>
 #include <examples/tpm_test.h>
@@ -396,16 +395,15 @@ exit:
 /* --- END TPM2 PKCS7 Example -- */
 /******************************************************************************/
 
-#endif /* !WOLFTPM2_NO_WRAPPER && HAVE_PKCS7 && WOLF_CRYPTO_DEV */
+#endif /* !WOLFTPM2_NO_WRAPPER && WOLFTPM_CRYPTOCB && HAVE_PKCS7 */
 
 #ifndef NO_MAIN_DRIVER
 int main(int argc, char *argv[])
 {
     int rc = -1;
 
-#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
-    defined(HAVE_PKCS7) && \
-    (defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB))
+#if !defined(WOLFTPM2_NO_WRAPPER) && defined(WOLFTPM_CRYPTOCB) && \
+    defined(HAVE_PKCS7)
     rc = TPM2_PKCS7_ExampleArgs(NULL, argc, argv);
 #else
     (void)argc;

--- a/examples/tls/tls_client.c
+++ b/examples/tls/tls_client.c
@@ -23,9 +23,8 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 
-#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
-    !defined(NO_WOLFSSL_CLIENT) && \
-    (defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB))
+#if !defined(WOLFTPM2_NO_WRAPPER) && defined(WOLFTPM_CRYPTOCB) && \
+    !defined(NO_WOLFSSL_CLIENT)
 
 #include <examples/tpm_io.h>
 #include <examples/tpm_test.h>
@@ -572,16 +571,15 @@ exit:
 /* --- END TPM TLS Client Example -- */
 /******************************************************************************/
 
-#endif /* !WOLFTPM2_NO_WRAPPER && WOLF_CRYPTO_DEV */
+#endif /* !WOLFTPM2_NO_WRAPPER && WOLFTPM_CRYPTOCB && !NO_WOLFSSL_CLIENT */
 
 #ifndef NO_MAIN_DRIVER
 int main(int argc, char* argv[])
 {
     int rc = -1;
 
-#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
-    !defined(NO_WOLFSSL_CLIENT) && \
-    (defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB))
+#if !defined(WOLFTPM2_NO_WRAPPER) && defined(WOLFTPM_CRYPTOCB) && \
+    !defined(NO_WOLFSSL_CLIENT)
     rc = TPM2_TLS_ClientArgs(NULL, argc, argv);
 #else
     (void)argc;

--- a/examples/tls/tls_server.c
+++ b/examples/tls/tls_server.c
@@ -23,9 +23,8 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 
-#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
-    !defined(NO_WOLFSSL_SERVER) && \
-    (defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB))
+#if !defined(WOLFTPM2_NO_WRAPPER) && defined(WOLFTPM_CRYPTOCB) && \
+    !defined(NO_WOLFSSL_SERVER)
 
 #include <examples/tpm_io.h>
 #include <examples/tpm_test.h>
@@ -549,16 +548,15 @@ exit:
 /* --- END TLS Server Example -- */
 /******************************************************************************/
 
-#endif /* !WOLFTPM2_NO_WRAPPER && WOLF_CRYPTO_DEV */
+#endif /* !WOLFTPM2_NO_WRAPPER && WOLFTPM_CRYPTOCB && !NO_WOLFSSL_SERVER */
 
 #ifndef NO_MAIN_DRIVER
 int main(int argc, char* argv[])
 {
     int rc = -1;
 
-#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
-    !defined(NO_WOLFSSL_SERVER) && \
-    (defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB))
+#if !defined(WOLFTPM2_NO_WRAPPER) && defined(WOLFTPM_CRYPTOCB) && \
+    !defined(NO_WOLFSSL_SERVER)
     rc = TPM2_TLS_ServerArgs(NULL, argc, argv);
 #else
     (void)argc;

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -80,7 +80,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
     TPMT_PUBLIC publicTemplate;
     TPM2B_ECC_POINT pubPoint;
     word32 nvAttributes = 0;
-#if defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB)
+#ifdef WOLFTPM_CRYPTOCB
     TpmCryptoDevCtx tpmCtx;
 #endif
     WOLFTPM2_HASH hash;
@@ -165,7 +165,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
     rc = wolfTPM2_Init(&dev, TPM2_IoCb, userCtx);
     if (rc != 0) return rc;
 
-#if defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB)
+#ifdef WOLFTPM_CRYPTOCB
     /* Setup the wolf crypto device callback */
     XMEMSET(&tpmCtx, 0, sizeof(tpmCtx));
 #ifndef NO_RSA

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -173,24 +173,18 @@ int wolfTPM2_Init(WOLFTPM2_DEV* dev, TPM2HalIoCb ioCb, void* userCtx)
 }
 
 #ifndef WOLFTPM2_NO_HEAP
-WOLFTPM2_DEV *wolfTPM2_New(void)
+WOLFTPM2_DEV* wolfTPM2_New(void)
 {
-    WOLFTPM2_DEV *dev = NULL;
-
-    dev = (WOLFTPM2_DEV *) XMALLOC(sizeof(WOLFTPM2_DEV), NULL,
-                                   DYNAMIC_TYPE_TMP_BUFFER);
-    if (dev == NULL) {
-        return NULL;
+    WOLFTPM2_DEV *dev = (WOLFTPM2_DEV*)XMALLOC(
+        sizeof(WOLFTPM2_DEV), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (dev != NULL) {
+        if (wolfTPM2_Init(dev, NULL, NULL) != TPM_RC_SUCCESS) {
+            XFREE(dev, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            dev = NULL;
+        }
     }
-
-    if (wolfTPM2_Init(dev, NULL, NULL) != TPM_RC_SUCCESS) {
-        XFREE(dev, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        return NULL;
-    }
-
     return dev;
 }
-
 int wolfTPM2_Free(WOLFTPM2_DEV *dev)
 {
     if (dev != NULL) {
@@ -202,18 +196,13 @@ int wolfTPM2_Free(WOLFTPM2_DEV *dev)
 
 WOLFTPM2_KEYBLOB* wolfTPM2_NewKeyBlob(void)
 {
-    WOLFTPM2_KEYBLOB* blob = NULL;
-
-    blob = (WOLFTPM2_KEYBLOB *) XMALLOC(sizeof(WOLFTPM2_KEYBLOB), NULL,
-                                      DYNAMIC_TYPE_TMP_BUFFER);
-    if (blob == NULL) {
-        return NULL;
+    WOLFTPM2_KEYBLOB* blob = (WOLFTPM2_KEYBLOB*)XMALLOC(
+        sizeof(WOLFTPM2_KEYBLOB), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (blob != NULL) {
+        XMEMSET(blob, 0, sizeof(WOLFTPM2_KEYBLOB));
     }
-
-    XMEMSET(blob, 0, sizeof(WOLFTPM2_KEYBLOB));
     return blob;
 }
-
 int wolfTPM2_FreeKeyBlob(WOLFTPM2_KEYBLOB* blob)
 {
     if (blob != NULL) {
@@ -224,18 +213,13 @@ int wolfTPM2_FreeKeyBlob(WOLFTPM2_KEYBLOB* blob)
 
 TPMT_PUBLIC* wolfTPM2_NewPublicTemplate(void)
 {
-    TPMT_PUBLIC* PublicTemplate = NULL;
-
-    PublicTemplate = (TPMT_PUBLIC *) XMALLOC(sizeof(TPMT_PUBLIC), NULL,
-                                       DYNAMIC_TYPE_TMP_BUFFER);
-    if (PublicTemplate == NULL) {
-        return NULL;
+    TPMT_PUBLIC* PublicTemplate = (TPMT_PUBLIC*)XMALLOC(
+        sizeof(TPMT_PUBLIC), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (PublicTemplate != NULL) {
+        XMEMSET(PublicTemplate, 0, sizeof(TPMT_PUBLIC));
     }
-
-    XMEMSET(PublicTemplate, 0, sizeof(TPMT_PUBLIC));
     return PublicTemplate;
 }
-
 int wolfTPM2_FreePublicTemplate(TPMT_PUBLIC* PublicTemplate)
 {
     if (PublicTemplate != NULL) {
@@ -246,18 +230,13 @@ int wolfTPM2_FreePublicTemplate(TPMT_PUBLIC* PublicTemplate)
 
 WOLFTPM2_KEY* wolfTPM2_NewKey(void)
 {
-    WOLFTPM2_KEY* key = NULL;
-
-    key = (WOLFTPM2_KEY *) XMALLOC(sizeof(WOLFTPM2_KEY), NULL,
-                                    DYNAMIC_TYPE_TMP_BUFFER);
-    if (key == NULL) {
-        return NULL;
+    WOLFTPM2_KEY* key = (WOLFTPM2_KEY*)XMALLOC(
+        sizeof(WOLFTPM2_KEY), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (key != NULL) {
+        XMEMSET(key, 0, sizeof(WOLFTPM2_KEY));
     }
-
-    XMEMSET(key, 0, sizeof(WOLFTPM2_KEY));
     return key;
 }
-
 int wolfTPM2_FreeKey(WOLFTPM2_KEY* key)
 {
     if (key != NULL) {
@@ -268,18 +247,13 @@ int wolfTPM2_FreeKey(WOLFTPM2_KEY* key)
 
 WOLFTPM2_SESSION* wolfTPM2_NewSession(void)
 {
-    WOLFTPM2_SESSION* session = NULL;
-
-    session = (WOLFTPM2_SESSION *) XMALLOC(sizeof(WOLFTPM2_SESSION), NULL,
-                                    DYNAMIC_TYPE_TMP_BUFFER);
-    if (session == NULL) {
-        return NULL;
+    WOLFTPM2_SESSION* session = (WOLFTPM2_SESSION*)XMALLOC(
+        sizeof(WOLFTPM2_SESSION), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (session != NULL) {
+        XMEMSET(session, 0, sizeof(WOLFTPM2_SESSION));
     }
-
-    XMEMSET(session, 0, sizeof(WOLFTPM2_SESSION));
     return session;
 }
-
 int wolfTPM2_FreeSession(WOLFTPM2_SESSION* session)
 {
     if (session != NULL) {
@@ -287,6 +261,29 @@ int wolfTPM2_FreeSession(WOLFTPM2_SESSION* session)
     }
     return TPM_RC_SUCCESS;
 }
+
+#ifdef WOLFTPM2_CERT_GEN
+WOLFTPM2_CSR* wolfTPM2_NewCSR(void)
+{
+    WOLFTPM2_CSR* csr = (WOLFTPM2_CSR*)XMALLOC(
+        sizeof(WOLFTPM2_CSR), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (csr != NULL) {
+        if (wc_InitCert(&csr->req) != 0) {
+            XFREE(csr, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            csr = NULL;
+        }
+    }
+    return csr;
+}
+int wolfTPM2_FreeCSR(WOLFTPM2_CSR* csr)
+{
+    if (csr != NULL) {
+        XFREE(csr, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    return TPM_RC_SUCCESS;
+}
+#endif /* WOLFTPM2_CERT_GEN */
+
 #endif /* !WOLFTPM2_NO_HEAP */
 
 WOLFTPM2_HANDLE* wolfTPM2_GetHandleRefFromKey(WOLFTPM2_KEY* key)
@@ -831,8 +828,7 @@ int wolfTPM2_Cleanup_ex(WOLFTPM2_DEV* dev, int doShutdown)
         return BAD_FUNC_ARG;
     }
 
-#if !defined(WOLFTPM2_NO_WOLFCRYPT) && \
-    (defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB))
+#ifdef WOLFTPM_CRYPTOCB
     /* make sure crypto dev callback is unregistered */
     rc = wolfTPM2_ClearCryptoDevCb(dev, INVALID_DEVID);
     if (rc != 0)
@@ -4749,6 +4745,365 @@ int wolfTPM2_GetTime(WOLFTPM2_KEY* aikKey, GetTime_Out* getTimeOut)
     return rc;
 }
 
+#ifdef WOLFTPM2_CERT_GEN
+
+/* Distinguished Name Strings */
+typedef struct DNTags {
+    const char* tag;
+    size_t certNameOff;
+} DNTags;
+
+static int CSR_Parse_DN(CertName* name, const char* subject)
+{
+    int rc = 0, i;
+    const DNTags tags[] = {
+        {"/CN=",     OFFSETOF(CertName, commonName)}, /* Common Name */
+        {"/C=",      OFFSETOF(CertName, country)},    /* Country */
+        {"/ST=",     OFFSETOF(CertName, state)},      /* State */
+        {"/street=", OFFSETOF(CertName, street)},     /* Street */
+        {"/L=",      OFFSETOF(CertName, locality)},   /* Locality */
+        {"/SN=",     OFFSETOF(CertName, sur)},        /* Surname */
+        {"/O=",      OFFSETOF(CertName, org)},        /* Organization */
+        {"/OU=",     OFFSETOF(CertName, unit)},       /* Organization Unit */
+        {"/postalCode=",   OFFSETOF(CertName, postalCode)}, /* PostalCode */
+        {"/userid=",       OFFSETOF(CertName, userId)},     /* UserID */
+        {"/serialNumber=", OFFSETOF(CertName, serialDev)},  /* Serial Number */
+        {"/emailAddress=", OFFSETOF(CertName, email)},      /* Email Address */
+    #ifdef WOLFSSL_CERT_EXT
+        {"/businessCategory=", OFFSETOF(CertName, busCat)}, /* Business Category */
+    #endif
+    };
+
+    for (i = 0; i < (int)(sizeof(tags) / sizeof(DNTags)); i++) {
+        const char *begin, *end;
+        word32 len = 0;
+        /* find start tag */
+        begin = XSTRSTR(subject, tags[i].tag);
+        if (begin != NULL) {
+            /* find end of string or / */
+            begin += XSTRLEN(tags[i].tag);
+            end = XSTRSTR(begin, "/");
+            if (end == NULL) {
+                end = begin + XSTRLEN(begin); /* remainder of string */
+            }
+            if (end > begin) {
+                len = (word32)(size_t)(end - begin);
+            }
+            if (len > CTC_NAME_SIZE-1) {
+                len = CTC_NAME_SIZE-1; /* leave room for null term */
+            }
+            XMEMCPY((byte*)name + tags[i].certNameOff, begin, len);
+        }
+    }
+    return rc;
+}
+
+typedef struct CSRKey {
+    int keyType;
+    int tpmDevId;
+    WOLFTPM2_KEY* tpmKey;
+    union {
+    #ifndef NO_RSA
+        RsaKey rsa;
+    #endif
+    #ifdef HAVE_ECC
+        ecc_key ecc;
+    #endif
+    } key;
+    TpmCryptoDevCtx tpmCtx;
+} CSRKey;
+
+static int CSR_MakeAndSign(WOLFTPM2_DEV* dev, WOLFTPM2_CSR* csr, CSRKey* key,
+    int outFormat, byte* out, int outSz, int selfSignCert)
+{
+    int rc = 0;
+
+    if (dev == NULL || csr == NULL || key == NULL || out == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (rc == 0 && selfSignCert) {
+    #ifdef WOLFSSL_CERT_GEN
+        rc = wc_MakeCert_ex(&csr->req, out, outSz, key->keyType, &key->key,
+            wolfTPM2_GetRng(dev));
+    #else
+        rc = NOT_COMPILED_IN;
+    #endif
+    }
+    if (rc == 0 && !selfSignCert) {
+        rc = wc_MakeCertReq_ex(&csr->req, out, outSz, key->keyType, &key->key);
+    }
+
+    if (rc >= 0) {
+        rc = wc_SignCert_ex(csr->req.bodySz, csr->req.sigType, out,
+            (word32)outSz, key->keyType, &key->key, wolfTPM2_GetRng(dev));
+    }
+
+    /* Optionally convert to PEM */
+    if (rc >= 0 && outFormat == WOLFSSL_FILETYPE_PEM) {
+    #ifdef WOLFSSL_DER_TO_PEM
+        WOLFTPM2_BUFFER tmp;
+        tmp.size = rc;
+        XMEMCPY(tmp.buffer, out, rc);
+        XMEMSET(out, 0, outSz);
+        rc = wc_DerToPem(tmp.buffer, tmp.size, out, outSz,
+            selfSignCert ? CERT_TYPE : CERTREQ_TYPE);
+    #else
+        #ifdef DEBUG_WOLFTPM
+        printf("CSR_MakeAndSign PEM not supported\n")
+        #endif
+        rc = NOT_COMPILED_IN;
+    #endif
+    }
+
+    return rc;
+}
+
+static int CSR_KeySetup(WOLFTPM2_DEV* dev, WOLFTPM2_CSR* csr, WOLFTPM2_KEY* key,
+    CSRKey* csrKey, int sigType, int devId)
+{
+    int rc;
+
+    if (dev == NULL || key == NULL || csrKey == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    XMEMSET(csrKey, 0, sizeof(CSRKey));
+    csrKey->tpmDevId = INVALID_DEVID;
+    csrKey->tpmKey = key;
+
+    /* confirm crypto callback is setup */
+    if (devId == INVALID_DEVID) {
+        /* Setup the wolf crypto device callback */
+    #ifndef NO_RSA
+        csrKey->tpmCtx.rsaKey = key;
+    #endif
+    #ifdef HAVE_ECC
+        csrKey->tpmCtx.eccKey = key;
+    #endif
+        rc = wolfTPM2_SetCryptoDevCb(dev, wolfTPM2_CryptoDevCb,
+            &csrKey->tpmCtx, &csrKey->tpmDevId);
+        if (rc == 0) {
+            devId = csrKey->tpmDevId;
+        }
+    }
+
+    /* determine the type of key in WOLFTPM2_KEY */
+    if (key->pub.publicArea.type == TPM_ALG_ECC) {
+        csrKey->keyType = ECC_TYPE;
+
+    #ifdef HAVE_ECC
+        /* setup wolf ECC key with TPM deviceID, so crypto callbacks are used */
+        rc = wc_ecc_init_ex(&csrKey->key.ecc, NULL, devId);
+        if (rc == 0) {
+            /* load public portion of key into wolf ECC Key */
+            rc = wolfTPM2_EccKey_TpmToWolf(dev, key, &csrKey->key.ecc);
+        }
+    #else
+        rc = NOT_COMPILED_IN;
+    #endif
+    }
+    else if (key->pub.publicArea.type == TPM_ALG_RSA) {
+        csrKey->keyType = RSA_TYPE;
+
+    #ifndef NO_RSA
+        /* setup wolf RSA key with TPM deviceID, so crypto callbacks are used */
+        rc = wc_InitRsaKey_ex(&csrKey->key.rsa, NULL, devId);
+        if (rc == 0) {
+            /* load public portion of key into wolf RSA Key */
+            rc = wolfTPM2_RsaKey_TpmToWolf(dev, key, &csrKey->key.rsa);
+        }
+    #else
+        rc = NOT_COMPILED_IN;
+    #endif
+    }
+    else {
+    #ifdef DEBUG_WOLFTPM
+        printf("CSR_KeySetup invalid input key\n");
+    #endif
+        rc = BAD_FUNC_ARG;
+    }
+
+    /* Set the signature type */
+    if (rc == 0) {
+        if (sigType == 0 && csrKey != NULL) {
+            /* Choose defaults if sigType is zero */
+            if (csrKey->keyType == RSA_TYPE) {
+                csr->req.sigType = CTC_SHA256wRSA;
+            }
+            else if (csrKey->keyType == ECC_TYPE) {
+                csr->req.sigType = CTC_SHA256wECDSA;
+            }
+        }
+        else if (csr->req.sigType == 0) {
+            csr->req.sigType = sigType;
+        }
+    }
+
+#ifdef WOLFSSL_CERT_EXT
+    /* add SKID from the Public Key */
+    if (rc == 0 && csrKey != NULL) {
+        rc = wc_SetSubjectKeyIdFromPublicKey_ex(&csr->req, csrKey->keyType,
+            &csrKey->key);
+    }
+#endif
+
+    return rc;
+}
+
+static void CSR_KeyCleanup(WOLFTPM2_DEV* dev, CSRKey* csrKey)
+{
+    if (dev != NULL && csrKey != NULL) {
+    #ifdef HAVE_ECC
+        if (csrKey->keyType == ECC_TYPE) {
+            wc_ecc_free(&csrKey->key.ecc);
+        }
+    #endif
+    #ifndef NO_RSA
+        if (csrKey->keyType == RSA_TYPE) {
+            wc_FreeRsaKey(&csrKey->key.rsa);
+        }
+    #endif
+        if (csrKey->tpmDevId != INVALID_DEVID) {
+            wolfTPM2_ClearCryptoDevCb(dev, csrKey->tpmDevId);
+        }
+    }
+}
+
+int wolfTPM2_CSR_SetCustomExt(WOLFTPM2_DEV* dev, WOLFTPM2_CSR* csr, int critical,
+    const char *oid, const byte *der, word32 derSz)
+{
+    int rc;
+    if (csr == NULL) {
+        return BAD_FUNC_ARG;
+    }
+#if defined(WOLFSSL_ASN_TEMPLATE) && defined(WOLFSSL_CUSTOM_OID) && \
+    defined(HAVE_OID_ENCODING)
+    rc = wc_SetCustomExtension(&csr->req, critical, oid, der, derSz);
+#else
+    (void)critical;
+    (void)oid;
+    (void)der;
+    (void)derSz;
+    /* Requires: 
+     * ./configure --enable-wolftpm --enable-certgen --enable-asn=template \
+                 CFLAGS="-DWOLFSSL_CUSTOM_OID -DHAVE_OID_ENCODING"
+     */
+    rc = NOT_COMPILED_IN;
+#endif
+    (void)dev; /* not used */
+    return rc;
+}
+
+int wolfTPM2_CSR_SetSubject(WOLFTPM2_DEV* dev, WOLFTPM2_CSR* csr,
+    const char* subject)
+{
+    int rc = BAD_FUNC_ARG;
+    if (csr != NULL && subject != NULL) {
+        rc = CSR_Parse_DN(&csr->req.subject, subject);
+    }
+    (void)dev; /* not used */
+    return rc;
+}
+
+int wolfTPM2_CSR_SetKeyUsage(WOLFTPM2_DEV* dev, WOLFTPM2_CSR* csr,
+    const char* keyUsage)
+{
+    int rc;
+
+    if (csr == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifdef WOLFSSL_CERT_EXT
+    if (keyUsage == NULL) {
+        /* use a default key usage value */
+        keyUsage = "serverAuth,clientAuth,codeSigning";
+    }
+
+    /* add Extended Key Usage */
+    rc = wc_SetExtKeyUsage(&csr->req, keyUsage);
+#else
+    if (keyUsage != NULL) {
+    #ifdef DEBUG_WOLFTPM
+        printf("CSR_Generate key usage supplied, but not available\n");
+    #endif
+        rc = NOT_COMPILED_IN;
+    }
+#endif
+    (void)dev; /* not used */
+    return rc;
+}
+
+int wolfTPM2_CSR_MakeAndSign_ex(WOLFTPM2_DEV* dev, WOLFTPM2_CSR* csr,
+    WOLFTPM2_KEY* key, int outFormat, byte* out, int outSz,
+    int sigType, int selfSignCert, int devId)
+{
+    int rc;
+    CSRKey csrKey;
+
+    if (dev == NULL || key == NULL || csr == NULL || out == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    rc = CSR_KeySetup(dev, csr, key, &csrKey, sigType, devId);
+    if (rc == 0) {
+        rc = CSR_MakeAndSign(dev, csr, &csrKey, outFormat, out, outSz,
+            selfSignCert);
+    }
+    CSR_KeyCleanup(dev, &csrKey);
+
+    return rc;
+}
+int wolfTPM2_CSR_MakeAndSign(WOLFTPM2_DEV* dev, WOLFTPM2_CSR* csr,
+    WOLFTPM2_KEY* key, int outFormat, byte* out, int outSz)
+{
+    return wolfTPM2_CSR_MakeAndSign_ex(dev, csr, key, outFormat, out, outSz,
+        0, 0, INVALID_DEVID);
+}
+
+int wolfTPM2_CSR_Generate_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
+    const char* subject, const char* keyUsage, int outFormat,
+    byte* out, int outSz, int sigType, int selfSignCert, int devId)
+{
+    int rc;
+    WOLFTPM2_CSR csr;
+    CSRKey csrKey;
+
+    if (dev == NULL || key == NULL || subject == NULL || out == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    rc = wc_InitCert(&csr.req);
+    if (rc == 0) {
+        rc = CSR_KeySetup(dev, &csr, key, &csrKey, sigType, devId);
+    }
+    if (rc == 0) {
+        rc = wolfTPM2_CSR_SetSubject(dev, &csr, subject);
+    }
+    if (rc == 0) {
+        rc = wolfTPM2_CSR_SetKeyUsage(dev, &csr, keyUsage);
+    }
+    if (rc == 0) {
+        rc = CSR_MakeAndSign(dev, &csr, &csrKey, outFormat, out, outSz,
+            selfSignCert);
+    }
+    CSR_KeyCleanup(dev, &csrKey);
+
+    return rc;
+}
+
+int wolfTPM2_CSR_Generate(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
+    const char* subject, const char* keyUsage, int outFormat,
+    byte* out, int outSz)
+{
+    return wolfTPM2_CSR_Generate_ex(dev, key, subject, keyUsage, outFormat,
+        out, outSz, 0, 0, INVALID_DEVID);
+}
+
+#endif /* WOLFTPM2_CERT_GEN */
+
+
 static void wolfTPM2_CopySymmetric(TPMT_SYM_DEF* out, const TPMT_SYM_DEF* in)
 {
     if (out == NULL || in == NULL)
@@ -4963,8 +5318,7 @@ static void wolfTPM2_CopyNvPublic(TPMS_NV_PUBLIC* out, const TPMS_NV_PUBLIC* in)
 /******************************************************************************/
 
 
-#if !defined(WOLFTPM2_NO_WOLFCRYPT) && (defined(WOLF_CRYPTO_DEV) || \
-    defined(WOLF_CRYPTO_CB))
+#ifdef WOLFTPM_CRYPTOCB
 /******************************************************************************/
 /* --- BEGIN wolf Crypto Device Support -- */
 /******************************************************************************/
@@ -5515,7 +5869,7 @@ int wolfTPM2_SetCryptoDevCb(WOLFTPM2_DEV* dev, CryptoDevCallbackFunc cb,
         devId = rc;
         tpmCtx->dev = dev;
 
-        rc = wc_CryptoDev_RegisterDevice(devId, cb, tpmCtx);
+        rc = wc_CryptoCb_RegisterDevice(devId, cb, tpmCtx);
     }
 
     if (pDevId) {
@@ -5552,7 +5906,7 @@ int wolfTPM2_ClearCryptoDevCb(WOLFTPM2_DEV* dev, int devId)
 /* --- END wolf Crypto Device Support -- */
 /******************************************************************************/
 
-#endif /* !WOLFTPM2_NO_WOLFCRYPT && (WOLF_CRYPTO_DEV || WOLF_CRYPTO_CB) */
+#endif /* WOLFTPM_CRYPTOCB */
 
 
 #endif /* !WOLFTPM2_NO_WRAPPER */

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -138,18 +138,29 @@ typedef int64_t  INT64;
     #define SOCKET_ERROR_E        -308  /* error state on socket    */
 
 #ifndef WOLFTPM_CUSTOM_TYPES
-    #define XMALLOC(s, h, t)     malloc((size_t)(s))
-    #define XFREE(p, h, t)       free(p)
+    #ifndef WOLFTPM2_NO_HEAP
+    #define XMALLOC(s, h, t)  malloc((size_t)(s))
+    #define XFREE(p, h, t)    free(p)
+    #endif
     #define XMEMCPY(d,s,l)    memcpy((d),(s),(l))
     #define XMEMSET(b,c,l)    memset((b),(c),(l))
     #define XMEMCMP(s1,s2,n)  memcmp((s1),(s2),(n))
     #define XSTRLEN(s1)       strlen((s1))
     #define XSTRNCMP(s1,s2,n) strncmp((s1),(s2),(n))
+    #define XSTRSTR(s1,s2)    strstr((s1),(s2))
 #endif /* !WOLFTPM_CUSTOM_TYPES */
 
     /* Endianess */
     #ifndef BIG_ENDIAN_ORDER
         #define LITTLE_ENDIAN_ORDER
+    #endif
+
+    #ifndef OFFSETOF
+        #if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ >= 4))
+            #define OFFSETOF(type, field) __builtin_offsetof(type, field)
+        #else
+            #define OFFSETOF(type, field) ((size_t)&(((type *)0)->field))
+        #endif
     #endif
 
     /* GCC Version */
@@ -554,6 +565,18 @@ typedef int64_t  INT64;
 #endif
 #ifndef WOLFTPM2_WRAP_ECC_KEY_BITS
     #define WOLFTPM2_WRAP_ECC_KEY_BITS (MAX_ECC_KEY_BITS*8)
+#endif
+
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && \
+    (defined(WOLF_CRYPTO_DEV) || defined(WOLF_CRYPTO_CB))
+    /* Enable the crypto callback support */
+    #define WOLFTPM_CRYPTOCB
+#endif
+
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && defined(WOLFSSL_CERT_GEN) && \
+    (!defined(NO_RSA) || defined(HAVE_ECC))
+    /* Enable the certificate generation support */
+    #define WOLFTPM2_CERT_GEN
 #endif
 
 


### PR DESCRIPTION
* Support for `wolfTPM2_CSR_Generate` wrapper to assist with CSR generation.
* Modified the existing CSR example to use wrapper.
* Adds support for `WOLFTPM2_CSR` structure and using custom OIDs in the CSR. This allows passing a `WOLFTPM2_CSR` to a set of new `wolfTPM2_CSR_*` API's.
* Added CSharp wrappers and tests for CSR feature.

The custom OID feature requires:

user_settings.h:
```
#define WOLFSSL_ASN_TEMPLATE
#define WOLFSSL_CUSTOM_OID
#define HAVE_OID_ENCODING
```
Cmake:
```
"CMAKE_C_FLAGS": "-DWOLFSSL_CUSTOM_OID -DHAVE_OID_ENCODING -DWOLFSSL_ASN_TEMPLATE",
```

Configure (autoconf):
```
./configure --enable-wolftpm --enable-certgen --enable-asn=template CFLAGS="-DWOLFSSL_CUSTOM_OID -DHAVE_OID_ENCODING"
```