### PR TITLE
undefine HAVE_THREAD_LS if NO_THREAD_LS is defined

### DIFF
--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -81,6 +81,10 @@ typedef int64_t  INT64;
     #ifndef WOLFSSL_USER_SETTINGS
         #include <wolfssl/options.h>
     #endif
+    /* enforce NO_THREAD_LS within wolfTPM */
+    #ifdef NO_THREAD_LS
+        #undef HAVE_THREAD_LS
+    #endif
     #include <wolfssl/wolfcrypt/settings.h>
     #include <wolfssl/wolfcrypt/types.h>
     #include <wolfssl/wolfcrypt/logging.h>


### PR DESCRIPTION
ZD 16126

I couldn't turn off `HAVE_THREAD_LS` if it was defined in wolfssl, and I think it has to be defined for FIPS I tried turning it off but it redefined somewhere, so I've made `NO_THREAD_LS` undefine it after pulling in options