### PR TITLE
Sealing secrets with PolicyPCR and PolicyAuthorize

### DIFF
--- a/.github/workflows/make-test-swtpm.yml
+++ b/.github/workflows/make-test-swtpm.yml
@@ -44,4 +44,4 @@ jobs:
     - name: make test
       run: |
           ./ibmswtpm2/src/tpm_server &
-          sleep 10 && ./autogen.sh && ./configure --enable-swtpm && make test && ./examples/native/native_test && ./examples/wrap/wrap_test
+          sleep 10 && make test && ./examples/native/native_test && ./examples/wrap/wrap_test

--- a/.github/workflows/make-test-swtpm.yml
+++ b/.github/workflows/make-test-swtpm.yml
@@ -44,4 +44,4 @@ jobs:
     - name: make test
       run: |
           ./ibmswtpm2/src/tpm_server &
-          sleep 10 && make test && ./examples/native/native_test && ./examples/wrap/wrap_test
+          sleep 10 && ./autogen.sh && ./configure --enable-swtpm && make test && ./examples/native/native_test && ./examples/wrap/wrap_test

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ examples/gpio/gpio_nuvoton
 examples/seal/seal
 examples/seal/unseal
 examples/seal/seal_policy_auth
+examples/seal/seal_policy_auth_nv
 examples/attestation/make_credential
 examples/attestation/activate_credential
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ examples/timestamp/signed_timestamp
 examples/pcr/quote
 examples/pcr/read_pcr
 examples/pcr/extend
+examples/pcr/policy
 examples/pcr/reset
 examples/timestamp/clock_set
 examples/management/flush

--- a/examples/keygen/keyimport.c
+++ b/examples/keygen/keyimport.c
@@ -31,7 +31,7 @@
 #include <stdio.h>
 
 
-#ifndef WOLFTPM2_NO_WRAPPER
+#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT)
 
 /******************************************************************************/
 /* --- BEGIN TPM Key Import / Blob Example -- */
@@ -230,7 +230,7 @@ exit:
 /******************************************************************************/
 /* --- END TPM Key Import / Blob Example -- */
 /******************************************************************************/
-#endif /* !WOLFTPM2_NO_WRAPPER */
+#endif /* !WOLFTPM2_NO_WRAPPER && !WOLFTPM2_NO_WOLFCRYPT */
 
 
 #ifndef NO_MAIN_DRIVER
@@ -238,7 +238,7 @@ int main(int argc, char *argv[])
 {
     int rc = NOT_COMPILED_IN;
 
-#ifndef WOLFTPM2_NO_WRAPPER
+#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT)
     rc = TPM2_Keyimport_Example(NULL, argc, argv);
 #else
     printf("KeyImport code not compiled in\n");

--- a/examples/native/native_test.c
+++ b/examples/native/native_test.c
@@ -157,7 +157,9 @@ int TPM2_Native_TestArgs(void* userCtx, int argc, char *argv[])
     TPML_TAGGED_TPM_PROPERTY* tpmProp;
     TPM_HANDLE handle = TPM_RH_NULL;
     TPM_HANDLE sessionHandle = TPM_RH_NULL;
+#ifndef WOLFTPM_WINAPI
     TPMI_RH_NV_INDEX nvIndex;
+#endif
     TPM2B_PUBLIC_KEY_RSA message;
 
 #ifndef WOLFTPM2_NO_WOLFCRYPT

--- a/examples/nvram/include.am
+++ b/examples/nvram/include.am
@@ -22,13 +22,20 @@ examples_nvram_counter_SOURCES      = examples/nvram/counter.c \
 examples_nvram_counter_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_nvram_counter_DEPENDENCIES = src/libwolftpm.la
 
+noinst_PROGRAMS += examples/nvram/seal_policy_auth_nv
+examples_nvram_seal_policy_auth_nv_SOURCES      = examples/nvram/seal_policy_auth_nv.c \
+                                                  examples/tpm_test_keys.c
+examples_nvram_seal_policy_auth_nv_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
+examples_nvram_seal_policy_auth_nv_DEPENDENCIES = src/libwolftpm.la
+
 endif
 
 example_nvramdir = $(exampledir)/nvram
 dist_example_nvram_DATA = \
   examples/nvram/store.c \
   examples/nvram/read.c \
-  examples/nvram/counter.c
+  examples/nvram/counter.c \
+  examples/nvram/seal_policy_auth_nv.c
 
 DISTCLEANFILES+= examples/nvram/.libs/store
 DISTCLEANFILES+= examples/nvram/.libs/read

--- a/examples/nvram/nvram.h
+++ b/examples/nvram/nvram.h
@@ -1,6 +1,6 @@
 /* nvram.h
  *
- * Copyright (C) 2006-2022 wolfSSL Inc.
+ * Copyright (C) 2006-2023 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *
@@ -29,6 +29,7 @@
 int TPM2_NVRAM_Store_Example(void* userCtx, int argc, char *argv[]);
 int TPM2_NVRAM_Read_Example(void* userCtx, int argc, char *argv[]);
 int TPM2_NVRAM_Counter_Example(void* userCtx, int argc, char *argv[]);
+int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]);
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/examples/nvram/seal_policy_auth_nv.c
+++ b/examples/nvram/seal_policy_auth_nv.c
@@ -66,7 +66,7 @@ int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]
     word32 pcrIndex = 16;
     word32 pcrArray[48];
     word32 pcrArraySz = 0;
-    byte secret[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    byte secret[16];
     byte secretOut[16];
     word32 secretOutSz = (word32)sizeof(secretOut);
     byte policySignedSig[MAX_RSA_KEY_BYTES];
@@ -78,6 +78,10 @@ int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]
     XMEMSET(&tpmSession, 0, sizeof(WOLFTPM2_SESSION));
     XMEMSET(&nv, 0, sizeof(nv));
     XMEMSET(&authTemplate, 0, sizeof(TPMT_PUBLIC));
+
+    for (i = 0; i < (int)sizeof(secret); i++) {
+        secret[i] = i;
+    }
 
     if (argc >= 2) {
         if (XSTRCMP(argv[1], "-?") == 0 ||
@@ -150,7 +154,8 @@ int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]
 
     /* set session for authorization of the storage key */
     rc = wolfTPM2_SetAuthSession(&dev, 0, &tpmSession,
-        (TPMA_SESSION_decrypt | TPMA_SESSION_encrypt | TPMA_SESSION_continueSession));
+        (TPMA_SESSION_decrypt | TPMA_SESSION_encrypt |
+        TPMA_SESSION_continueSession));
     if (rc != 0) goto exit;
 
     /* get SRK */
@@ -215,7 +220,8 @@ int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]
 
     /* set session for authorization of the storage key */
     rc = wolfTPM2_SetAuthSession(&dev, 0, &tpmSession,
-        (TPMA_SESSION_decrypt | TPMA_SESSION_encrypt | TPMA_SESSION_continueSession));
+        (TPMA_SESSION_decrypt | TPMA_SESSION_encrypt |
+        TPMA_SESSION_continueSession));
     if (rc != 0) goto exit;
 
     nv.handle.hndl = sealNvIndex;

--- a/examples/nvram/seal_policy_auth_nv.c
+++ b/examples/nvram/seal_policy_auth_nv.c
@@ -189,7 +189,7 @@ int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]
 
     /* seal the secret */
     rc = wolfTPM2_SealWithAuthKeyNV(&dev, &authKey,
-        tpmSession.handle.hndl, TPM_ALG_SHA256, TPM_ALG_SHA256, pcrArray,
+        &tpmSession, TPM_ALG_SHA256, TPM_ALG_SHA256, pcrArray,
         pcrArraySz, secret, sizeof(secret),
         NULL, 0, sealNvIndex, policyDigestNvIndex, policySignedSig,
         &policySignedSigSz);
@@ -227,11 +227,11 @@ int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]
 
     /* unseal the secret */
     rc = wolfTPM2_UnsealWithAuthSigNV(&dev, &authKey,
-        tpmSession.handle.hndl, TPM_ALG_SHA256, pcrArray,
+        &tpmSession, TPM_ALG_SHA256, pcrArray,
         pcrArraySz, NULL, 0, policySignedSig, policySignedSigSz, sealNvIndex,
         policyDigestNvIndex, secretOut, &secretOutSz);
     if (rc != TPM_RC_SUCCESS) {
-        printf("wolfTPM2_UnsealWithAuthPolicyNV failed 0x%x: %s\n", rc,
+        printf("wolfTPM2_UnsealWithAuthSigNV failed 0x%x: %s\n", rc,
             TPM2_GetRCString(rc));
         goto exit;
     }

--- a/examples/nvram/seal_policy_auth_nv.c
+++ b/examples/nvram/seal_policy_auth_nv.c
@@ -188,7 +188,7 @@ int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]
     }
 
     /* seal the secret */
-    rc = wolfTPM2_SealWithAuthKeyNV(&dev, &authKey,
+    rc = wolfTPM2_SealWithAuthKeyNV(&dev, (WOLFTPM2_KEY*)&authKey,
         &tpmSession, TPM_ALG_SHA256, TPM_ALG_SHA256, pcrArray,
         pcrArraySz, secret, sizeof(secret),
         NULL, 0, sealNvIndex, policyDigestNvIndex, policySignedSig,
@@ -226,7 +226,7 @@ int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]
     }
 
     /* unseal the secret */
-    rc = wolfTPM2_UnsealWithAuthSigNV(&dev, &authKey,
+    rc = wolfTPM2_UnsealWithAuthSigNV(&dev, (WOLFTPM2_KEY*)&authKey,
         &tpmSession, TPM_ALG_SHA256, pcrArray,
         pcrArraySz, NULL, 0, policySignedSig, policySignedSigSz, sealNvIndex,
         policyDigestNvIndex, secretOut, &secretOutSz);

--- a/examples/nvram/seal_policy_auth_nv.c
+++ b/examples/nvram/seal_policy_auth_nv.c
@@ -64,13 +64,13 @@ int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]
     /* default to aes since parm encryption is required */
     TPM_ALG_ID paramEncAlg = TPM_ALG_CFB;
     word32 pcrIndex = 16;
