### PR TITLE
Microchip macro names and Support for bench with MPLABX Harmony

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ autogen.sh requires: automake and libtool: `sudo apt-get install automake libtoo
 --enable-autodetect     Enable Runtime Module Detection (default: enable - when no module specified) - WOLFTPM_AUTODETECT
 --enable-infineon       Enable Infineon SLB9670/SLB9672 TPM Support (default: disabled)
 --enable-st             Enable ST ST33TPM Support (default: disabled) - WOLFTPM_ST33
---enable-microchip      Enable Microchip ATTPM20 Support (default: disabled) - WOLFTPM_MCHP
+--enable-microchip      Enable Microchip ATTPM20 Support (default: disabled) - WOLFTPM_MICROCHIP
 --enable-nuvoton        Enable Nuvoton NPCT65x/NPCT75x Support (default: disabled) - WOLFTPM_NUVOTON
 
 --enable-devtpm         Enable using Linux kernel driver for /dev/tpmX (default: disabled) - WOLFTPM_LINUX_DEV

--- a/configure.ac
+++ b/configure.ac
@@ -294,7 +294,7 @@ AC_ARG_ENABLE([microchip],
 if test "x$ENABLED_MCHP" = "xyes" || test "x$ENABLED_MICROCHIP" = "xyes"
 then
     ENABLED_MICROCHIP=yes
-    AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_MCHP"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_MICROCHIP"
 fi
 
 # Nuvoton NPCT65x/NPCT75x

--- a/examples/tpm_test.h
+++ b/examples/tpm_test.h
@@ -82,7 +82,7 @@ static const char pemFileKey[] = "key.pem";
 #define TEST_AES_VERIFY kTestAesCbc128Verify
 #endif
 
-#ifdef WOLFTPM_MCHP
+#ifdef WOLFTPM_MICROCHIP
     /* workaround due to issue with older firmware */
     #define TEST_WRAP_DIGEST TPM_ALG_SHA1
 #else
@@ -93,7 +93,7 @@ static const char pemFileKey[] = "key.pem";
     #ifndef WOLFSSL_USER_CURRTIME
 #ifdef _WIN32
         #include <time.h>
-#elif defined(WOLFTPM_MICROCHIP)
+#elif defined(WOLFTPM_MICROCHIP_HARMONY)
         #include "system/time/sys_time.h"
 #else
         #include <sys/time.h>
@@ -109,7 +109,7 @@ static const char pemFileKey[] = "key.pem";
         unsigned long long ticks = GetTickCount64();
         (void)reset;
         return ((double)ticks)/1000.0;
-    #elif defined(WOLFTPM_MICROCHIP)
+    #elif defined(WOLFTPM_MICROCHIP_HARMONY)
         if (reset)
             SYS_TIME_CounterSet(0);
         return (double)(SYS_TIME_Counter64Get()) /

--- a/examples/tpm_test.h
+++ b/examples/tpm_test.h
@@ -93,10 +93,13 @@ static const char pemFileKey[] = "key.pem";
     #ifndef WOLFSSL_USER_CURRTIME
 #ifdef _WIN32
         #include <time.h>
+#elif defined(WOLFTPM_MICROCHIP)
+        #include "system/time/sys_time.h"
 #else
         #include <sys/time.h>
 #endif
     #endif
+
     static inline double gettime_secs(int reset)
     {
     #ifdef WOLFSSL_USER_CURRTIME
@@ -106,6 +109,11 @@ static const char pemFileKey[] = "key.pem";
         unsigned long long ticks = GetTickCount64();
         (void)reset;
         return ((double)ticks)/1000.0;
+    #elif defined(WOLFTPM_MICROCHIP)
+        if (reset)
+            SYS_TIME_CounterSet(0);
+        return (double)(SYS_TIME_Counter64Get()) /
+               (double)SYS_TIME_FrequencyGet();
     #else
         struct timeval tv;
         gettimeofday(&tv, 0);

--- a/hal/README.md
+++ b/hal/README.md
@@ -23,7 +23,7 @@ If using a HAL IO callback it is registered on library initialization using:
 | Barebox | `tpm_io_barebox.c` | `__BAREBOX__` |
 | Infineon | `tpm_io_infineon.c` | `WOLFTPM_INFINEON_TRICORE` |
 | Linux | `tpm_io_linux.c` | `__linux__` |
-| Microchip | `tpm_io_microchip.c` | `WOLFTPM_MICROCHIP` |
+| Microchip | `tpm_io_microchip.c` | `WOLFTPM_MICROCHIP_HARMONY` |
 | QNX | `tpm_io_qnx.c` | `__QNX__` |
 | ST Cube HAL | `tpm_io_st.c` | `WOLFSSL_STM32_CUBEMX` |
 | Xilinx | `tpm_io_xilinx.c` | `__XILINX__` |

--- a/hal/tpm_io.c
+++ b/hal/tpm_io.c
@@ -60,7 +60,7 @@
 #include "hal/tpm_io_xilinx.c"
 #elif defined(WOLFTPM_INFINEON_TRICORE)
 #include "hal/tpm_io_infineon.c"
-#elif defined(WOLFTPM_MICROCHIP)
+#elif defined(WOLFTPM_MICROCHIP_HARMONY)
 #include "hal/tpm_io_microchip.c"
 #endif
 
@@ -84,7 +84,7 @@ static int TPM2_IoCb_SPI(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
     ret = TPM2_IoCb_Xilinx_SPI(ctx, txBuf, rxBuf, xferSz, userCtx);
 #elif defined(WOLFTPM_INFINEON_TRICORE)
     ret = TPM2_IoCb_Infineon_TriCore_SPI(ctx, txBuf, rxBuf, xferSz, userCtx);
-#elif defined(WOLFTPM_MICROCHIP)
+#elif defined(WOLFTPM_MICROCHIP_HARMONY)
     ret = TPM2_IoCb_Microchip_SPI(ctx, txBuf, rxBuf, xferSz, userCtx);
 #else
 

--- a/hal/tpm_io.h
+++ b/hal/tpm_io.h
@@ -49,7 +49,7 @@
  * - Barebox
  * - QNX
  * - Infineon Tri-Core
- * - Microchip MPLAB X Harmony (WOLFTPM_MICROCHIP)
+ * - Microchip MPLAB X Harmony (WOLFTPM_MICROCHIP_HARMONY)
  * Using custom IO Callback is always possible.
  *
  */
@@ -106,7 +106,7 @@ WOLFTPM_LOCAL int TPM2_IoCb_Xilinx_SPI(TPM2_CTX* ctx, const byte* txBuf,
 #elif defined(WOLFTPM_INFINEON_TRICORE)
 WOLFTPM_LOCAL int TPM2_IoCb_Infineon_TriCore_SPI(TPM2_CTX* ctx, const byte* txBuf,
     byte* rxBuf, word16 xferSz, void* userCtx);
-#elif defined(WOLFTPM_MICROCHIP)
+#elif defined(WOLFTPM_MICROCHIP_HARMONY)
 WOLFTPM_LOCAL int TPM2_IoCb_Microchip_SPI(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
     word16 xferSz, void* userCtx);
 #endif

--- a/hal/tpm_io_linux.c
+++ b/hal/tpm_io_linux.c
@@ -68,7 +68,7 @@
         #define TPM2_I2C_HZ   400000 /* 400kHz */
     #else
         /* SPI */
-        #ifdef WOLFTPM_MCHP
+        #ifdef WOLFTPM_MICROCHIP
             /* Microchip ATTPM20 uses CE0 */
             #define TPM2_SPI_DEV_CS "0"
         #elif defined(WOLFTPM_ST33)

--- a/hal/tpm_io_microchip.c
+++ b/hal/tpm_io_microchip.c
@@ -43,7 +43,7 @@
     #define TPM2_SPI_HZ TPM2_SPI_MAX_HZ
 #endif
 
-#if defined(WOLFTPM_MICROCHIP)
+#if defined(WOLFTPM_MICROCHIP_HARMONY)
 
 #ifdef WOLFTPM_CHECK_WAIT_STATE
     #error This driver does not support check wait state yet
@@ -94,7 +94,7 @@ int TPM2_IoCb_Microchip_SPI(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
     return ret;
 }
 
-#endif /* WOLFTPM_MICROCHIP */
+#endif /* WOLFTPM_MICROCHIP_HARMONY */
 #endif /* !(WOLFTPM_LINUX_DEV || WOLFTPM_SWTPM || WOLFTPM_WINAPI) */
 #endif /* WOLFTPM_INCLUDE_IO_FILE */
 

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -51,7 +51,7 @@ static int wolfTPM2_Init_ex(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx,
 
 #if !defined(WOLFTPM_LINUX_DEV) && !defined(WOLFTPM_WINAPI)
     Startup_In startupIn;
-#if defined(WOLFTPM_MCHP) || defined(WOLFTPM_PERFORM_SELFTEST)
+#if defined(WOLFTPM_MICROCHIP) || defined(WOLFTPM_PERFORM_SELFTEST)
     SelfTest_In selfTest;
 #endif
 #endif /* ! WOLFTPM_LINUX_DEV */
@@ -99,7 +99,7 @@ static int wolfTPM2_Init_ex(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx,
     printf("TPM2_Startup pass\n");
 #endif
 
-#if defined(WOLFTPM_MCHP) || defined(WOLFTPM_PERFORM_SELFTEST)
+#if defined(WOLFTPM_MICROCHIP) || defined(WOLFTPM_PERFORM_SELFTEST)
     /* Do full self-test (Chips such as ATTPM20 require this before some operations) */
     XMEMSET(&selfTest, 0, sizeof(selfTest));
     selfTest.fullTest = YES;
@@ -115,7 +115,7 @@ static int wolfTPM2_Init_ex(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx,
 #endif
 #else
     rc = TPM_RC_SUCCESS;
-#endif /* WOLFTPM_MCHP || WOLFTPM_PERFORM_SELFTEST */
+#endif /* WOLFTPM_MICROCHIP || WOLFTPM_PERFORM_SELFTEST */
 #endif /* !WOLFTPM_LINUX_DEV && !WOLFTPM_WINAPI */
 
     return rc;
@@ -4475,7 +4475,7 @@ int wolfTPM2_GetKeyTemplate_Symmetric(TPMT_PUBLIC* publicTemplate, int keyBits,
     if (publicTemplate == NULL)
         return BAD_FUNC_ARG;
 
-#ifdef WOLFTPM_MCHP
+#ifdef WOLFTPM_MICROCHIP
     isSign = 0; /* Microchip TPM does not like "sign" set for symmetric keys */
 #endif
 

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -224,7 +224,11 @@ typedef int64_t  INT64;
 /* TPM HARDWARE TYPE */
 /* ---------------------------------------------------------------------------*/
 /* Microchip ATTPM20 */
-/* #define WOLFTPM_MCHP */
+/* #define WOLFTPM_MICROCHIP */
+/* #define WOLFTPM_MCHP (old) - for backwards compatibility */
+#if defined(WOLFTPM_MCHP) && !defined(WOLFTPM_MICROCHIP)
+    #define WOLFTPM_MICROCHIP
+#endif
 
 /* ST ST33TP TPM 2.0 */
 /* #define WOLFTPM_ST33 */
@@ -238,7 +242,7 @@ typedef int64_t  INT64;
 
 
 /* Chip Specific Settings */
-#ifdef WOLFTPM_MCHP
+#ifdef WOLFTPM_MICROCHIP
     /* Microchip ATTPM20 */
     /* Requires SPI wait states */
     #ifndef WOLFTPM_CHECK_WAIT_STATE


### PR DESCRIPTION
Fix for Microchip Harmony build settings. Rename to `WOLFTPM_MICROCHIP_HARMONY`. Avoids confusion with the TPM 2.0 module ATTPM from Microchip. Now enabled with `WOLFTPM_MICROCHIP` and provides backwards compatibility for `WOLFTPM_MCHP`. The new `WOLFTPM_MICROCHIP` has not been released (was added in PR #251).

Support for TPM benchmarking with Microchip MPLABX (`WOLFTPM_MICROCHIP_HARMONY `).

ZD 15350