### PR TITLE
Fix SPI_MAX_HZ to typ value of the SLB9672

### DIFF
--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -246,8 +246,8 @@ typedef int64_t  INT64;
     #endif
 #else
     /* Infineon OPTIGA SLB9670/SLB9672 */
-    /* Max: 43MHz */
-    #define TPM2_SPI_MAX_HZ_INFINEON 43000000
+    /* Max: 43MHz for SLB9670 and 33MHz for SLB9672*/
+    #define TPM2_SPI_MAX_HZ_INFINEON 33000000
     #ifndef TPM2_SPI_MAX_HZ
         #define TPM2_SPI_MAX_HZ TPM2_SPI_MAX_HZ_INFINEON
     #endif


### PR DESCRIPTION
SPI CLK Max is for the SLB9672 FW 15/16 is only 33MHz

![image](https://user-images.githubusercontent.com/28053215/177052923-c7d7959d-89be-46bd-9c05-eb94d6ed860b.png)

Datasheet reference table 14: 
[Datasheet: SLB9672 FW15](https://www.infineon.com/dgdl/Infineon-OPTIGA%20TPM%20SLB%209672%20FW16-DataSheet-v01_00-EN.pdf?fileId=8ac78c8c7f2a768a017f899f82094435
)
[Datasheet: SLB9672 FW16](https://www.infineon.com/dgdl/Infineon-OPTIGA%20TPM%20SLB%209672%20FW15-DataSheet-v01_00-EN.pdf?fileId=8ac78c8c7f2a768a017f89965f764432)

Signed-off-by: @PaulKissinger paul.kissinger@letstrust.de