-    word32 pcrArray[256];
+    word32 pcrArray[48];
     word32 pcrArraySz = 0;
     byte secret[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
     byte secretOut[16];
     word32 secretOutSz = (word32)sizeof(secretOut);
-    byte policySignedSig[RSA_SIG_SZ];
-    word32 policySignedSigSz = RSA_SIG_SZ;
+    byte policySignedSig[MAX_RSA_KEY_BYTES];
+    word32 policySignedSigSz = MAX_RSA_KEY_BYTES;
     TPM_ALG_ID alg = TPM_ALG_RSA;
 
     XMEMSET(&dev, 0, sizeof(WOLFTPM2_DEV));
@@ -118,7 +118,7 @@ int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]
     }
 
     if (pcrArraySz == 0) {
-        pcrArray[pcrArraySz] = 16;
+        pcrArray[pcrArraySz] = pcrIndex;
         pcrArraySz++;
     }
 
@@ -170,6 +170,10 @@ int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]
                  TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth |
                  TPMA_OBJECT_sign | TPMA_OBJECT_noDA,
                  TPM_ECC_NIST_P256, TPM_ALG_ECDSA);
+    }
+    if (rc != TPM_RC_SUCCESS) {
+        printf("create template failed failed\n");
+        goto exit;
     }
 
     /* generate the authorized key, this auth key can also generated and */

--- a/examples/nvram/seal_policy_auth_nv.c
+++ b/examples/nvram/seal_policy_auth_nv.c
@@ -1,4 +1,4 @@
-/* seal_policy_auth.c
+/* seal_policy_auth_nv.c
  *
  * Copyright (C) 2006-2023 wolfSSL Inc.
  *
@@ -58,7 +58,8 @@ int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]
     WOLFTPM2_NV nv;
     WOLFTPM2_DEV dev;
     WOLFTPM2_SESSION tpmSession;
-    TPM_ALG_ID paramEncAlg = TPM_ALG_NULL;
+    /* default to aes since parm encryption is required */
+    TPM_ALG_ID paramEncAlg = TPM_ALG_CFB;
     word32 pcrIndex = 16;
     word32 pcrArray[256];
     word32 pcrArraySz = 0;
@@ -195,7 +196,7 @@ int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]
         goto exit;
     }
 
-    if (memcmp(secret, secretOut, sizeof(secret)) != 0) {
+    if (XMEMCMP(secret, secretOut, sizeof(secret)) != 0) {
         printf("Usealed secret does not match\n");
         goto exit;
     }

--- a/examples/nvram/seal_policy_auth_nv.c
+++ b/examples/nvram/seal_policy_auth_nv.c
@@ -43,7 +43,7 @@
 static void usage(void)
 {
     printf("Expected usage:\n");
-    printf("./examples/pcr/policy [-aes/xor] [-digest=HEXSTR] [pcr]\n");
+    printf("./examples/pcr/policy [-aes/xor] [pcr]\n");
     printf("* pcr: PCR index between 0-23 (default %d)\n", 16);
     printf("* -aes/xor: Use Parameter Encryption\n");
 }
@@ -65,7 +65,7 @@ int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]
     word32 pcrArraySz = 0;
     byte secret[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
     byte secretOut[16];
-    word32 secretOutSz = sizeof(secretOut);
+    word32 secretOutSz = (word32)sizeof(secretOut);
 
     XMEMSET(&dev, 0, sizeof(WOLFTPM2_DEV));
     XMEMSET(&tpmSession, 0, sizeof(WOLFTPM2_SESSION));
@@ -180,8 +180,8 @@ int TPM2_PCR_Seal_With_Policy_Auth_NV_Test(void* userCtx, int argc, char *argv[]
     rc = wolfTPM2_NVReadAuth(&dev, &nv, sealNvIndex,
         secretOut, &secretOutSz, 0);
     if (rc == TPM_RC_SUCCESS) {
-        printf("wolfTPM2_NVReadAuth failed, it should not have allowed a read without PolicyAuthorizeNV 0x%x: %s\n", rc,
-            TPM2_GetRCString(rc));
+        printf("wolfTPM2_NVReadAuth failed, it should not have allowed a read"
+            " without PolicyAuthorizeNV 0x%x: %s\n", rc, TPM2_GetRCString(rc));
         goto exit;
     }
 

--- a/examples/pcr/extend.c
+++ b/examples/pcr/extend.c
@@ -53,7 +53,7 @@ static void usage(void)
         TPM2_TEST_PCR);
 }
 
