### PR TITLE
Fixes for low resource build options

### DIFF
--- a/examples/attestation/activate_credential.c
+++ b/examples/attestation/activate_credential.c
@@ -25,14 +25,14 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #ifndef WOLFTPM2_NO_WRAPPER
 
 #include <examples/attestation/credential.h>
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include <examples/tpm_test_keys.h>
-
-#include <stdio.h>
 
 
 /******************************************************************************/

--- a/examples/bench/bench.c
+++ b/examples/bench/bench.c
@@ -25,14 +25,14 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #if !defined(WOLFTPM2_NO_WRAPPER) && !defined(NO_TPM_BENCH)
 
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include <examples/tpm_test_keys.h>
 #include <examples/bench/bench.h>
-
-#include <stdio.h>
 
 /* Configuration */
 #define TPM2_BENCH_DURATION_SEC         1

--- a/examples/csr/csr.c
+++ b/examples/csr/csr.c
@@ -23,6 +23,8 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #if !defined(WOLFTPM2_NO_WRAPPER) && defined(WOLFTPM2_CERT_GEN)
 
 #include <hal/tpm_io.h>
@@ -30,8 +32,6 @@
 #include <examples/tpm_test_keys.h>
 #include <examples/csr/csr.h>
 #include <wolfssl/wolfcrypt/asn_public.h>
-
-#include <stdio.h>
 
 #ifndef NO_RSA
 static const char* gClientCsrRsaFile = "./certs/tpm-rsa-cert.csr";

--- a/examples/gpio/gpio_config.c
+++ b/examples/gpio/gpio_config.c
@@ -24,14 +24,14 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #if !defined(WOLFTPM2_NO_WRAPPER) && \
     (defined(WOLFTPM_ST33) || defined(WOLFTPM_NUVOTON))
 
 #include <examples/gpio/gpio.h>
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
-
-#include <stdio.h>
 
 /******************************************************************************/
 /* --- BEGIN TPM2.0 GPIO Configuration example  -- */

--- a/examples/gpio/gpio_set.c
+++ b/examples/gpio/gpio_set.c
@@ -27,14 +27,15 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
-#include <examples/gpio/gpio.h>
-#include <hal/tpm_io.h>
-#include <examples/tpm_test.h>
-
 #include <stdio.h>
 
 #if !defined(WOLFTPM2_NO_WRAPPER) && \
     (defined(WOLFTPM_ST33) || defined(WOLFTPM_NUVOTON))
+
+
+#include <examples/gpio/gpio.h>
+#include <hal/tpm_io.h>
+#include <examples/tpm_test.h>
 
 /******************************************************************************/
 /* --- BEGIN TPM GPIO Set Example -- */

--- a/examples/keygen/create_primary.c
+++ b/examples/keygen/create_primary.c
@@ -23,14 +23,14 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
+#ifndef WOLFTPM2_NO_WRAPPER
+
 #include <examples/keygen/keygen.h>
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include <examples/tpm_test_keys.h>
-
-#include <stdio.h>
-
-#ifndef WOLFTPM2_NO_WRAPPER
 
 /******************************************************************************/
 /* --- BEGIN TPM Create Primary Key Example -- */

--- a/examples/keygen/keygen.c
+++ b/examples/keygen/keygen.c
@@ -23,14 +23,14 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
+#ifndef WOLFTPM2_NO_WRAPPER
+
 #include <examples/keygen/keygen.h>
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include <examples/tpm_test_keys.h>
-
-#include <stdio.h>
-
-#ifndef WOLFTPM2_NO_WRAPPER
 
 #define SYM_EXTRA_OPTS_LEN 14 /* 5 chars for "-sym=" and 9 for extra options */
 #define SYM_EXTRA_OPTS_POS 4  /* Array pos of the equal sign for extra opts */

--- a/examples/keygen/keyimport.c
+++ b/examples/keygen/keyimport.c
@@ -23,15 +23,14 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
+#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT)
+
 #include <examples/keygen/keygen.h>
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include <examples/tpm_test_keys.h>
-
-#include <stdio.h>
-
-
-#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT)
 
 /******************************************************************************/
 /* --- BEGIN TPM Key Import / Blob Example -- */

