### PR TITLE
fix broken evict control example

### DIFF
--- a/examples/keygen/create_primary.c
+++ b/examples/keygen/create_primary.c
@@ -117,7 +117,7 @@ int TPM2_CreatePrimaryKey_Example(void* userCtx, int argc, char *argv[])
         else if (XSTRCMP(argv[argc-1], "-auth=") == 0) {
             authStr = argv[argc-1] + 6;
         }
-        else if (XSTRCMP(argv[argc-1], "-store=") == 0) {
+        else if (XSTRNCMP(argv[argc-1], "-store=", XSTRLEN("-store=")) == 0) {
             persistHandle = (word32)XSTRTOL(argv[argc-1] + XSTRLEN("-store="),
                 NULL, 0);
             if (persistHandle < 0x81000000 && persistHandle > 0x810FFFF) {
@@ -181,7 +181,7 @@ int TPM2_CreatePrimaryKey_Example(void* userCtx, int argc, char *argv[])
             (word32)tpmSession.handle.hndl);
 
         /* set session for authorization of the primary key */
-        rc = wolfTPM2_SetAuthSession(&dev, 1, &tpmSession,
+        rc = wolfTPM2_SetAuthSession(&dev, 0, &tpmSession,
             (TPMA_SESSION_decrypt | TPMA_SESSION_encrypt | TPMA_SESSION_continueSession));
         if (rc != TPM_RC_SUCCESS) goto exit;
     }

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -122,7 +122,7 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
     int i, authPos;
     int tmpSz = 0; /* Used to calculate the new total size of the Auth Area */
 #ifndef WOLFTPM2_NO_WOLFCRYPT
-    UINT32 handleValue;
+    UINT32 handleValue1, handleValue2, handleValue3;
     int handlePos;
 #endif
 
@@ -167,7 +167,9 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
 #ifndef WOLFTPM2_NO_WOLFCRYPT
     handlePos = packet->pos;
     packet->pos = TPM2_HEADER_SIZE; /* Handles are right after header */
-    TPM2_Packet_ParseU32(packet, &handleValue);
+    TPM2_Packet_ParseU32(packet, &handleValue1);
+    TPM2_Packet_ParseU32(packet, &handleValue2);
+    TPM2_Packet_ParseU32(packet, &handleValue3);
     packet->pos = handlePos;
 #endif
 
@@ -216,9 +218,9 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
             }
 
         #ifndef WOLFTPM2_NO_WOLFCRYPT
-            rc =  TPM2_GetName(ctx, handleValue, info->inHandleCnt, 0, &name1);
-            rc |= TPM2_GetName(ctx, handleValue, info->inHandleCnt, 1, &name2);
-            rc |= TPM2_GetName(ctx, handleValue, info->inHandleCnt, 2, &name3);
+            rc =  TPM2_GetName(ctx, handleValue1, info->inHandleCnt, 0, &name1);
+            rc |= TPM2_GetName(ctx, handleValue2, info->inHandleCnt, 1, &name2);
+            rc |= TPM2_GetName(ctx, handleValue3, info->inHandleCnt, 2, &name3);
             if (rc != TPM_RC_SUCCESS) {
             #ifdef DEBUG_WOLFTPM
                 printf("Error getting names for cpHash!\n");

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -762,7 +762,7 @@ int wolfTPM2_SetAuthHandleName(WOLFTPM2_DEV* dev, int index,
 }
 
 int wolfTPM2_SetAuthSession(WOLFTPM2_DEV* dev, int index,
-    const WOLFTPM2_SESSION* tpmSession, TPMA_SESSION sessionAttributes)
+    WOLFTPM2_SESSION* tpmSession, TPMA_SESSION sessionAttributes)
 {
     int rc;
 
@@ -780,6 +780,9 @@ int wolfTPM2_SetAuthSession(WOLFTPM2_DEV* dev, int index,
         &tpmSession->handle.auth, sessionAttributes, NULL);
     if (rc == TPM_RC_SUCCESS) {
         TPM2_AUTH_SESSION* session = &dev->session[index];
+
+        /* save off session attributes */
+        tpmSession->sessionAttributes = sessionAttributes;
 
         /* define the symmetric algorithm */
         session->authHash = tpmSession->authHash;

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -116,6 +116,10 @@ typedef int64_t  INT64;
         #define XFEOF      feof
     #endif
 
+    #ifndef XREWIND
+        #define XREWIND    rewind
+    #endif
+
 #else
 
     #include <stdio.h>

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -47,6 +47,7 @@ typedef struct WOLFTPM2_SESSION {
     TPM2B_NONCE     nonceCaller;  /* Fresh nonce at each command */
     TPM2B_DIGEST    salt;         /* User defined */
     TPMI_ALG_HASH   authHash;
+    TPMA_SESSION    sessionAttributes;
 } WOLFTPM2_SESSION;
 
 typedef struct WOLFTPM2_DEV {
@@ -446,7 +447,7 @@ WOLFTPM_API int wolfTPM2_SetAuthHandle(WOLFTPM2_DEV* dev, int index, const WOLFT
     \sa wolfTPM2_SetAuthHandle
 */
 WOLFTPM_API int wolfTPM2_SetAuthSession(WOLFTPM2_DEV* dev, int index,
-    const WOLFTPM2_SESSION* tpmSession, TPMA_SESSION sessionAttributes);
+    WOLFTPM2_SESSION* tpmSession, TPMA_SESSION sessionAttributes);
 
 /*!
     \ingroup wolfTPM2_Wrappers


### PR DESCRIPTION
for forum post https://www.wolfssl.com/forums/topic2001-storing-key-in-nv-with-authentication-fails-createprimary-example.html

evict control had an issue where the default noauth session was being used alongisde the encrypted section. to fix this wolfTPM2_SetAuthSession needs to be called with index 0 to override the default session, it's possible we've made this mistake in many places