-int TPM2_Extend_Test(void* userCtx, int argc, char *argv[])
+int TPM2_PCR_Extend_Test(void* userCtx, int argc, char *argv[])
 {
     int i, j, pcrIndex = TPM2_TEST_PCR, rc = -1;
     WOLFTPM2_DEV dev;
@@ -199,7 +199,7 @@ int main(int argc, char *argv[])
     int rc = -1;
 
 #ifndef WOLFTPM2_NO_WRAPPER
-    rc = TPM2_Extend_Test(NULL, argc, argv);
+    rc = TPM2_PCR_Extend_Test(NULL, argc, argv);
 #else
     printf("Wrapper code not compiled in\n");
     (void)argc;

--- a/examples/pcr/include.am
+++ b/examples/pcr/include.am
@@ -5,6 +5,7 @@ if BUILD_EXAMPLES
 noinst_PROGRAMS += examples/pcr/quote \
                    examples/pcr/read_pcr \
                    examples/pcr/extend \
+                   examples/pcr/policy \
                    examples/pcr/reset
 
 noinst_HEADERS  += examples/pcr/quote.h \
@@ -26,6 +27,11 @@ examples_pcr_extend_DEPENDENCIES = src/libwolftpm.la
 examples_pcr_reset_SOURCES      = examples/pcr/reset.c
 examples_pcr_reset_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_pcr_reset_DEPENDENCIES = src/libwolftpm.la
+
+examples_pcr_policy_SOURCES      = examples/pcr/policy.c \
+                                   examples/tpm_io.c
+examples_pcr_policy_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
+examples_pcr_policy_DEPENDENCIES = src/libwolftpm.la
 endif
 
 example_pcrdir = $(exampledir)/pcr
@@ -33,10 +39,12 @@ dist_example_pcr_DATA = \
   examples/pcr/quote.c \
   examples/pcr/read_pcr.c \
   examples/pcr/extend.c \
+  examples/pcr/policy.c \
   examples/pcr/reset.c
 
 DISTCLEANFILES+= examples/pcr/.libs/quote \
                  examples/pcr/.libs/read_pcr \
+                 examples/pcr/.libs/policy \
                  examples/pcr/.libs/extend \
                  examples/pcr/.libs/reset
 

--- a/examples/pcr/pcr.h
+++ b/examples/pcr/pcr.h
@@ -26,9 +26,10 @@
     extern "C" {
 #endif
 
-int TPM2_Read_Test(void* userCtx, int argc, char *argv[]);
-int TPM2_Extend_Test(void* userCtx, int argc, char *argv[]);
-int TPM2_Reset_Test(void* userCtx, int argc, char *argv[]);
+int TPM2_PCR_Read_Test(void* userCtx, int argc, char *argv[]);
+int TPM2_PCR_Extend_Test(void* userCtx, int argc, char *argv[]);
+int TPM2_PCR_Reset_Test(void* userCtx, int argc, char *argv[]);
+int TPM2_PCR_Policy_Test(void* userCtx, int argc, char *argv[]);
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/examples/pcr/policy.c
+++ b/examples/pcr/policy.c
@@ -1,0 +1,248 @@
+/* policy.c
+ *
+ * Copyright (C) 2006-2022 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/* This is a helper tool for setting policies on a TPM 2.0 PCR */
+
+#include <wolftpm/tpm2_wrap.h>
+
+#ifndef WOLFTPM2_NO_WRAPPER
+
+#ifndef WOLFTPM2_NO_WOLFCRYPT
+#include <wolfssl/wolfcrypt/hash.h>
+#endif
+
+#include <examples/pcr/pcr.h>
+#include <examples/tpm_io.h>
+#include <examples/tpm_test.h>
+
+#include <stdio.h>
+
+static char HexCharToByte(char ch)
+{
+    char ret = (char)ch;
+    if (ret >= '0' && ret <= '9')
+        ret -= '0';
+    else if (ret >= 'A' && ret <= 'F')
+        ret -= 'A' - 10;
+    else if (ret >= 'a' && ret <= 'f')
+        ret -= 'a' - 10;
+    else
+        ret = -1; /* error case - return code must be signed */
+    return ret;
+}
+static int HexToByte(const char *hex, unsigned char *output, unsigned long sz)
+{
+    word32 i;
+    for (i = 0; i < sz; i++) {
+        char ch1, ch2;
+        ch1 = HexCharToByte(hex[i * 2]);
+        ch2 = HexCharToByte(hex[i * 2 + 1]);
+        if ((ch1 < 0) || (ch2 < 0)) {
+            return -1;
+        }
+        output[i] = (unsigned char)((ch1 << 4) + ch2);
+    }
+    return (int)sz;
+}
+
+
+/******************************************************************************/
+/* --- BEGIN TPM2.0 PCR Policy example tool  -- */
+/******************************************************************************/
+
+static void usage(void)
+{
+    printf("Expected usage:\n");
+    printf("./examples/pcr/policy [-aes/xor] [-digest=HEXSTR] [pcr]\n");
+    printf("* pcr: PCR index between 0-23 (default %d)\n", TPM2_TEST_PCR);
+    printf("* -aes/xor: Use Parameter Encryption\n");
+    printf("* -digest=[HEXSTR]: SHA-1 or SHA2-256 hash of expected PCR's\n");
+}
+
+int TPM2_PCR_Policy_Test(void* userCtx, int argc, char *argv[])
+{
+    int rc = -1;
+    int pcrIndex = TPM2_TEST_PCR;
+    WOLFTPM2_DEV dev;
+    TPM_ALG_ID paramEncAlg = TPM_ALG_NULL;
+    WOLFTPM2_SESSION tpmSession;
+    int i;
+    byte digest[32];
+    word32 digestLen = 0;
+    union {
+        PolicyPCR_In pcrPolicy;
+        PolicyGetDigest_In policyGetDigest;
+        PolicyAuthorize_In policyAuth;
+        byte maxInput[MAX_COMMAND_SIZE];
+    } cmdIn;
+    union {
+        PolicyGetDigest_Out policyGetDigest;
+        byte maxOutput[MAX_RESPONSE_SIZE];
+    } cmdOut;
+
+    XMEMSET(&cmdIn, 0, sizeof(cmdIn));
+    XMEMSET(&cmdOut, 0, sizeof(cmdOut));
+    XMEMSET(&tpmSession, 0, sizeof(tpmSession));
+
+    if (argc >= 2) {
+        if (XSTRCMP(argv[1], "-?") == 0 ||
+            XSTRCMP(argv[1], "-h") == 0 ||
+            XSTRCMP(argv[1], "--help") == 0) {
+            usage();
+            return 0;
+        }
+    }
+    while (argc > 1) {
+        if (XSTRCMP(argv[argc-1], "-aes") == 0) {
+            paramEncAlg = TPM_ALG_CFB;
+        }
+        else if (XSTRCMP(argv[argc-1], "-xor") == 0) {
+            paramEncAlg = TPM_ALG_XOR;
+        }
+        else if (XSTRCMP(argv[argc-1], "-digest=") == 0) {
+            const char *digestStr, *end;
+            digestStr = argv[argc-1] + 8;
+            end = XSTRSTR(digestStr, " ");
+            if (end != NULL) {
+                digestLen = (word32)(size_t)(end - digestStr);
+            }
+            else {
+                digestLen = (word32)XSTRLEN(digestStr);
+            }
+            if (digestLen > sizeof(digest)*2) {
+                printf("Invalid digest! Must be 16 or 32 bytes of hex like 01020304050607080910111213141516\n");
+                usage();
+                return 0;
+            }
+            digestLen = HexToByte(digestStr, digest, digestLen);
+        }
+        else if (argv[1][0] != '-') {
+            /* TODO: Allow selection of multiple PCR's SHA-1 or SHA2-256 */
+            pcrIndex = XATOI(argv[1]);
+            if (pcrIndex < (int)PCR_FIRST || pcrIndex > (int)PCR_LAST) {
+                printf("PCR index is out of range (0-23)\n");
+                usage();
+                return 0;
+            }
+        }
+        else {
+            printf("Warning: Unrecognized option: %s\n", argv[argc-1]);
+        }
+        argc--;
+    }
+
+    printf("Example for setting PCR policies\n");
+    printf("\tPCR Index: %d\n", pcrIndex);
+    printf("\tDigest Len: %d\n", digestLen);
+    printf("\tUse Parameter Encryption: %s\n", TPM2_GetAlgName(paramEncAlg));
+
+    rc = wolfTPM2_Init(&dev, TPM2_IoCb, userCtx);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("wolfTPM2_Init failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("wolfTPM2_Init: success\n");
+
+    if (paramEncAlg != TPM_ALG_NULL) {
+        /* Start an authenticated policy session (salted / unbound) */
+        rc = wolfTPM2_StartSession(&dev, &tpmSession, NULL, NULL,
+            TPM_SE_POLICY, paramEncAlg);
+        if (rc != 0) goto exit;
+        printf("TPM2_StartAuthSession: sessionHandle 0x%x\n",
+            (word32)tpmSession.handle.hndl);
+
+        /* set session for authorization of the storage key */
+        rc = wolfTPM2_SetAuthSession(&dev, 0, &tpmSession,
+            (TPMA_SESSION_decrypt | TPMA_SESSION_encrypt | TPMA_SESSION_continueSession));
+        if (rc != 0) goto exit;
+    }
+
+    /* TODO Add wrappers for these API's */
+    cmdIn.pcrPolicy.policySession = tpmSession.handle.hndl;
+    cmdIn.pcrPolicy.pcrDigest.size = digestLen;
+    if (digestLen > 0) {
+        XMEMCPY(cmdIn.pcrPolicy.pcrDigest.buffer, digest, digestLen);
+    }
+    TPM2_SetupPCRSel(&cmdIn.pcrPolicy.pcrs, TPM_ALG_SHA256, pcrIndex);
+    rc = TPM2_PolicyPCR(&cmdIn.pcrPolicy);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_PolicyPCR failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+    printf("TPM2_PolicyPCR Set\n");
+
+    /* Policy Get Digest */
+    XMEMSET(&cmdIn.policyGetDigest, 0, sizeof(cmdIn.policyGetDigest));
+    cmdIn.policyGetDigest.policySession = tpmSession.handle.hndl;
+    rc = TPM2_PolicyGetDigest(&cmdIn.policyGetDigest, &cmdOut.policyGetDigest);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("TPM2_PolicyGetDigest failed 0x%x: %s\n", rc,
+            TPM2_GetRCString(rc));
+        goto exit;
+    }
+
+    printf("TPM2_PolicyGetDigest: size %d\n",
+        cmdOut.policyGetDigest.policyDigest.size);
+    for (i=0; i < cmdOut.policyGetDigest.policyDigest.size; i++)
+        printf("%02X", cmdOut.policyGetDigest.policyDigest.buffer[i]);
+    printf("\n");
+
+
+    //TPM_RC TPM2_PolicyAuthorize(PolicyAuthorize_In* in)
+
+exit:
+
+    if (rc != 0) {
+        printf("Failure 0x%x: %s\n", rc, wolfTPM2_GetRCString(rc));
+    }
+
+    wolfTPM2_UnloadHandle(&dev, &tpmSession.handle);
+    wolfTPM2_Cleanup(&dev);
+
+    return rc;
+}
+
+/******************************************************************************/
+/* --- END TPM2.0 PCR Policy example tool -- */
+/******************************************************************************/
+
+#endif /* !WOLFTPM2_NO_WRAPPER */
+
+#ifndef NO_MAIN_DRIVER
+int main(int argc, char *argv[])
+{
+    int rc = -1;
+
+#ifndef WOLFTPM2_NO_WRAPPER
+    rc = TPM2_PCR_Policy_Test(NULL, argc, argv);
+#else
+    printf("Wrapper code not compiled in\n");
+    (void)argc;
+    (void)argv;
+#endif /* !WOLFTPM2_NO_WRAPPER */
+
+    return rc;
+}
+#endif
+
+
+

--- a/examples/pcr/policy.c
+++ b/examples/pcr/policy.c
@@ -35,9 +35,9 @@
 
 #include <stdio.h>
 
-static char HexCharToByte(char ch)
+static signed char HexCharToByte(signed char ch)
 {
-    char ret = (char)ch;
+    signed char ret = (signed char)ch;
     if (ret >= '0' && ret <= '9')
         ret -= '0';
     else if (ret >= 'A' && ret <= 'F')
@@ -52,7 +52,7 @@ static int HexToByte(const char *hex, unsigned char *output, unsigned long sz)
 {
     word32 i;
     for (i = 0; i < sz; i++) {
-        char ch1, ch2;
+        signed char ch1, ch2;
         ch1 = HexCharToByte(hex[i * 2]);
         ch2 = HexCharToByte(hex[i * 2 + 1]);
         if ((ch1 < 0) || (ch2 < 0)) {

--- a/examples/pcr/policy.c
+++ b/examples/pcr/policy.c
@@ -206,10 +206,6 @@ int TPM2_PCR_Policy_Test(void* userCtx, int argc, char *argv[])
     for (i=0; i < cmdOut.policyGetDigest.policyDigest.size; i++)
         printf("%02X", cmdOut.policyGetDigest.policyDigest.buffer[i]);
     printf("\n");
-
-
-    //TPM_RC TPM2_PolicyAuthorize(PolicyAuthorize_In* in)
-
 exit:
 
     if (rc != 0) {

--- a/examples/pcr/quote.c
+++ b/examples/pcr/quote.c
@@ -50,7 +50,7 @@ static void usage(void)
            TPM2_TEST_PCR);
 }
 
-int TPM2_Quote_Test(void* userCtx, int argc, char *argv[])
+int TPM2_PCR_Quote_Test(void* userCtx, int argc, char *argv[])
 {
     int pcrIndex = TPM2_TEST_PCR, rc = -1;
     const char *outputFile = "quote.blob";
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
     int rc = -1;
 
 #ifndef WOLFTPM2_NO_WRAPPER
-    rc = TPM2_Quote_Test(NULL, argc, argv);
+    rc = TPM2_PCR_Quote_Test(NULL, argc, argv);
 #else
     printf("Wrapper code not compiled in\n");
     (void)argc;

--- a/examples/pcr/quote.h
+++ b/examples/pcr/quote.h
@@ -26,7 +26,7 @@
     extern "C" {
 #endif
 
-int TPM2_Quote_Test(void* userCtx, int argc, char *argv[]);
+int TPM2_PCR_Quote_Test(void* userCtx, int argc, char *argv[]);
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/examples/pcr/read_pcr.c
+++ b/examples/pcr/read_pcr.c
@@ -49,7 +49,7 @@ static void usage(void)
         TPM2_TEST_PCR);
 }
 
-int TPM2_Read_Test(void* userCtx, int argc, char *argv[])
+int TPM2_PCR_Read_Test(void* userCtx, int argc, char *argv[])
 {
     int rc = -1, i, j;
     int pcrIndex = TPM2_TEST_PCR;
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
     int rc = -1;
 
 #ifndef WOLFTPM2_NO_WRAPPER
-    rc = TPM2_Read_Test(NULL, argc, argv);
+    rc = TPM2_PCR_Read_Test(NULL, argc, argv);
 #else
     printf("Wrapper code not compiled in\n");
     (void)argc;

--- a/examples/pcr/reset.c
+++ b/examples/pcr/reset.c
@@ -44,7 +44,7 @@ static void usage(void)
     printf("Demo usage without parameters, resets PCR%d.\n", TPM2_TEST_PCR);
 }
 
-int TPM2_Reset_Test(void* userCtx, int argc, char *argv[])
+int TPM2_PCR_Reset_Test(void* userCtx, int argc, char *argv[])
 {
     int i, j, pcrIndex = TPM2_TEST_PCR, rc = -1;
     WOLFTPM2_DEV dev;
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
     int rc = -1;
 
 #ifndef WOLFTPM2_NO_WRAPPER
-    rc = TPM2_Reset_Test(NULL, argc, argv);
+    rc = TPM2_PCR_Reset_Test(NULL, argc, argv);
 #else
     printf("Wrapper code not compiled in\n");
     (void)argc;

--- a/examples/seal/seal_policy_auth.c
+++ b/examples/seal/seal_policy_auth.c
@@ -65,7 +65,7 @@ int TPM2_PCR_Seal_With_Policy_Auth_Test(void* userCtx, int argc, char *argv[])
     word32 pcrIndex = 16;
     byte policyDigest[TPM_MAX_DIGEST_SIZE];
     word32 policyDigestSz = (word32)sizeof(policyDigest);
-    byte policyDigestSig[RSA_SIG_SZ];
+    byte policyDigestSig[MAX_RSA_KEY_BYTES];
     word32 policyDigestSigSz = (word32)sizeof(policyDigestSig);
     byte badDigest[TPM_MAX_DIGEST_SIZE] = {0};
     byte badSig[TPM_MAX_DIGEST_SIZE] = {0};
@@ -244,9 +244,6 @@ int TPM2_PCR_Seal_With_Policy_Auth_Test(void* userCtx, int argc, char *argv[])
             TPM2_GetRCString(rc));
         goto exit;
     }
-    else {
-        rc = 0;
-    }
 
     /* unseal the secret */
     rc = wolfTPM2_UnsealWithAuthSig(&dev, &authKey,
@@ -278,9 +275,6 @@ int TPM2_PCR_Seal_With_Policy_Auth_Test(void* userCtx, int argc, char *argv[])
         printf("wolfTPM2_UnsealWithAuthorizedKey failed, should not have allowed bad signature 0x%x: %s\n", rc,
             TPM2_GetRCString(rc));
         goto exit;
-    }
-    else {
-        rc = 0;
     }
 
     /* sign the bad digest, this is done for testing */

--- a/examples/seal/seal_policy_auth.c
+++ b/examples/seal/seal_policy_auth.c
@@ -181,6 +181,11 @@ int TPM2_PCR_Seal_With_Policy_Auth_Test(void* userCtx, int argc, char *argv[])
                  TPM_ECC_NIST_P256, TPM_ALG_ECDSA);
     }
 
+    if (rc != TPM_RC_SUCCESS) {
+        printf("key template generation failed\n");
+        goto exit;
+    }
+
     /* generate the authorized key, this auth key can also generated and */
     /* loaded externally */
     rc = wolfTPM2_CreateKey(&dev, &authKey, &storage.handle,

--- a/examples/seal/seal_policy_auth.c
+++ b/examples/seal/seal_policy_auth.c
@@ -48,8 +48,6 @@ static void usage(void)
     printf("* -aes/xor: Use Parameter Encryption\n");
 }
 
-#define SIG_SZ 256
-
 int TPM2_PCR_Seal_With_Policy_Auth_Test(void* userCtx, int argc, char *argv[])
 {
     int i;
@@ -67,7 +65,7 @@ int TPM2_PCR_Seal_With_Policy_Auth_Test(void* userCtx, int argc, char *argv[])
     word32 pcrIndex = 16;
     byte policyDigest[TPM_MAX_DIGEST_SIZE];
     word32 policyDigestSz = (word32)sizeof(policyDigest);
-    byte policyDigestSig[SIG_SZ];
+    byte policyDigestSig[RSA_SIG_SZ];
     word32 policyDigestSigSz = (word32)sizeof(policyDigestSig);
     byte badDigest[TPM_MAX_DIGEST_SIZE] = {0};
     byte badSig[TPM_MAX_DIGEST_SIZE] = {0};

--- a/examples/seal/seal_policy_auth.c
+++ b/examples/seal/seal_policy_auth.c
@@ -59,22 +59,23 @@ int TPM2_PCR_Seal_With_Policy_Auth_Test(void* userCtx, int argc, char *argv[])
     WOLFTPM2_KEYBLOB sealBlob;
     TPMT_PUBLIC authTemplate;
     TPMT_PUBLIC sealTemplate;
-    TPM_ALG_ID paramEncAlg = TPM_ALG_NULL;
+    /* default to aes since parm encryption is required */
+    TPM_ALG_ID paramEncAlg = TPM_ALG_CFB;
     TPM_ALG_ID alg = TPM_ALG_RSA;
     word32 pcrIndex = 16;
     byte policyDigest[TPM_MAX_DIGEST_SIZE];
     word32 policyDigestSz = sizeof(policyDigest);
-    byte policyDigestSig[TPM_MAX_DIGEST_SIZE];
+    byte policyDigestSig[256];
     word32 policyDigestSigSz = sizeof(policyDigestSig);
-    byte badDigest[256] = {0};
-    byte badSig[256] = {0};
-    word32 badSigSz = 256;
+    byte badDigest[TPM_MAX_DIGEST_SIZE] = {0};
+    byte badSig[TPM_MAX_DIGEST_SIZE] = {0};
+    word32 badSigSz = TPM_MAX_DIGEST_SIZE;
     word32 pcrArray[256];
     word32 pcrArraySz = 0;
-    byte nonce[] = {15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
-    byte secret[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    const byte nonce[] = {15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+    const byte secret[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
     byte secretOut[16];
-    word32 secretOutSz = sizeof(secretOut);
+    word32 secretOutSz = (word32)sizeof(secretOut);
     Unseal_In unsealIn[1];
     Unseal_Out unsealOut[1];
 
@@ -260,7 +261,7 @@ int TPM2_PCR_Seal_With_Policy_Auth_Test(void* userCtx, int argc, char *argv[])
         goto exit;
     }
 
-    if (memcmp(secret, secretOut, sizeof(secret)) != 0) {
+    if (XMEMCMP(secret, secretOut, sizeof(secret)) != 0) {
         printf("Usealed secret does not match\n");
         goto exit;
     }

--- a/examples/seal/seal_policy_auth.c
+++ b/examples/seal/seal_policy_auth.c
@@ -43,10 +43,12 @@
 static void usage(void)
 {
     printf("Expected usage:\n");
-    printf("./examples/pcr/policy [-aes/xor] [-digest=HEXSTR] [pcr]\n");
+    printf("./examples/pcr/policy [-aes/xor] [pcr]\n");
     printf("* pcr: PCR index between 0-23 (default %d)\n", 16);
     printf("* -aes/xor: Use Parameter Encryption\n");
 }
+
+#define SIG_SZ 256
 
 int TPM2_PCR_Seal_With_Policy_Auth_Test(void* userCtx, int argc, char *argv[])
 {
@@ -64,12 +66,12 @@ int TPM2_PCR_Seal_With_Policy_Auth_Test(void* userCtx, int argc, char *argv[])
     TPM_ALG_ID alg = TPM_ALG_RSA;
     word32 pcrIndex = 16;
     byte policyDigest[TPM_MAX_DIGEST_SIZE];
-    word32 policyDigestSz = sizeof(policyDigest);
-    byte policyDigestSig[256];
-    word32 policyDigestSigSz = sizeof(policyDigestSig);
+    word32 policyDigestSz = (word32)sizeof(policyDigest);
+    byte policyDigestSig[SIG_SZ];
+    word32 policyDigestSigSz = (word32)sizeof(policyDigestSig);
     byte badDigest[TPM_MAX_DIGEST_SIZE] = {0};
     byte badSig[TPM_MAX_DIGEST_SIZE] = {0};
-    word32 badSigSz = TPM_MAX_DIGEST_SIZE;
+    word32 badSigSz = (word32)TPM_MAX_DIGEST_SIZE;
     word32 pcrArray[256];
     word32 pcrArraySz = 0;
     const byte nonce[] = {15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
@@ -128,7 +130,7 @@ int TPM2_PCR_Seal_With_Policy_Auth_Test(void* userCtx, int argc, char *argv[])
     }
 
     if (pcrArraySz == 0) {
-        pcrArray[pcrArraySz] = 16;
+        pcrArray[pcrArraySz] = pcrIndex;
         pcrArraySz++;
     }
 
@@ -244,8 +246,7 @@ int TPM2_PCR_Seal_With_Policy_Auth_Test(void* userCtx, int argc, char *argv[])
             TPM2_GetRCString(rc));
         goto exit;
     }
-    else
-    {
+    else {
         rc = 0;
     }
 
@@ -280,8 +281,7 @@ int TPM2_PCR_Seal_With_Policy_Auth_Test(void* userCtx, int argc, char *argv[])
             TPM2_GetRCString(rc));
         goto exit;
     }
-    else
-    {
+    else {
         rc = 0;
     }
 
@@ -305,8 +305,7 @@ int TPM2_PCR_Seal_With_Policy_Auth_Test(void* userCtx, int argc, char *argv[])
             TPM2_GetRCString(rc));
         goto exit;
     }
-    else
-    {
+    else {
         rc = 0;
     }
 

--- a/examples/tpm_test.h
+++ b/examples/tpm_test.h
@@ -103,7 +103,9 @@ static const char pemFileKey[] = "key.pem";
         extern double current_time(int reset);
         return current_time(reset);
     #elif defined(_WIN32)
-        return ((double)GetTickCount64())/1000.0;
+        unsigned long long ticks = GetTickCount64();
+        (void)reset;
+        return ((double)ticks)/1000.0;
     #else
         struct timeval tv;
         gettimeofday(&tv, 0);

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -79,7 +79,9 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
     WOLFTPM2_BUFFER plain;
     TPMT_PUBLIC publicTemplate;
     TPM2B_ECC_POINT pubPoint;
+#ifndef WOLFTPM_WINAPI
     word32 nvAttributes = 0;
+#endif
 #ifdef WOLFTPM_CRYPTOCB
     TpmCryptoDevCtx tpmCtx;
 #endif

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -187,8 +187,9 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
         /* Note: Copy between TPM2_AUTH_SESSION and TPMS_AUTH_COMMAND is allowed */
         XMEMCPY(&authCmd, session, sizeof(TPMS_AUTH_COMMAND));
 
-        /* Skip Policy session, because Enhanced Authorization is not yet implemented */
-        if (TPM2_IS_HMAC_SESSION(session->sessionHandle)) {
+        if (TPM2_IS_HMAC_SESSION(session->sessionHandle) ||
+            TPM2_IS_POLICY_SESSION(session->sessionHandle))
+        {
         #ifndef WOLFTPM2_NO_WOLFCRYPT
             TPM2B_NAME name1, name2, name3;
             TPM2B_DIGEST hash;

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -5549,12 +5549,12 @@ void TPM2_SetupPCRSel(TPML_PCR_SELECTION* pcr, TPM_ALG_ID alg, int pcrIndex)
 }
 
 void TPM2_SetupPCRSelArray(TPML_PCR_SELECTION* pcr, TPM_ALG_ID alg,
-    int* pcrArray, int pcrArrayLen)
+    word32* pcrArray, word32 pcrArraySz)
 {
     int i;
 
-    for (i = 0; i < pcrArrayLen; i++) {
-        TPM2_SetupPCRSel(pcr, alg, pcrArray[i]);
+    for (i = 0; i < (int)pcrArraySz; i++) {
+        TPM2_SetupPCRSel(pcr, alg, (int)pcrArray[i]);
     }
 }
 

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -122,7 +122,7 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
     int i, authPos;
     int tmpSz = 0; /* Used to calculate the new total size of the Auth Area */
 #ifndef WOLFTPM2_NO_WOLFCRYPT
-    UINT32 handleValue;
+    UINT32 handleValue1, handleValue2, handleValue3;
     int handlePos;
 #endif
 
@@ -167,7 +167,9 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
 #ifndef WOLFTPM2_NO_WOLFCRYPT
     handlePos = packet->pos;
     packet->pos = TPM2_HEADER_SIZE; /* Handles are right after header */
-    TPM2_Packet_ParseU32(packet, &handleValue);
+    TPM2_Packet_ParseU32(packet, &handleValue1);
+    TPM2_Packet_ParseU32(packet, &handleValue2);
+    TPM2_Packet_ParseU32(packet, &handleValue3);
     packet->pos = handlePos;
 #endif
 
@@ -217,9 +219,9 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
             }
 
         #ifndef WOLFTPM2_NO_WOLFCRYPT
-            rc =  TPM2_GetName(ctx, handleValue, info->inHandleCnt, 0, &name1);
-            rc |= TPM2_GetName(ctx, handleValue, info->inHandleCnt, 1, &name2);
-            rc |= TPM2_GetName(ctx, handleValue, info->inHandleCnt, 2, &name3);
+            rc =  TPM2_GetName(ctx, handleValue1, info->inHandleCnt, 0, &name1);
+            rc |= TPM2_GetName(ctx, handleValue2, info->inHandleCnt, 1, &name2);
+            rc |= TPM2_GetName(ctx, handleValue3, info->inHandleCnt, 2, &name3);
             if (rc != TPM_RC_SUCCESS) {
             #ifdef DEBUG_WOLFTPM
                 printf("Error getting names for cpHash!\n");

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -2704,7 +2704,7 @@ int wolfTPM2_SignHash(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 
 /* sigAlg: TPM_ALG_RSASSA, TPM_ALG_RSAPSS, TPM_ALG_ECDSA or TPM_ALG_ECDAA */
 /* hashAlg: TPM_ALG_SHA1, TPM_ALG_SHA256, TPM_ALG_SHA384 or TPM_ALG_SHA512 */
-int wolfTPM2_VerifyHashScheme_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
+int wolfTPM2_VerifyHashSchemeGetTicket(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const byte* sig, int sigSz, const byte* digest, int digestSz,
     TPMI_ALG_SIG_SCHEME sigAlg, TPMI_ALG_HASH hashAlg,
     TPMT_TK_VERIFIED* sigTicket)
@@ -2789,11 +2789,11 @@ int wolfTPM2_VerifyHashScheme(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const byte* sig, int sigSz, const byte* digest, int digestSz,
     TPMI_ALG_SIG_SCHEME sigAlg, TPMI_ALG_HASH hashAlg)
 {
-    return wolfTPM2_VerifyHashScheme_ex(dev, key, sig, sigSz, digest, digestSz,
-        sigAlg, hashAlg, NULL);
+    return wolfTPM2_VerifyHashSchemeGetTicket(dev, key, sig, sigSz, digest,
+        digestSz, sigAlg, hashAlg, NULL);
 }
 
-int wolfTPM2_VerifyHash_ex2(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
+int wolfTPM2_VerifyHashGetTicket(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const byte* sig, int sigSz, const byte* digest, int digestSz,
     int hashAlg, TPMT_TK_VERIFIED* sigTicket)
 {
@@ -2810,15 +2810,15 @@ int wolfTPM2_VerifyHash_ex2(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
         sigAlg = key->pub.publicArea.parameters.rsaDetail.scheme.scheme;
     }
 
-    return wolfTPM2_VerifyHashScheme_ex(dev, key, sig, sigSz, digest, digestSz,
-        sigAlg, hashAlg, sigTicket);
+    return wolfTPM2_VerifyHashSchemeGetTicket(dev, key, sig, sigSz, digest,
+        digestSz, sigAlg, hashAlg, sigTicket);
 }
 
 int wolfTPM2_VerifyHash_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const byte* sig, int sigSz, const byte* digest, int digestSz,
     int hashAlg)
 {
-    return wolfTPM2_VerifyHash_ex2(dev, key, sig, sigSz, digest, digestSz,
+    return wolfTPM2_VerifyHashGetTicket(dev, key, sig, sigSz, digest, digestSz,
         hashAlg, NULL);
 }
 
@@ -6266,7 +6266,7 @@ int wolfTPM2_SealWithAuthSig(WOLFTPM2_DEV* dev, WOLFTPM2_KEYBLOB* authKey,
                 sigAlg = TPM_ALG_RSASSA;
         }
 
-        rc = wolfTPM2_VerifyHashScheme_ex(dev, (WOLFTPM2_KEY*)authKey,
+        rc = wolfTPM2_VerifyHashSchemeGetTicket(dev, (WOLFTPM2_KEY*)authKey,
             policyDigestSig, policyDigestSigSz, checkDigest, checkDigestSz,
             sigAlg, WOLFTPM2_WRAP_DIGEST, &policyAuthIn->checkTicket);
     }
@@ -6373,7 +6373,7 @@ int wolfTPM2_SealWithAuthKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEYBLOB* authKey,
 
     /* verify the signature, get the auth ticket */
     if (rc == 0) {
-        rc = wolfTPM2_VerifyHashScheme_ex(dev, (WOLFTPM2_KEY*)authKey,
+        rc = wolfTPM2_VerifyHashSchemeGetTicket(dev, (WOLFTPM2_KEY*)authKey,
             policyDigestSig, *policyDigestSigSz, checkDigest, checkDigestSz,
             sigAlg, WOLFTPM2_WRAP_DIGEST, &policyAuthIn->checkTicket);
     }
@@ -6466,7 +6466,7 @@ int wolfTPM2_UnsealWithAuthSig(WOLFTPM2_DEV* dev, WOLFTPM2_KEYBLOB* authKey,
                 sigAlg = TPM_ALG_RSASSA;
         }
 
-        rc = wolfTPM2_VerifyHashScheme_ex(dev, (WOLFTPM2_KEY*)authKey,
+        rc = wolfTPM2_VerifyHashSchemeGetTicket(dev, (WOLFTPM2_KEY*)authKey,
             policyDigestSig, policyDigestSigSz, checkDigest, checkDigestSz,
             sigAlg, WOLFTPM2_WRAP_DIGEST, &policyAuthIn->checkTicket);
     }

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -512,7 +512,7 @@ int wolfTPM2_SelfTest(WOLFTPM2_DEV* dev)
     selfTest.fullTest = YES;
     rc = TPM2_SelfTest(&selfTest);
 #ifdef WOLFTPM_WINAPI
-    if (rc == TPM_E_COMMAND_BLOCKED) { /* 0x80280400 */
+    if (rc == (int)TPM_E_COMMAND_BLOCKED) { /* 0x80280400 */
     #ifdef DEBUG_WOLFTPM
         printf("TPM2_SelfTest not allowed on Windows TBS (err 0x%x)\n", rc);
     #endif
@@ -2510,7 +2510,7 @@ int wolfTPM2_NVStoreKey(WOLFTPM2_DEV* dev, TPM_HANDLE primaryHandle,
     rc = TPM2_EvictControl(&in);
     if (rc != TPM_RC_SUCCESS) {
     #ifdef WOLFTPM_WINAPI
-        if (rc == TPM_E_COMMAND_BLOCKED) { /* 0x80280400 */
+        if (rc == (int)TPM_E_COMMAND_BLOCKED) { /* 0x80280400 */
         #ifdef DEBUG_WOLFTPM
             printf("TPM2_EvictControl (storing key to NV) not allowed on "
                    "Windows TBS (err 0x%x)\n", rc);

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -6223,7 +6223,6 @@ int wolfTPM2_SealWithAuthSig(WOLFTPM2_DEV* dev, WOLFTPM2_KEYBLOB* authKey,
 
     /* verify the signature, get the auth ticket, save it to policyAuthIn */
     if (rc == 0) {
-
         if (authKey->pub.publicArea.type == TPM_ALG_ECC) {
             sigAlg = authKey->pub.publicArea.parameters.eccDetail.scheme.scheme;
 

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -3765,7 +3765,8 @@ int wolfTPM2_HashStart(WOLFTPM2_DEV* dev, WOLFTPM2_HASH* hash,
     HashSequenceStart_In in;
     HashSequenceStart_Out out;
 
-    if (dev == NULL || hash == NULL || hashAlg == TPM_ALG_NULL) {
+    if (dev == NULL || hash == NULL || hashAlg == TPM_ALG_NULL ||
+        (usageAuthSz > 0 && usageAuth == NULL)) {
         return BAD_FUNC_ARG;
     }
 
@@ -3774,7 +3775,8 @@ int wolfTPM2_HashStart(WOLFTPM2_DEV* dev, WOLFTPM2_HASH* hash,
         usageAuthSz = sizeof(hash->handle.auth.buffer);
     XMEMSET(hash, 0, sizeof(WOLFTPM2_HASH));
     hash->handle.auth.size = usageAuthSz;
-    XMEMCPY(hash->handle.auth.buffer, usageAuth, usageAuthSz);
+    if (usageAuth != NULL)
+        XMEMCPY(hash->handle.auth.buffer, usageAuth, usageAuthSz);
 
     XMEMSET(&in, 0, sizeof(in));
     wolfTPM2_CopyAuth(&in.auth, &hash->handle.auth);
@@ -6285,7 +6287,8 @@ int wolfTPM2_SealWithAuthSig(WOLFTPM2_DEV* dev, WOLFTPM2_KEYBLOB* authKey,
 
         /* set the nonce */
         policyAuthIn->policyRef.size = nonceSz;
-        XMEMCPY(policyAuthIn->policyRef.buffer, nonce, nonceSz);
+        if (nonce != NULL)
+            XMEMCPY(policyAuthIn->policyRef.buffer, nonce, nonceSz);
 
         rc = TPM2_PolicyAuthorize(policyAuthIn);
     }
@@ -6391,7 +6394,8 @@ int wolfTPM2_SealWithAuthKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEYBLOB* authKey,
 
         /* set the nonce */
         policyAuthIn->policyRef.size = nonceSz;
-        XMEMCPY(policyAuthIn->policyRef.buffer, nonce, nonceSz);
+        if (nonce != NULL)
+            XMEMCPY(policyAuthIn->policyRef.buffer, nonce, nonceSz);
 
         rc = TPM2_PolicyAuthorize(policyAuthIn);
     }
@@ -6488,7 +6492,8 @@ int wolfTPM2_UnsealWithAuthSig(WOLFTPM2_DEV* dev, WOLFTPM2_KEYBLOB* authKey,
 
         /* set the nonce */
         policyAuthIn->policyRef.size = nonceSz;
-        XMEMCPY(policyAuthIn->policyRef.buffer, nonce, nonceSz);
+        if (nonce != NULL)
+            XMEMCPY(policyAuthIn->policyRef.buffer, nonce, nonceSz);
 
         rc = TPM2_PolicyAuthorize(policyAuthIn);
     }

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1670,9 +1670,9 @@ struct wolfTPM_winContext {
 #define TPM_E_COMMAND_BLOCKED (0x80284000)
 #endif
 
-#define WOLFTPM_IS_COMMAND_UNAVAILABLE(code) ((code) == TPM_RC_COMMAND_CODE || (code) == TPM_E_COMMAND_BLOCKED)
+#define WOLFTPM_IS_COMMAND_UNAVAILABLE(code) ((code) == (int)TPM_RC_COMMAND_CODE || (code) == (int)TPM_E_COMMAND_BLOCKED)
 #else
-#define WOLFTPM_IS_COMMAND_UNAVAILABLE(code) (code == TPM_RC_COMMAND_CODE)
+#define WOLFTPM_IS_COMMAND_UNAVAILABLE(code) (code == (int)TPM_RC_COMMAND_CODE)
 #endif /* WOLFTPM_WINAPI */
 
 /* make sure advanced IO is enabled for I2C */

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -3323,7 +3323,6 @@ WOLFTPM_API void TPM2_SetupPCRSel(TPML_PCR_SELECTION* pcr, TPM_ALG_ID alg,
     \sa TPM2_PCR_Reset
     \sa TPM2_Quote
 */
-
 WOLFTPM_API void TPM2_SetupPCRSelArray(TPML_PCR_SELECTION* pcr, TPM_ALG_ID alg,
     word32* pcrArray, word32 pcrArrayLen);
 

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -3325,7 +3325,7 @@ WOLFTPM_API void TPM2_SetupPCRSel(TPML_PCR_SELECTION* pcr, TPM_ALG_ID alg,
 */
 
 WOLFTPM_API void TPM2_SetupPCRSelArray(TPML_PCR_SELECTION* pcr, TPM_ALG_ID alg,
-    int* pcrArray, int pcrArrayLen);
+    word32* pcrArray, word32 pcrArrayLen);
 
 /*!
     \ingroup TPM2_Proprietary

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -235,8 +235,6 @@ typedef int64_t  INT64;
 
 #endif
 
-#define RSA_SIG_SZ 256
-
 /* enable way for customer to override printf */
 #ifdef XPRINTF
     #undef  printf

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -219,7 +219,10 @@ typedef int64_t  INT64;
 
     #define XSTRTOL(s,e,b)    strtol((s),(e),(b))
     #define XATOI(s)          atoi((s))
+
 #endif
+
+#define RSA_SIG_SZ 256
 
 /* enable way for customer to override printf */
 #ifdef XPRINTF

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -216,7 +216,11 @@ typedef int64_t  INT64;
     #ifndef XHTONS
         /* WOLFCRYPT_ONLY means no wolfio and no arpa/inet.h */
         #ifdef WOLFCRYPT_ONLY
-            #define XHTONS(s) ((((s) & 0xff) << 8) | (((s) & 0xff00) >> 8))
+            #ifdef BIG_ENDIAN_ORDER
+                #define XHTONS(s) (s)
+            #else
+                #define XHTONS(s) ((((s) & 0xff) << 8) | (((s) & 0xff00) >> 8))
+            #endif
         #else
             #include <arpa/inet.h>
             #define XHTONS(s)         htons((s))

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -213,8 +213,14 @@ typedef int64_t  INT64;
 #ifndef WOLFTPM_CUSTOM_TYPES
     #include <stdlib.h>
 
-    #ifdef WOLFTPM2_NO_WOLFCRYPT
-        #define XHTONS(s)         htons((s))
+    #ifndef XHTONS
+        /* WOLFCRYPT_ONLY means no wolfio and no arpa/inet.h */
+        #ifdef WOLFCRYPT_ONLY
+            #define XHTONS(s) ((((s) & 0xff) << 8) | (((s) & 0xff00) >> 8))
+        #else
+            #include <arpa/inet.h>
+            #define XHTONS(s)         htons((s))
+        #endif
     #endif
 
     #define XSTRTOL(s,e,b)    strtol((s),(e),(b))

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -121,6 +121,7 @@ typedef int64_t  INT64;
     #include <stdio.h>
     #include <stdlib.h>
     #include <string.h>
+    #include <arpa/inet.h>
 
     typedef uint8_t  byte;
     typedef uint16_t word16;
@@ -133,6 +134,8 @@ typedef int64_t  INT64;
     #define NOT_COMPILED_IN       -174  /* Feature not compiled in */
     #define BAD_MUTEX_E           -106  /* Bad mutex operation */
     #define WC_TIMEOUT_E          -107  /* timeout error */
+    #define LENGTH_ONLY_E         -202
+    #define INPUT_SIZE_E          -412
 
     /* Errors from wolfssl/error-ssl.h */
     #define SOCKET_ERROR_E        -308  /* error state on socket    */
@@ -147,6 +150,7 @@ typedef int64_t  INT64;
     #define XMEMCMP(s1,s2,n)  memcmp((s1),(s2),(n))
     #define XSTRLEN(s1)       strlen((s1))
     #define XSTRCMP(s1,s2)    strcmp((s1),(s2))
+    #define XSTRNCMP(s1,s2,n) strncmp((s1),(s2),(n))
     #define XSTRSTR(s1,s2)    strstr((s1),(s2))
 #endif /* !WOLFTPM_CUSTOM_TYPES */
 
@@ -208,6 +212,11 @@ typedef int64_t  INT64;
 
 #ifndef WOLFTPM_CUSTOM_TYPES
     #include <stdlib.h>
+
+    #ifdef WOLFTPM2_NO_WOLFCRYPT
+        #define XHTONS(s)         htons((s))
+    #endif
+
     #define XSTRTOL(s,e,b)    strtol((s),(e),(b))
     #define XATOI(s)          atoi((s))
 #endif

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -115,6 +115,9 @@ typedef int64_t  INT64;
     #ifndef XFEOF
         #define XFEOF      feof
     #endif
+    #ifndef XREWIND
+        #define XREWIND    rewind
+    #endif
 
 #else
 

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -2923,6 +2923,8 @@ WOLFTPM_API int wolfTPM2_GetKeyBlobAsBuffer(byte *buffer, word32 bufferSz,
 WOLFTPM_API int wolfTPM2_SetKeyBlobFromBuffer(WOLFTPM2_KEYBLOB* key,
     byte *buffer, word32 bufferSz);
 
+WOLFTPM_API int wolfTPM2_PolicyRestart(TPM_HANDLE sessionHandle);
+
 /*!
     \ingroup wolfTPM2_Wrappers
 
@@ -3075,6 +3077,14 @@ WOLFTPM_API int wolfTPM2_UnsealWithAuthSig(WOLFTPM2_DEV* dev,
     const byte* policyDigestSig, word32 policyDigestSigSz, byte* out,
     word32* outSz);
 
+
+WOLFTPM_API int wolfTPM2_SealWithAuthSigNV(WOLFTPM2_DEV* dev,
+    WOLFTPM2_KEY* authKey, WOLFTPM2_SESSION* session,
+    TPM_ALG_ID policyHashAlg, TPM_ALG_ID pcrAlg, const byte* sealData,
+    word32 sealSz, const byte* nonce, word32 nonceSz,
+    const byte* policySignedSig, word32 policySignedSigSz, word32 sealNvIndex,
+    word32 policyDigestNvIndex);
+
 /*!
     \ingroup wolfTPM2_Wrappers
 
@@ -3101,7 +3111,7 @@ WOLFTPM_API int wolfTPM2_UnsealWithAuthSig(WOLFTPM2_DEV* dev,
     \sa wolfTPM2_SealWithAuthPolicyNV
 */
 WOLFTPM_API int wolfTPM2_SealWithAuthKeyNV(WOLFTPM2_DEV* dev,
-    WOLFTPM2_KEYBLOB* authKey, WOLFTPM2_SESSION* session,
+    WOLFTPM2_KEY* authKey, WOLFTPM2_SESSION* session,
     TPM_ALG_ID policyHashAlg, TPM_ALG_ID pcrAlg, word32* pcrArray,
     word32 pcrArraySz, const byte* sealData, word32 sealSz,
     const byte* nonce, word32 nonceSz, word32 sealNvIndex,
@@ -3133,7 +3143,7 @@ WOLFTPM_API int wolfTPM2_SealWithAuthKeyNV(WOLFTPM2_DEV* dev,
     \sa wolfTPM2_UnsealWithAuthSigNV
 */
 WOLFTPM_API int wolfTPM2_UnsealWithAuthSigNV(WOLFTPM2_DEV* dev,
-    WOLFTPM2_KEYBLOB* authKey, WOLFTPM2_SESSION* session, TPM_ALG_ID pcrAlg,
+    WOLFTPM2_KEY* authKey, WOLFTPM2_SESSION* session, TPM_ALG_ID pcrAlg,
     word32* pcrArray, word32 pcrArraySz, const byte* nonce, word32 nonceSz,
     const byte* policySignedSig, word32 policySignedSigSz, word32 sealNvIndex,
     word32 policyDigestNvIndex, byte* out, word32* outSz);

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -1288,6 +1288,9 @@ WOLFTPM_API int wolfTPM2_EccKey_WolfToPubPoint(WOLFTPM2_DEV* dev, ecc_key* wolfK
 WOLFTPM_API int wolfTPM2_SignHash(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const byte* digest, int digestSz, byte* sig, int* sigSz);
 
+WOLFTPM_API int wolfTPM2_SignHashScheme_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
+    const byte* digest, int digestSz, byte* sig, int* sigSz,
+    TPMI_ALG_SIG_SCHEME sigAlg, TPMI_ALG_HASH hashAlg, TPMT_SIGNATURE* sigOut);
 /*!
     \ingroup wolfTPM2_Wrappers
     \brief Advanced helper function to sign arbitrary data using a TPM key, and specify the signature scheme and hashing algorithm
@@ -3095,10 +3098,13 @@ WOLFTPM_API int wolfTPM2_UnsealWithAuthSig(WOLFTPM2_DEV* dev,
 
     \sa wolfTPM2_SealWithAuthPolicyNV
 */
-WOLFTPM_API int wolfTPM2_SealWithAuthPolicyNV(WOLFTPM2_DEV* dev,
-    TPM_HANDLE sessionHandle, TPM_ALG_ID policyHashAlg, TPM_ALG_ID pcrAlg,
-    word32* pcrArray, word32 pcrArraySz, const byte* sealData, word32 sealSz,
-    word32 sealNvIndex, word32 policyDigestNvIndex);
+WOLFTPM_API int wolfTPM2_SealWithAuthKeyNV(WOLFTPM2_DEV* dev,
+    WOLFTPM2_KEYBLOB* authKey, TPM_HANDLE sessionHandle,
+    TPM_ALG_ID policyHashAlg, TPM_ALG_ID pcrAlg, word32* pcrArray,
+    word32 pcrArraySz, const byte* sealData, word32 sealSz,
+    const byte* nonce, word32 nonceSz, word32 sealNvIndex,
+    word32 policyDigestNvIndex, byte* policySignedSig,
+    word32* policySignedSigSz);
 
 /*!
     \ingroup wolfTPM2_Wrappers
@@ -3106,7 +3112,7 @@ WOLFTPM_API int wolfTPM2_SealWithAuthPolicyNV(WOLFTPM2_DEV* dev,
     \brief Seal a secret to the TPM's NVM after calling PolicyPCR and authorizing the current
     policyDigest to later unseal the secret from NVM
 
-    wolfTPM2_UnsealWithAuthPolicyNV
+    wolfTPM2_UnsealWithAuthSigNV
 
     \return TPM_RC_SUCCESS: successful
     \return BAD_FUNC_ARG: check the provided arguments
@@ -3121,12 +3127,13 @@ WOLFTPM_API int wolfTPM2_SealWithAuthPolicyNV(WOLFTPM2_DEV* dev,
     \param out output buffer to read the unsealed secret
     \param outSz pointer to the size of the output buffer
 
-    \sa wolfTPM2_UnsealWithAuthPolicyNV
+    \sa wolfTPM2_UnsealWithAuthSigNV
 */
-WOLFTPM_API int wolfTPM2_UnsealWithAuthPolicyNV(WOLFTPM2_DEV* dev,
-    TPM_HANDLE sessionHandle, TPM_ALG_ID pcrAlg, word32* pcrArray,
-    word32 pcrArraySz, word32 sealNvIndex, word32 policyDigestNvIndex,
-    byte* out, word32* outSz);
+WOLFTPM_API int wolfTPM2_UnsealWithAuthSigNV(WOLFTPM2_DEV* dev,
+    WOLFTPM2_KEYBLOB* authKey, TPM_HANDLE sessionHandle, TPM_ALG_ID pcrAlg,
+    word32* pcrArray, word32 pcrArraySz, const byte* nonce, word32 nonceSz,
+    const byte* policySignedSig, word32 policySignedSigSz, word32 sealNvIndex,
+    word32 policyDigestNvIndex, byte* out, word32* outSz);
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -47,6 +47,7 @@ typedef struct WOLFTPM2_SESSION {
     TPM2B_NONCE     nonceCaller;  /* Fresh nonce at each command */
     TPM2B_DIGEST    salt;         /* User defined */
     TPMI_ALG_HASH   authHash;
+    TPMA_SESSION    sessionAttributes;
 } WOLFTPM2_SESSION;
 
 typedef struct WOLFTPM2_DEV {
@@ -446,7 +447,7 @@ WOLFTPM_API int wolfTPM2_SetAuthHandle(WOLFTPM2_DEV* dev, int index, const WOLFT
     \sa wolfTPM2_SetAuthHandle
 */
 WOLFTPM_API int wolfTPM2_SetAuthSession(WOLFTPM2_DEV* dev, int index,
-    const WOLFTPM2_SESSION* tpmSession, TPMA_SESSION sessionAttributes);
+    WOLFTPM2_SESSION* tpmSession, TPMA_SESSION sessionAttributes);
 
 /*!
     \ingroup wolfTPM2_Wrappers
@@ -3086,7 +3087,8 @@ WOLFTPM_API int wolfTPM2_UnsealWithAuthSig(WOLFTPM2_DEV* dev,
     \return BAD_FUNC_ARG: check the provided arguments
 
     \param dev pointer to a populated structure of WOLFTPM2_DEV type
-    \param sessionHandle the handle of the current session, a session is required to use policy pcr
+    \param authKey authentication key
+    \param session the pointer to current session, a session is required to use policy pcr
     \param policyHashAlg the hashing algorithm used to generate the policyDigest
     \param pcrAlg the hashing algorithm to use for pcr values
     \param pcrArray array of PCR indices to use with this policy
@@ -3099,7 +3101,7 @@ WOLFTPM_API int wolfTPM2_UnsealWithAuthSig(WOLFTPM2_DEV* dev,
     \sa wolfTPM2_SealWithAuthPolicyNV
 */
 WOLFTPM_API int wolfTPM2_SealWithAuthKeyNV(WOLFTPM2_DEV* dev,
-    WOLFTPM2_KEYBLOB* authKey, TPM_HANDLE sessionHandle,
+    WOLFTPM2_KEYBLOB* authKey, WOLFTPM2_SESSION* session,
     TPM_ALG_ID policyHashAlg, TPM_ALG_ID pcrAlg, word32* pcrArray,
     word32 pcrArraySz, const byte* sealData, word32 sealSz,
     const byte* nonce, word32 nonceSz, word32 sealNvIndex,
@@ -3118,7 +3120,8 @@ WOLFTPM_API int wolfTPM2_SealWithAuthKeyNV(WOLFTPM2_DEV* dev,
     \return BAD_FUNC_ARG: check the provided arguments
 
     \param dev pointer to a populated structure of WOLFTPM2_DEV type
-    \param sessionHandle the handle of the current session, a session is required to use policy pcr
+    \param authKey authentication key
+    \param session the pointer to current session, a session is required to use policy pcr
     \param pcrAlg the hashing algorithm to use for pcr values
     \param pcrArray array of PCR indices to use with this policy
     \param pcrArraySz length of pcrArray
@@ -3130,7 +3133,7 @@ WOLFTPM_API int wolfTPM2_SealWithAuthKeyNV(WOLFTPM2_DEV* dev,
     \sa wolfTPM2_UnsealWithAuthSigNV
 */
 WOLFTPM_API int wolfTPM2_UnsealWithAuthSigNV(WOLFTPM2_DEV* dev,
-    WOLFTPM2_KEYBLOB* authKey, TPM_HANDLE sessionHandle, TPM_ALG_ID pcrAlg,
+    WOLFTPM2_KEYBLOB* authKey, WOLFTPM2_SESSION* session, TPM_ALG_ID pcrAlg,
     word32* pcrArray, word32 pcrArraySz, const byte* nonce, word32 nonceSz,
     const byte* policySignedSig, word32 policySignedSigSz, word32 sealNvIndex,
     word32 policyDigestNvIndex, byte* out, word32* outSz);

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -989,7 +989,7 @@ WOLFTPM_API int wolfTPM2_CreateKeySeal(WOLFTPM2_DEV* dev,
     \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)
     \return BAD_FUNC_ARG: check the provided arguments
 
-    \param dev pointer to a TPM2_DEV struct
+    \param dev pointer to a WOLFTPM2_DEV struct
     \param keyBlob pointer to an empty struct of WOLFTPM2_KEYBLOB type
     \param parent pointer to a struct of WOLFTPM2_HANDLE type, specifying the a 2.0 Primary Key to be used as the parent(Storage Key)
     \param publicTemplate pointer to a TPMT_PUBLIC structure populated using one of the wolfTPM2_GetKeyTemplate_KeySeal
@@ -1005,7 +1005,6 @@ WOLFTPM_API int wolfTPM2_CreateKeySeal(WOLFTPM2_DEV* dev,
     \sa TPM2_Unseal
     \sa wolfTPM2_CreatePrimary
 */
-
 WOLFTPM_API int wolfTPM2_CreateKeySeal_ex(WOLFTPM2_DEV* dev,
     WOLFTPM2_KEYBLOB* keyBlob, WOLFTPM2_HANDLE* parent,
     TPMT_PUBLIC* publicTemplate, const byte* auth, int authSz,
@@ -1292,6 +1291,7 @@ WOLFTPM_API int wolfTPM2_SignHash(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 WOLFTPM_API int wolfTPM2_SignHashScheme_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const byte* digest, int digestSz, byte* sig, int* sigSz,
     TPMI_ALG_SIG_SCHEME sigAlg, TPMI_ALG_HASH hashAlg, TPMT_SIGNATURE* sigOut);
+
 /*!
     \ingroup wolfTPM2_Wrappers
     \brief Advanced helper function to sign arbitrary data using a TPM key, and specify the signature scheme and hashing algorithm
@@ -1343,9 +1343,9 @@ WOLFTPM_API int wolfTPM2_VerifyHash_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const byte* sig, int sigSz, const byte* digest, int digestSz,
     int hashAlg);
 
-WOLFTPM_API int wolfTPM2_VerifyHash_ex2(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
-    const byte* sig, int sigSz, const byte* digest, int digestSz,
-    int hashAlg, TPMT_TK_VERIFIED* sigTicket);
+WOLFTPM_API int wolfTPM2_VerifyHashGetTicket(WOLFTPM2_DEV* dev,
+    WOLFTPM2_KEY* key, const byte* sig, int sigSz, const byte* digest,
+    int digestSz, int hashAlg, TPMT_TK_VERIFIED* sigTicket);
 
 /*!
     \ingroup wolfTPM2_Wrappers
@@ -1373,9 +1373,9 @@ WOLFTPM_API int wolfTPM2_VerifyHashScheme(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const byte* sig, int sigSz, const byte* digest, int digestSz,
     TPMI_ALG_SIG_SCHEME sigAlg, TPMI_ALG_HASH hashAlg);
 
-WOLFTPM_API int wolfTPM2_VerifyHashScheme_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
-    const byte* sig, int sigSz, const byte* digest, int digestSz,
-    TPMI_ALG_SIG_SCHEME sigAlg, TPMI_ALG_HASH hashAlg,
+WOLFTPM_API int wolfTPM2_VerifyHashSchemeGetTicket(WOLFTPM2_DEV* dev,
+    WOLFTPM2_KEY* key, const byte* sig, int sigSz, const byte* digest,
+    int digestSz, TPMI_ALG_SIG_SCHEME sigAlg, TPMI_ALG_HASH hashAlg,
     TPMT_TK_VERIFIED* sigTicket);
 
 /*!
@@ -2988,7 +2988,7 @@ WOLFTPM_API int wolfTPM2_PolicyPCR(TPM_HANDLE sessionHandle, TPM_ALG_ID pcrAlg,
     \param pcrArrayLen the number of indicies in the pcrArray
     \param sealData the data to seal into the tpm
     \param sealSz the size of the seal data
-    \param policyDigest input digest of the policy, used to retreive the secret later
+    \param policyDigest input digest of the policy, used to retrieve the secret later
     \param policyDigestSz size of the policyDigest to be updated by this function
     \param nonce a one time number to include in our policy
     \param nonceSz size of nonce
@@ -3028,7 +3028,7 @@ WOLFTPM_API int wolfTPM2_SealWithAuthSig(WOLFTPM2_DEV* dev,
     \param sealSz the size of the seal data
     \param nonce a one time number to include in our policy
     \param nonceSz size of nonce
-    \param policyDigest output digest of the policy, used to retreive the secret later
+    \param policyDigest output digest of the policy, used to retrieve the secret later
     \param policyDigestSz pointer to the size of the policyDigest to be updated by this function
 
     \sa wolfTPM2_SealWithAuthKey

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -3043,8 +3043,9 @@ WOLFTPM_API int wolfTPM2_SealWithAuthKey(WOLFTPM2_DEV* dev,
 /*!
     \ingroup wolfTPM2_Wrappers
 
-    \brief Unseal a secret from the TPM after verifying the digest signature was signed by the auth private key
-    and checking the policy using policy authorize and and policy pcr
+    \brief Unseal a secret from the TPM after verifying the digest signature
+    was signed by the auth private key and checking the policy using policy
+    authorize and and policy pcr
 
     wolfTPM2_UnsealWithAuthSig
 
@@ -3077,7 +3078,36 @@ WOLFTPM_API int wolfTPM2_UnsealWithAuthSig(WOLFTPM2_DEV* dev,
     const byte* policyDigestSig, word32 policyDigestSigSz, byte* out,
     word32* outSz);
 
+/*!
+    \ingroup wolfTPM2_Wrappers
 
+    \brief Seal a secret to the TPM NVM after verifying the PolicySigned
+    signature was signed by the auth private key along with the policyDigest
+    of the session. Other policy functions such as PolicyPCR should be called
+    before calling this function
+
+    wolfTPM2_SealWithAuthSigNV
+
+    \return TPM_RC_SUCCESS: successful
+    \return INPUT_SIZE_E: policyDigestSz is too small to hold the returned digest
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a populated structure of WOLFTPM2_DEV type
+    \param authKey pointer to a public key used to verify the policy digest signature
+    \param session the current session, a session is required to use policy pcr
+    \param policyHashAlg the hashing algorithm used to calculate policyDigest
+    \param pcrAlg the hashing algorithm to use for pcr values
+    \param sealData the data to seal into the tpm
+    \param sealSz the size of the seal data
+    \param nonce a one time number to include in our policy
+    \param nonceSz size of nonce
+    \param policySignedSig a signature of aHash as defined in the tpm2 documentation for PolicySigned
+    \param policySignedSigSz size of policySignedSig
+    \param sealNvIndex the NV index of the TPM to seal the secret to
+    \param policyDigestNvIndex the NV index of the TPM to seal the policyDigest to
+
+    \sa wolfTPM2_SealWithAuthSigNV
+*/
 WOLFTPM_API int wolfTPM2_SealWithAuthSigNV(WOLFTPM2_DEV* dev,
     WOLFTPM2_KEY* authKey, WOLFTPM2_SESSION* session,
     TPM_ALG_ID policyHashAlg, TPM_ALG_ID pcrAlg, const byte* sealData,
@@ -3105,8 +3135,12 @@ WOLFTPM_API int wolfTPM2_SealWithAuthSigNV(WOLFTPM2_DEV* dev,
     \param pcrArraySz length of pcrArray
     \param sealData the secret to save to NVM
     \param sealSz size of the secret buffer
+    \param nonce a one time number to include in our policy
+    \param nonceSz size of nonce
     \param sealNvIndex nvIndex to write the secret to
     \param policyDigestNvIndex nvIndex to write the policyDigest to
+    \param policySignedSig output signature of aHash as defined in the tpm2 documentation for PolicySigned
+    \param policySignedSigSz size of policySignedSig
 
     \sa wolfTPM2_SealWithAuthPolicyNV
 */
@@ -3121,8 +3155,9 @@ WOLFTPM_API int wolfTPM2_SealWithAuthKeyNV(WOLFTPM2_DEV* dev,
 /*!
     \ingroup wolfTPM2_Wrappers
 
-    \brief Seal a secret to the TPM's NVM after calling PolicyPCR and authorizing the current
-    policyDigest to later unseal the secret from NVM
+    \brief Unseal a secret from the TPM's NVM after calling PolicyPCR and
+    authorizing the current policyDigest with PolicyAuthorizeNV and checking
+    the policySignedSig with PolicySigned
 
     wolfTPM2_UnsealWithAuthSigNV
 
@@ -3135,6 +3170,10 @@ WOLFTPM_API int wolfTPM2_SealWithAuthKeyNV(WOLFTPM2_DEV* dev,
     \param pcrAlg the hashing algorithm to use for pcr values
     \param pcrArray array of PCR indices to use with this policy
     \param pcrArraySz length of pcrArray
+    \param nonce a one time number to include in our policy
+    \param nonceSz size of nonce
+    \param policySignedSig a signature of aHash as defined in the tpm2 documentation for PolicySigned
+    \param policySignedSigSz size of policySignedSig
     \param sealNvIndex nvIndex to read the secret from
     \param policyDigestNvIndex nvIndex to read the policyDigest from
     \param out output buffer to read the unsealed secret


### PR DESCRIPTION
TPM2 has a special way of controlling access to resources within the TPM called policy authorization. A policy can be created by running any number of policy commands. The policy doesn't have any struct or metadata on what commands were run, instead each policy command updates an internal digest called `policyDigest`, which is stored within the tpm session being used. If resources are created withing the tpm after setting up a policy, they can only be retrieved by re-running the same policy commands to re-create the `policyDigest`.

This commit adds wrapper functions to create a policy using PolicyPCR and PolicyAuthorize and then seal and unseal a secret to the TPM, for both NVM and ram storage, with the resulting `policyDigest`. In effect these functions will gate access to the sealed secret on:
1. The PCR values selected, which is the state of the TPM and the board it manages
2. The presence of a signed `policyDigest` in case the PCR values have changed but have been re-signed by an authoritative key
In the case of NVM storage an authoritative key is not used, only the PCR values are but the policy can still be updated by overwriting the NVM index that holds the `policyDigest` when the PCR's change

The topic of policies is esoteric so examples have been provided to show how these functions are used in `examples/seal/seal_policy_auth` and `examples/nvram/seal_policy_auth_nv.c`.