### PR TITLE
Fix for using type not available with wolfCrypt only

### DIFF
--- a/examples/csr/csr.c
+++ b/examples/csr/csr.c
@@ -77,7 +77,7 @@ static int TPM2_CSR_Generate(WOLFTPM2_DEV* dev, int keyType, WOLFTPM2_KEY* key,
 #ifdef WOLFTPM2_NO_HEAP
     /* single shot API for CSR generation */
     rc = wolfTPM2_CSR_Generate_ex(dev, key, subject, keyUsage,
-        WOLFSSL_FILETYPE_PEM, output.buffer, output.size, 0, makeSelfSignedCert,
+        CTC_FILETYPE_PEM, output.buffer, output.size, 0, makeSelfSignedCert,
         devId);
 #else
     rc = wolfTPM2_CSR_SetSubject(dev, csr, subject);
@@ -94,7 +94,7 @@ static int TPM2_CSR_Generate(WOLFTPM2_DEV* dev, int keyType, WOLFTPM2_KEY* key,
         }
     }
     if (rc == 0) {
-        rc = wolfTPM2_CSR_MakeAndSign_ex(dev, csr, key, WOLFSSL_FILETYPE_PEM,
+        rc = wolfTPM2_CSR_MakeAndSign_ex(dev, csr, key, CTC_FILETYPE_PEM,
             output.buffer, output.size, 0, makeSelfSignedCert, devId);
     }
 #endif

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -4929,7 +4929,7 @@ static int CSR_MakeAndSign(WOLFTPM2_DEV* dev, WOLFTPM2_CSR* csr, CSRKey* key,
     }
 
     /* Optionally convert to PEM */
-    if (rc >= 0 && outFormat == WOLFSSL_FILETYPE_PEM) {
+    if (rc >= 0 && outFormat == CTC_FILETYPE_PEM) {
     #ifdef WOLFSSL_DER_TO_PEM
         WOLFTPM2_BUFFER tmp;
         tmp.size = rc;

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -2399,7 +2399,7 @@ WOLFTPM_API int wolfTPM2_CSR_SetSubject(WOLFTPM2_DEV* dev, WOLFTPM2_CSR* csr,
     \param dev pointer to a TPM2_DEV struct
     \param csr pointer to a WOLFTPM2_CSR structure
     \param key WOLFTPM2_KEY structure
-    \param outFormat WOLFSSL_FILETYPE_ASN1 or WOLFSSL_FILETYPE_PEM
+    \param outFormat CTC_FILETYPE_ASN1 or CTC_FILETYPE_PEM
     \param out destination buffer for CSR as ASN.1/DER or PEM
     \param outSz destination buffer maximum size
     \param sigType Use 0 to automatically select SHA2-256 based on keyType (CTC_SHA256wRSA or CTC_SHA256wECDSA).
@@ -2430,7 +2430,7 @@ WOLFTPM_API int wolfTPM2_CSR_MakeAndSign_ex(WOLFTPM2_DEV* dev, WOLFTPM2_CSR* csr
     \param dev pointer to a TPM2_DEV struct
     \param csr pointer to a WOLFTPM2_CSR structure
     \param key WOLFTPM2_KEY structure
-    \param outFormat WOLFSSL_FILETYPE_ASN1 or WOLFSSL_FILETYPE_PEM
+    \param outFormat CTC_FILETYPE_ASN1 or CTC_FILETYPE_PEM
     \param out destination buffer for CSR as ASN.1/DER or PEM
     \param outSz destination buffer maximum size
 
@@ -2458,7 +2458,7 @@ WOLFTPM_API int wolfTPM2_CSR_MakeAndSign(WOLFTPM2_DEV* dev, WOLFTPM2_CSR* csr,
     \param keyUsage string list of comma separated key usage attributes.
         Possible values: any, serverAuth, clientAuth, codeSigning, emailProtection, timeStamping and OCSPSigning
         Default: "serverAuth,clientAuth,codeSigning"
-    \param outFormat WOLFSSL_FILETYPE_ASN1 or WOLFSSL_FILETYPE_PEM
+    \param outFormat CTC_FILETYPE_ASN1 or CTC_FILETYPE_PEM
     \param out destination buffer for CSR as ASN.1/DER or PEM
     \param outSz destination buffer maximum size
     \param sigType Use 0 to automatically select SHA2-256 based on keyType (CTC_SHA256wRSA or CTC_SHA256wECDSA).
@@ -2491,7 +2491,7 @@ WOLFTPM_API int wolfTPM2_CSR_Generate_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     \param keyUsage string list of comma separated key usage attributes.
         Possible values: any, serverAuth, clientAuth, codeSigning, emailProtection, timeStamping and OCSPSigning
         Default: "serverAuth,clientAuth,codeSigning"
-    \param outFormat WOLFSSL_FILETYPE_ASN1 or WOLFSSL_FILETYPE_PEM
+    \param outFormat CTC_FILETYPE_ASN1 or CTC_FILETYPE_PEM
     \param out destination buffer for CSR as ASN.1/DER or PEM
     \param outSz destination buffer maximum size
 

--- a/wrapper/CSharp/wolfTPM.cs
+++ b/wrapper/CSharp/wolfTPM.cs
@@ -187,7 +187,7 @@ namespace wolfTPM
         LAST         = AUTH_FF,
     }
 
-    /* from wolfSSL WOLFSSL_FILETYPE_ASN1 and WOLFSSL_FILETYPE_PEM */
+    /* from wolfSSL CTC_FILETYPE_ASN1 and CTC_FILETYPE_PEM */
     public enum X509_Format : int
     {
         PEM = 1,


### PR DESCRIPTION
Resolves error with `WOLFSSL_FILETYPE_PEM` not being available with `WOLFCRYPT_ONLY`.