--- a/examples/keygen/keyimport.c
+++ b/examples/keygen/keyimport.c
@@ -159,7 +159,8 @@ int TPM2_Keyimport_Example(void* userCtx, int argc, char *argv[])
 
     if (alg == TPM_ALG_RSA) {
         if (derEncode == 1) {
-        #if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_RSA)
+        #if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_RSA) && \
+            !defined(NO_ASN)
             rc = wolfTPM2_RsaPrivateKeyImportDer(&dev, &storage, &impKey,
                 kRsaKeyPrivDer, sizeof(kRsaKeyPrivDer), TPM_ALG_NULL,
                 TPM_ALG_NULL);

--- a/examples/keygen/keyload.c
+++ b/examples/keygen/keyload.c
@@ -31,15 +31,15 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
+#ifndef WOLFTPM2_NO_WRAPPER
+
 #include <examples/keygen/keygen.h>
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include <examples/tpm_test_keys.h>
 
-#include <stdio.h>
-
-
-#ifndef WOLFTPM2_NO_WRAPPER
 /******************************************************************************/
 /* --- BEGIN TPM Key Load Example -- */
 /******************************************************************************/

--- a/examples/nvram/counter.c
+++ b/examples/nvram/counter.c
@@ -28,14 +28,14 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
+#ifndef WOLFTPM2_NO_WRAPPER
+
 #include <examples/nvram/nvram.h>
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include <examples/tpm_test_keys.h>
-
-#include <stdio.h>
-
-#ifndef WOLFTPM2_NO_WRAPPER
 
 /******************************************************************************/
 /* --- BEGIN TPM NV Counter Example -- */

--- a/examples/nvram/read.c
+++ b/examples/nvram/read.c
@@ -28,14 +28,14 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
+#ifndef WOLFTPM2_NO_WRAPPER
+
 #include <examples/nvram/nvram.h>
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include <examples/tpm_test_keys.h>
-
-#include <stdio.h>
-
-#ifndef WOLFTPM2_NO_WRAPPER
 
 #define PRIVATE_PART_ONLY   0x01
 #define PUBLIC_PART_ONLY    0x02

--- a/examples/nvram/seal_policy_auth_nv_external.c
+++ b/examples/nvram/seal_policy_auth_nv_external.c
@@ -26,7 +26,7 @@
 #include <stdio.h>
 
 #if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
-    defined(WOLFSSL_PUBLIC_MP)
+    defined(WOLFSSL_PUBLIC_MP) && defined(HAVE_ECC)
 
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/sha256.h>
@@ -330,7 +330,7 @@ int main(int argc, char *argv[])
     int rc = -1;
 
 #if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
-    defined(WOLFSSL_PUBLIC_MP)
+    defined(WOLFSSL_PUBLIC_MP) && defined(HAVE_ECC)
     rc = TPM2_PCR_Seal_With_Policy_Auth_NV_External_Test(NULL, argc, argv);
 #else
     printf("Wrapper or wolfcrypt or WOLFSSL_PUBLIC_MP code not compiled in\n");

--- a/examples/nvram/seal_policy_auth_nv_external.c
+++ b/examples/nvram/seal_policy_auth_nv_external.c
@@ -23,6 +23,8 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
     defined(WOLFSSL_PUBLIC_MP)
 
@@ -35,8 +37,6 @@
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include <examples/tpm_test_keys.h>
-
-#include <stdio.h>
 
 #define ECC_KEY_SIZE 32
 

--- a/examples/nvram/store.c
+++ b/examples/nvram/store.c
@@ -28,14 +28,14 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
+#ifndef WOLFTPM2_NO_WRAPPER
+
 #include <examples/nvram/nvram.h>
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include <examples/tpm_test_keys.h>
-
-#include <stdio.h>
-
-#ifndef WOLFTPM2_NO_WRAPPER
 
 #define PRIVATE_PART_ONLY   0x01
 #define PUBLIC_PART_ONLY    0x02

--- a/examples/pcr/policy.c
+++ b/examples/pcr/policy.c
@@ -23,6 +23,8 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #ifndef WOLFTPM2_NO_WRAPPER
 
 #ifndef WOLFTPM2_NO_WOLFCRYPT
@@ -32,8 +34,6 @@
 #include "hal/tpm_io.h"
 #include <examples/pcr/pcr.h>
 #include <examples/tpm_test.h>
-
-#include <stdio.h>
 
 static signed char HexCharToByte(signed char ch)
 {

--- a/examples/pcr/read_pcr.c
+++ b/examples/pcr/read_pcr.c
@@ -23,6 +23,8 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #ifndef WOLFTPM2_NO_WRAPPER
 
 #ifndef WOLFTPM2_NO_WOLFCRYPT
@@ -32,8 +34,6 @@
 #include <examples/pcr/pcr.h>
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
-
-#include <stdio.h>
 
 
 /******************************************************************************/

--- a/examples/pkcs7/pkcs7.c
+++ b/examples/pkcs7/pkcs7.c
@@ -23,6 +23,8 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #if !defined(WOLFTPM2_NO_WRAPPER) && defined(WOLFTPM_CRYPTOCB) && \
     defined(HAVE_PKCS7)
 
@@ -31,8 +33,6 @@
 #include <examples/tpm_test_keys.h>
 #include <examples/pkcs7/pkcs7.h>
 #include <wolfssl/wolfcrypt/pkcs7.h>
-
-#include <stdio.h>
 
 /* Sign PKCS7 using TPM based key:
  * Must Run:

--- a/examples/seal/seal.c
+++ b/examples/seal/seal.c
@@ -23,12 +23,15 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
+#ifndef WOLFTPM2_NO_WRAPPER
+
 #include <examples/seal/seal.h>
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include <examples/tpm_test_keys.h>
 
-#ifndef WOLFTPM2_NO_WRAPPER
 
 /******************************************************************************/
 /* --- BEGIN TPM2.0 Seal Example -- */

--- a/examples/seal/seal_policy_auth.c
+++ b/examples/seal/seal_policy_auth.c
@@ -23,6 +23,8 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #ifndef WOLFTPM2_NO_WRAPPER
 
 #ifndef WOLFTPM2_NO_WOLFCRYPT
@@ -33,8 +35,6 @@
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include <examples/tpm_test_keys.h>
-
-#include <stdio.h>
 
 /******************************************************************************/
 /* --- BEGIN TPM2.0 PCR Policy example tool  -- */

--- a/examples/seal/unseal.c
+++ b/examples/seal/unseal.c
@@ -23,14 +23,14 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #if !defined(WOLFTPM2_NO_WRAPPER) && !defined(NO_FILESYSTEM)
 
 #include <examples/seal/seal.h>
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include <examples/tpm_test_keys.h>
-
-#include <stdio.h>
 
 
 /******************************************************************************/

--- a/examples/timestamp/clock_set.c
+++ b/examples/timestamp/clock_set.c
@@ -23,13 +23,13 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #ifndef WOLFTPM2_NO_WRAPPER
 
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include "clock_set.h"
-
-#include <stdio.h>
 
 /******************************************************************************/
 /* --- BEGIN TPM Clock Set Example -- */

--- a/examples/timestamp/signed_timestamp.c
+++ b/examples/timestamp/signed_timestamp.c
@@ -25,14 +25,14 @@
 
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #ifndef WOLFTPM2_NO_WRAPPER
 
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include <examples/tpm_test_keys.h>
 #include "signed_timestamp.h"
-
-#include <stdio.h>
 
 
 /******************************************************************************/

--- a/examples/tls/tls_client.c
+++ b/examples/tls/tls_client.c
@@ -23,8 +23,10 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #if !defined(WOLFTPM2_NO_WRAPPER) && defined(WOLFTPM_CRYPTOCB) && \
-    !defined(NO_WOLFSSL_CLIENT)
+    !defined(NO_WOLFSSL_CLIENT) && !defined(WOLFCRYPT_ONLY)
 
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
@@ -39,8 +41,6 @@
 #undef  USE_CERT_BUFFERS_256
 #define USE_CERT_BUFFERS_256
 #include <wolfssl/certs_test.h>
-
-#include <stdio.h>
 
 #ifdef TLS_BENCH_MODE
     double benchStart;
@@ -574,7 +574,8 @@ exit:
 /* --- END TPM TLS Client Example -- */
 /******************************************************************************/
 
-#endif /* !WOLFTPM2_NO_WRAPPER && WOLFTPM_CRYPTOCB && !NO_WOLFSSL_CLIENT */
+#endif /* !WOLFTPM2_NO_WRAPPER && WOLFTPM_CRYPTOCB && !NO_WOLFSSL_CLIENT && \
+        * !WOLFCRYPT_ONLY */
 
 #ifndef NO_MAIN_DRIVER
 int main(int argc, char* argv[])
@@ -582,13 +583,13 @@ int main(int argc, char* argv[])
     int rc = -1;
 
 #if !defined(WOLFTPM2_NO_WRAPPER) && defined(WOLFTPM_CRYPTOCB) && \
-    !defined(NO_WOLFSSL_CLIENT)
+    !defined(NO_WOLFSSL_CLIENT) && !defined(WOLFCRYPT_ONLY)
     rc = TPM2_TLS_ClientArgs(NULL, argc, argv);
 #else
     (void)argc;
     (void)argv;
 
-    printf("Wrapper/Crypto callback code not compiled in\n");
+    printf("Wrapper/Crypto callback code or TLS support not compiled in\n");
     printf("Build wolfssl with ./configure --enable-cryptocb\n");
 #endif
 

--- a/examples/tls/tls_client_notpm.c
+++ b/examples/tls/tls_client_notpm.c
@@ -23,6 +23,8 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
     !defined(NO_WOLFSSL_CLIENT) && !defined(WOLFCRYPT_ONLY)
 
@@ -39,8 +41,6 @@
 #undef  USE_CERT_BUFFERS_256
 #define USE_CERT_BUFFERS_256
 #include <wolfssl/certs_test.h>
-
-#include <stdio.h>
 
 #ifdef TLS_BENCH_MODE
     double benchStart;

--- a/examples/tls/tls_common.h
+++ b/examples/tls/tls_common.h
@@ -25,7 +25,8 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 
-#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(WOLFCRYPT_ONLY)
+#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
+    !defined(WOLFCRYPT_ONLY)
 
 #include <wolftpm/tpm2_socket.h>
 

--- a/examples/tls/tls_server.c
+++ b/examples/tls/tls_server.c
@@ -23,8 +23,10 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #if !defined(WOLFTPM2_NO_WRAPPER) && defined(WOLFTPM_CRYPTOCB) && \
-    !defined(NO_WOLFSSL_SERVER)
+    !defined(NO_WOLFSSL_SERVER) && !defined(WOLFCRYPT_ONLY)
 
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
@@ -33,8 +35,6 @@
 #include <examples/tls/tls_server.h>
 
 #include <wolfssl/ssl.h>
-
-#include <stdio.h>
 
 #ifdef TLS_BENCH_MODE
     double benchStart;
@@ -552,7 +552,8 @@ exit:
 /* --- END TLS Server Example -- */
 /******************************************************************************/
 
-#endif /* !WOLFTPM2_NO_WRAPPER && WOLFTPM_CRYPTOCB && !NO_WOLFSSL_SERVER */
+#endif /* !WOLFTPM2_NO_WRAPPER && WOLFTPM_CRYPTOCB && !NO_WOLFSSL_SERVER && \
+        * !WOLFCRYPT_ONLY */
 
 #ifndef NO_MAIN_DRIVER
 int main(int argc, char* argv[])
@@ -560,13 +561,13 @@ int main(int argc, char* argv[])
     int rc = -1;
 
 #if !defined(WOLFTPM2_NO_WRAPPER) && defined(WOLFTPM_CRYPTOCB) && \
-    !defined(NO_WOLFSSL_SERVER)
+    !defined(NO_WOLFSSL_SERVER) && !defined(WOLFCRYPT_ONLY)
     rc = TPM2_TLS_ServerArgs(NULL, argc, argv);
 #else
     (void)argc;
     (void)argv;
 
-    printf("Wrapper/Crypto callback code not compiled in\n");
+    printf("Wrapper/Crypto callback code or TLS support not compiled in\n");
     printf("Build wolfssl with ./configure --enable-cryptocb\n");
 #endif
 

--- a/examples/tpm_test_keys.c
+++ b/examples/tpm_test_keys.c
@@ -30,6 +30,8 @@
 #include "tpm_test_keys.h"
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #define RSA_FILENAME  "rsa_test_blob.raw"
 #define ECC_FILENAME  "ecc_test_blob.raw"
 

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -111,7 +111,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
 
 #ifndef WOLFTPM2_NO_WOLFCRYPT
     int tpmDevId = INVALID_DEVID;
-#if defined(HAVE_ECC) || !defined(NO_RSA)
+#if defined(HAVE_ECC) || (!defined(NO_RSA) && !defined(NO_ASN))
     word32 idx;
 #endif
 #ifndef NO_RSA
@@ -386,7 +386,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
     /*------------------------------------------------------------------------*/
     /* RSA KEY LOADING TESTS */
     /*------------------------------------------------------------------------*/
-#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_RSA)
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_RSA) && !defined(NO_ASN)
     /* Extract an RSA public key from TPM */
     /* Setup wolf RSA key with TPM deviceID */
     /* crypto dev callbacks are used for private portion */

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -24,13 +24,13 @@
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 
+#include <stdio.h>
+
 #ifndef WOLFTPM2_NO_WRAPPER
 
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
 #include <examples/wrap/wrap_test.h>
-
-#include <stdio.h>
 
 /* Configuration */
 #if 0
@@ -110,8 +110,8 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
         "\x88\x1d\xc2\x00\xc9\x83\x3d\xa7\x26\xe9\x37\x6c\x2e\x32\xcf\xf7";
 
 #ifndef WOLFTPM2_NO_WOLFCRYPT
-#if defined(HAVE_ECC) || !defined(NO_RSA)
     int tpmDevId = INVALID_DEVID;
+#if defined(HAVE_ECC) || !defined(NO_RSA)
     word32 idx;
 #endif
 #ifndef NO_RSA

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -259,7 +259,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
             (word32)tpmSession.handle.hndl);
 
         /* set session for authorization of the storage key */
-        rc = wolfTPM2_SetAuthSession(&dev, 1, &tpmSession,
+        rc = wolfTPM2_SetAuthSession(&dev, 0, &tpmSession,
             (TPMA_SESSION_decrypt | TPMA_SESSION_encrypt | TPMA_SESSION_continueSession));
         if (rc != 0) goto exit;
     }

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -432,7 +432,7 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
     rc = wolfTPM2_UnloadHandle(&dev, &publicKey.handle);
     if (rc != 0) goto exit;
 
-#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_RSA)
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_RSA) && !defined(NO_ASN)
     /* Load RSA private key into TPM */
     rc = wc_InitRsaKey(&wolfRsaPrivKey, NULL);
     if (rc != 0) goto exit;

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -5894,10 +5894,12 @@ int TPM2_GetWolfRng(WC_RNG** rng)
         return BAD_FUNC_ARG;
 
     if (!ctx->rngInit) {
-        rc = wc_InitRng(&ctx->rng);
+        /* Use did_vid for devId (conforms with wolfTPM2_GetTpmDevId) */
+        rc = wc_InitRng_ex(&ctx->rng, NULL, ctx->did_vid);
         if (rc < 0) {
         #ifdef DEBUG_WOLFTPM
-            printf("wc_InitRng failed %d: %s\n", (int)rc, wc_GetErrorString(rc));
+            printf("wc_InitRng_ex failed %d: %s\n",
+                (int)rc, wc_GetErrorString(rc));
         #endif
             return rc;
         }

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -2390,7 +2390,8 @@ int wolfTPM2_RsaKey_PubPemToTpm(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
         return BAD_FUNC_ARG;
 
 #if !defined(WOLFTPM2_NO_WOLFCRYPT) && defined(WOLFSSL_PEM_TO_DER) && \
-    (defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_PUB_PEM_TO_DER))
+    (defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_PUB_PEM_TO_DER)) && \
+    !defined(NO_ASN)
     /* Prepare wolfCrypt key structure */
     rc = wc_InitRsaKey(&rsaKey, NULL);
     if (rc == 0) {

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -2125,6 +2125,7 @@ int wolfTPM2_ReadPublicKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 
 #ifndef WOLFTPM2_NO_WOLFCRYPT
 #ifndef NO_RSA
+#ifndef NO_ASN
 int wolfTPM2_RsaPrivateKeyImportDer(WOLFTPM2_DEV* dev,
     const WOLFTPM2_KEY* parentKey, WOLFTPM2_KEYBLOB* keyBlob, const byte* input,
     word32 inSz, TPMI_ALG_RSA_SCHEME scheme, TPMI_ALG_HASH hashAlg)
@@ -2170,6 +2171,7 @@ int wolfTPM2_RsaPrivateKeyImportDer(WOLFTPM2_DEV* dev,
 
     return rc;
 }
+#endif /* !NO_ASN */
 
 #if !defined(WOLFTPM2_NO_HEAP) && defined(WOLFSSL_PEM_TO_DER)
 

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -3609,7 +3609,6 @@ typedef enum {
     \endcode
 
     \sa TPM2_GetCapabilities
-    \sa TPM2_GetTpmDevId
     \sa TPM2_Init
 */
 WOLFTPM_API UINT16 TPM2_GetVendorID(void);


### PR DESCRIPTION
* Fix for building with no PEM to DER.
* Fix for building with static library and no debug, due to missing stdio in examples.
* Fix for TLS examples missing `WOLFCRYPT_ONLY` check.
* Fix for building with `WC_NO_RNG`.
* Fix for RSA salt with RNG using crypto cb.
* Support for disabling ASN.1 (--disable-asn) and still provide parameter encryption support.

Related to: https://github.com/wolfSSL/wolfssl/pull/6371