### PR TITLE
Corrected Linux usage of cs_change, added config overrides.

### DIFF
--- a/hal/README.md
+++ b/hal/README.md
@@ -63,7 +63,9 @@ int TPM2_IoCb(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
 ## Additional Compiler macros
 
 * `TPM2_SPI_DEV_PATH`: Set to the device string to be opened by the Linux IOCb.  Default: "/dev/spidev0."
-* `TPM2_SPI_DEV_CS`: Set to the number string of the CS to use or the lowest CS to try during autodetect. Default: "0"
+* `TPM2_SPI_DEV_CS`: Set to the number string of the CS to use. Default: "0"
 
 These can be set during configure as:
 ./configure CPPFLAGS="-DTPM2_SPI_DEV_PATH=\"/dev/spidev0.\" -DTPM2_SPI_DEV_CS=\"0\" " 
+
+Note that autodetect will use TPM2_SPI_DEV_PATH[0..4] for the searched device paths.

--- a/hal/README.md
+++ b/hal/README.md
@@ -59,3 +59,11 @@ int TPM2_IoCb(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
 * `WOLFTPM_CHECK_WAIT_STATE`: Enables check of the wait state during a SPI transaction. Most TPM 2.0 chips require this and typically only require 0-2 wait cycles depending on the command. Only the Infineon TPM's guarantee no wait states.
 * `WOLFTPM_ADV_IO`: Enables advanced IO callback mode that includes TIS register and read/write flag. This is requires for I2C, but can be used with SPI also.
 * `WOLFTPM_DEBUG_IO`: Enable logging of the IO (if using the example HAL).
+
+## Additional Compiler macros
+
+* `TPM2_SPI_DEV_PATH`: Set to the device string to be opened by the Linux IOCb.  Default: "/dev/spidev0."
+* `TPM2_SPI_DEV_CS`: Set to the number string of the CS to use or the lowest CS to try during autodetect. Default: "0"
+
+These can be set during configure as:
+./configure CPPFLAGS="-DTPM2_SPI_DEV_PATH=\"/dev/spidev0.\" -DTPM2_SPI_DEV_CS=\"0\" " 

--- a/hal/tpm_io_linux.c
+++ b/hal/tpm_io_linux.c
@@ -80,7 +80,7 @@
                 #define TPM2_SPI_DEV_CS "0"
             #else
                 /* OPTIGA SLB9670/SLB9762 and LetsTrust TPM use CE1 */
-                #define TPM2_SPI_DEV_CS "0"
+                #define TPM2_SPI_DEV_CS "1"
             #endif
         #endif
 
@@ -91,7 +91,7 @@
         #ifdef WOLFTPM_AUTODETECT
             #undef TPM2_SPI_DEV
             /* this will try incrementing spidev chip selects */
-            static char TPM2_SPI_DEV[] = TPM2_SPI_DEV_PATH TPM2_SPI_DEV_CS;
+            static char TPM2_SPI_DEV[] = TPM2_SPI_DEV_PATH "0";
             #define MAX_SPI_DEV_CS '4'
             static int foundSpiDev = 0;
         #else

--- a/hal/tpm_io_linux.c
+++ b/hal/tpm_io_linux.c
@@ -68,28 +68,34 @@
         #define TPM2_I2C_HZ   400000 /* 400kHz */
     #else
         /* SPI */
-        #ifdef WOLFTPM_MICROCHIP
-            /* Microchip ATTPM20 uses CE0 */
-            #define TPM2_SPI_DEV_CS "0"
-        #elif defined(WOLFTPM_ST33)
-            /* STM ST33HTPH SPI uses CE0 */
-            #define TPM2_SPI_DEV_CS "0"
-        #elif defined(WOLFTPM_NUVOTON)
-            /* Nuvoton NPCT75x uses CE0 */
-            #define TPM2_SPI_DEV_CS "0"
-        #else
-            /* OPTIGA SLB9670/SLB9762 and LetsTrust TPM use CE1 */
-            #define TPM2_SPI_DEV_CS "1"
+        #ifndef TPM2_SPI_DEV_CS
+            #ifdef WOLFTPM_MICROCHIP
+                /* Microchip ATTPM20 uses CE0 */
+                #define TPM2_SPI_DEV_CS "0"
+            #elif defined(WOLFTPM_ST33)
+                /* STM ST33HTPH SPI uses CE0 */
+                #define TPM2_SPI_DEV_CS "0"
+            #elif defined(WOLFTPM_NUVOTON)
+                /* Nuvoton NPCT75x uses CE0 */
+                #define TPM2_SPI_DEV_CS "0"
+            #else
+                /* OPTIGA SLB9670/SLB9762 and LetsTrust TPM use CE1 */
+                #define TPM2_SPI_DEV_CS "0"
+            #endif
+        #endif
+
+        #ifndef TPM2_SPI_DEV_PATH
+            #define TPM2_SPI_DEV_PATH "/dev/spidev0."
         #endif
 
         #ifdef WOLFTPM_AUTODETECT
             #undef TPM2_SPI_DEV
             /* this will try incrementing spidev chip selects */
-            static char TPM2_SPI_DEV[] = "/dev/spidev0.0";
+            static char TPM2_SPI_DEV[] = TPM2_SPI_DEV_PATH TPM2_SPI_DEV_CS;
             #define MAX_SPI_DEV_CS '4'
             static int foundSpiDev = 0;
         #else
-            #define TPM2_SPI_DEV "/dev/spidev0."TPM2_SPI_DEV_CS
+            #define TPM2_SPI_DEV TPM2_SPI_DEV_PATH TPM2_SPI_DEV_CS
         #endif
     #endif
 #endif
@@ -193,10 +199,13 @@
     int TPM2_IoCb_Linux_SPI(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
         word16 xferSz, void* userCtx)
     {
-        int ret = TPM_RC_FAILURE;
+        int ret;
         int spiDev;
     #ifdef WOLFTPM_CHECK_WAIT_STATE
         int timeout;
+    #endif
+    #ifdef WOLFTPM_AUTODETECT
+        int devLen;
     #endif
 
         /* Note: PI has issue with 5-10Mhz on packets sized over 130 bytes */
@@ -212,10 +221,11 @@
         }
         #endif
     #endif
+
+        ret = TPM_RC_SUCCESS;
     #ifdef WOLFTPM_CHECK_WAIT_STATE
         timeout = TPM_SPI_WAIT_RETRY;
     #endif
-
         spiDev = open(TPM2_SPI_DEV, O_RDWR);
         if (spiDev >= 0) {
             struct spi_ioc_transfer spi;
@@ -226,48 +236,59 @@
             ioctl(spiDev, SPI_IOC_WR_BITS_PER_WORD, &bits_per_word);
 
             XMEMSET(&spi, 0, sizeof(spi));
-            spi.cs_change = 1; /* strobe CS between transfers */
 
     #ifdef WOLFTPM_CHECK_WAIT_STATE
+            /* Keep CS asserted for header and flow control transfers */
+            spi.cs_change = 1;
+
             /* Send Header */
             spi.tx_buf   = (unsigned long)txBuf;
             spi.rx_buf   = (unsigned long)rxBuf;
             spi.len      = TPM_TIS_HEADER_SZ;
             size = ioctl(spiDev, SPI_IOC_MESSAGE(1), &spi);
             if (size != TPM_TIS_HEADER_SZ) {
-                close(spiDev);
-                return TPM_RC_FAILURE;
+                ret =  TPM_RC_FAILURE;
             }
 
             /* Handle SPI wait states (ST33 typical wait is 2 bytes) */
-            if ((rxBuf[TPM_TIS_HEADER_SZ-1] & TPM_TIS_READY_MASK) == 0) {
+            if ((ret == TPM_RC_SUCCESS) &&
+                ((rxBuf[TPM_TIS_HEADER_SZ-1] & TPM_TIS_READY_MASK) == 0)) {
+                /* Place flow control byte in last header response byte*/
+                spi.rx_buf = (unsigned long)&rxBuf[TPM_TIS_HEADER_SZ-1];
+                spi.len = 1;
                 do {
                     /* Check for SPI ready */
-                    spi.len = 1;
                     size = ioctl(spiDev, SPI_IOC_MESSAGE(1), &spi);
-                    if (rxBuf[0] & TPM_TIS_READY_MASK)
-                        break;
-                } while (size == 1 && --timeout > 0);
+                } while (
+                    (size == 1) &&
+                    ((rxBuf[TPM_TIS_HEADER_SZ-1] & TPM_TIS_READY_MASK)==0) &&
+                    (--timeout > 0));
             #ifdef WOLFTPM_DEBUG_TIMEOUT
                 printf("SPI Ready Timeout %d\n", TPM_SPI_WAIT_RETRY - timeout);
             #endif
-                if (size == 1 && timeout > 0) {
-                    ret = TPM_RC_SUCCESS;
-                }
-            }
-            else {
-                ret = TPM_RC_SUCCESS;
+                if (size != 1 )
+                    ret = TPM_RC_FAILURE;
+                else if (timeout <= 0)
+                    ret = TPM_RC_FAILURE;  /* Timeout */
             }
 
+            /* Remainder of message */
             if (ret == TPM_RC_SUCCESS) {
-                /* Remainder of message */
+                spi.cs_change = 0;    /* Deassert cs after transfer */
                 spi.tx_buf   = (unsigned long)&txBuf[TPM_TIS_HEADER_SZ];
                 spi.rx_buf   = (unsigned long)&rxBuf[TPM_TIS_HEADER_SZ];
                 spi.len      = xferSz - TPM_TIS_HEADER_SZ;
                 size = ioctl(spiDev, SPI_IOC_MESSAGE(1), &spi);
+                if (size != (size_t)xferSz - TPM_TIS_HEADER_SZ)
+                    ret = TPM_RC_FAILURE;
+            }
 
-                if (size == (size_t)xferSz - TPM_TIS_HEADER_SZ)
-                    ret = TPM_RC_SUCCESS;
+            /* Send 1 byte dummy message to deassert cs if needed */
+            if (spi.cs_change == 1) {
+                spi.cs_change = 0;
+                spi.len = 1;
+                size = ioctl(spiDev, SPI_IOC_MESSAGE(1), &spi);
+                (void)size;  /* Ignore result */
             }
     #else
             /* Send Entire Message - no wait states */
@@ -275,24 +296,28 @@
             spi.rx_buf   = (unsigned long)rxBuf;
             spi.len      = xferSz;
             size = ioctl(spiDev, SPI_IOC_MESSAGE(1), &spi);
-            if (size == (size_t)xferSz)
-                ret = TPM_RC_SUCCESS;
+            if (size != (size_t)xferSz)
+                ret = TPM_RC_FAILURE;
     #endif /* WOLFTPM_CHECK_WAIT_STATE */
 
             close(spiDev);
+        }
+        else {
+            /* Failed to open device */
+            ret = TPM_RC_FAILURE;
         }
 
     #ifdef WOLFTPM_AUTODETECT
         /* if response is not 0xFF then we "found" something */
         if (!foundSpiDev) {
-            if (ret == TPM_RC_SUCCESS && rxBuf[0] != 0xFF) {
+            if ((ret == TPM_RC_SUCCESS) && (rxBuf[TPM_TIS_HEADER_SZ-1] != 0xFF)) {
         #ifdef DEBUG_WOLFTPM
                 printf("Found TPM @ %s\n", TPM2_SPI_DEV);
         #endif
                 foundSpiDev = 1;
             }
             else {
-                int devLen = (int)XSTRLEN(TPM2_SPI_DEV);
+                devLen = (int)XSTRLEN(TPM2_SPI_DEV);
                 /* tries spidev0.[0-4] */
                 if (TPM2_SPI_DEV[devLen-1] <= MAX_SPI_DEV_CS) {
                     TPM2_SPI_DEV[devLen-1]++;

--- a/hal/tpm_io_linux.c
+++ b/hal/tpm_io_linux.c
@@ -261,7 +261,7 @@
                     size = ioctl(spiDev, SPI_IOC_MESSAGE(1), &spi);
                 } while (
                     (size == 1) &&
-                    ((rxBuf[TPM_TIS_HEADER_SZ-1] & TPM_TIS_READY_MASK)==0) &&
+                    ((rxBuf[TPM_TIS_HEADER_SZ-1] & TPM_TIS_READY_MASK) == 0) &&
                     (--timeout > 0));
             #ifdef WOLFTPM_DEBUG_TIMEOUT
                 printf("SPI Ready Timeout %d\n", TPM_SPI_WAIT_RETRY - timeout);
@@ -310,7 +310,7 @@
     #ifdef WOLFTPM_AUTODETECT
         /* if response is not 0xFF then we "found" something */
         if (!foundSpiDev) {
-            if ((ret == TPM_RC_SUCCESS) && (rxBuf[TPM_TIS_HEADER_SZ-1] != 0xFF)) {
+            if (ret == TPM_RC_SUCCESS && rxBuf[TPM_TIS_HEADER_SZ-1] != 0xFF) {
         #ifdef DEBUG_WOLFTPM
                 printf("Found TPM @ %s\n", TPM2_SPI_DEV);
         #endif


### PR DESCRIPTION
The Linux IO subsystem's usage of cs_change within the SPI transfer ioctl() call has been corrected.  Since all transactions are single messages (last transactions), the cs_change must be set to 1 when a sequence of transactions must be issued while CS is asserted.  Only the last transaction should have the cs_change set back to 0 to ensure the cs line is desasserted.  Specifically, the fsl-dspi Linux kernel driver does not have a method to dessert CS under error conditions.  Hence, code was added to always complete all SPI transaction sequences with an additional byte transfer with cs_change=0 to ensure the kernel driver correctly reasserts cs.  This code will only be triggered in error handling cases where the SPI transactions have either failed to be issued or timeout for wait states is exceeded.

This code was tested on a Raspberry Pi with a Nuvoton SPI TPM and an LS1028A connected to an Optiga SLB9672.  Both configurations were run with and without auto detection as well as with and without wait state checking.  

Additionally, logic was added to allow the spidev path and cs to be overridden at configuration time by setting the TPM2_SPI_DEV_PATH and TPM_SPI_DEV_CS macros to valid strings such as:
```./configure CPPFLAGS="-DTPM2_SPI_DEV_PATH=\"/dev/spidev0.\" -DTPM2_SPI_DEV_CS=\"0\" "```


[pi_novuton_wraptest.txt](https://github.com/wolfSSL/wolfTPM/files/11266193/pi_novuton_wraptest.txt)
[ls1028a_optiga_wraptest.txt](https://github.com/wolfSSL/wolfTPM/files/11266194/ls1028a_optiga_wraptest.txt)
