### PR TITLE
Fixes for TPM private key import with custom seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ examples/keygen/create_primary
 examples/keygen/keyload
 examples/keygen/keygen
 examples/keygen/keyimport
+examples/keygen/external_import
 examples/nvram/store
 examples/nvram/read
 examples/nvram/counter

--- a/examples/keygen/external_import.c
+++ b/examples/keygen/external_import.c
@@ -141,7 +141,7 @@ int TPM2_ExternalImport_Example(void* userCtx, int argc, char *argv[])
 
     rc = wolfTPM2_ImportPrivateKeyBuffer(&dev, &storage, TPM_ALG_RSA, key2,
         ENCODING_TYPE_PEM, extRSAPrivatePem, (word32)strlen(extRSAPrivatePem),
-        NULL, attributes, &seedValue);
+        NULL, attributes, seedValue.buffer, seedValue.size);
     if (rc != 0) {
         printf("Failed to wolfTPM2_RsaPrivateKeyImportPem\n");
         goto exit;

--- a/examples/keygen/external_import.c
+++ b/examples/keygen/external_import.c
@@ -1,0 +1,214 @@
+/* external_import.c
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfTPM.
+ *
+ * wolfTPM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfTPM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* Example for importing an external RSA key with seed and creating a
+ * child key under it. */
+
+#include <wolftpm/tpm2_wrap.h>
+
+#include <stdio.h>
+
+#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT)
+
+#include <examples/keygen/keygen.h>
+#include <hal/tpm_io.h>
+
+/* from certs/example-rsa-key.pem */
+const char* extRSAPrivatePem =
+"-----BEGIN PRIVATE KEY-----\n"
+"MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCePbYR1SIZAL/2\n"
+"8FYbgpxynENgvHACM9LczZnsgVkZYxx3O9DTba2VTxhMN21i/aocJCzZB35qvz+R\n"
+"ickyvWBqPDXauJEn9icPXgSknqxzw0ZATzL0wbq/Tk5T+oITFFCGJ8/baFoktOKu\n"
+"iP5H50Dx6X2W1qNHiLkbGq7NbXHA8YG2wzK9kwikowSXQVB7pZ5bgjW2q73vIGSs\n"
+"eW802f7I/30wbf4oR1vfk4OQursT9sl2CFLNt5bJSw6lFTm4BOgC7Q3bpHPzC/YK\n"
+"uFYWKGeQL9GCsEZVWHCM6vzek6SNwQ0eoQ0i9IuF0os/0nJDwdXEZX9OoBhFT717\n"
+"svlxDXpFAgMBAAECggEABYIV6Jx/5ZloVTbr9GSxP+8PDFq61mTJ6fwxJ7Gf8ZmI\n"
+"1+Cp5fYrJOeeK6cBRIEabwTWV86iOKKEGrOOYJkFdmU2pbCngtnXZbpK1JUeYSAy\n"
+"vZHULv9gWgDmipdNeE8Md4MCwfspqh3uxw8HNOcIlHMhd0Ls55RLhzVAUO/GliXz\n"
+"5HIDhohyQAUvPvkwz1yrPNn5BQwMlJBARc2OKSKf+pJrlFw1KJWR9TKzGvRzMbI4\n"
+"gwrq9BZ5LCX5y6C7BpuzXdySHXofwihPNmi1KU/88cWhas2E0Xz+p+N/ifmkquTN\n"
+"3EqzqKBW+xobryM6X9JfQ6has211eUaZKNuU2/idKQKBgQC5rymu0UKHuAkr4uPS\n"
+"NLGmaWb4p+kDNxbVyzS2ENjtoJ6JyEo/pZQrTG4S/kCWFgGsuztCbx+1Kgk0Pgwi\n"
+"znaGvcfrjiP9XE1oVfMifA2JmH+drjASyjPqNfsf0BKQtlk0nZXwUO/C1FQ5vUU4\n"
+"lpmpx4EhTnucQ9E7r0+uXnQHTQKBgQDaKh4bBV7dLBF4ZxwCdydMMSZkBgckBiH7\n"
+"83BvyLW6I0GKXcFTa7KKLgTj41pXeWh6bmM9365+Cr8fxTZop28EfGRYFBMp08/g\n"
+"wHpmS3NZ4moSgirJ+PhZsH+nBq89W75INR7BqV4SAc3n4lcwv9eBL9q0Q/YJZ1ph\n"
+"NCKvz79y2QKBgFyDFPVwdQFBg/BFntRARLJwmUkR/1oGvG3QTHbZdfsOp25mR/fl\n"
+"+yiHb+AupOciF7uDnUbALsAILYXF1C4TR6JiM5T8wJmev0JYcEaiH+yJ+isJehIi\n"
+"hDMQqglzlYxcDZ3VVbrh2FLtjvklf7Nt9SlNqNx7ScLVVw2xjrWFgbGRAoGBAMjo\n"
+"Wnsl0fu6Noh74/Z9RmpLJQCd8HuDTk6ZHCVFX91/1D6ZIo0xM+U+hfBbkfnWa5m8\n"
+"CJaVZDrcqK+YTQfJkVo/N6VJL3Coh9qBRvbnat4OvQI4bzE6n3LxME1fwYeu8ifL\n"
+"C3zq/R92G+n8rbDOKqbkq/KwV2bHkBrOCVeA6NzZAoGACztyZbS5jCuSlPqk/xoN\n"
+"EzX9Cev/GipF5tZMeOcQlty+anPg3TC70O06yZ1SIJKLzOOyoPCUDNrM2M5TCaau\n"
+"vT0vW1GeNAryc+q9aOmFT3AlZ93Tfst+90Q+NJecEEhkO43tU5S1ZK2iVf9XAOV6\n"
+"ovHegJU35IUeaoyg23HjFWU=\n"
+"-----END PRIVATE KEY-----";
+
+static void usage(void)
+{
+    printf("Expected usage:\n");
+    printf("./examples/keygen/external_import [-ecc/-rsa]\n");
+    printf("Primary Key Type:\n");
+    printf("\t-rsa: Use RSA SRK (DEFAULT)\n");
+    printf("\t-ecc: Use ECC SRK\n");
+}
+
+int TPM2_ExternalImport_Example(void* userCtx, int argc, char *argv[])
+{
+    int rc;
+    WOLFTPM2_DEV dev;
+    WOLFTPM2_KEY storage; /* SRK */
+    WOLFTPM2_KEY *primary;
+    WOLFTPM2_KEYBLOB* key2;
+    WOLFTPM2_KEYBLOB* rsaKey3;
+    TPM2B_DIGEST seedValue;
+    TPMT_PUBLIC publicTemplate3;
+    TPMA_OBJECT attributes;
+    TPMI_ALG_PUBLIC alg = TPM_ALG_RSA;
+
+    if (argc >= 2) {
+        if (XSTRCMP(argv[1], "-?") == 0 ||
+            XSTRCMP(argv[1], "-h") == 0 ||
+            XSTRCMP(argv[1], "--help") == 0) {
+            usage();
+            return 0;
+        }
+    }
+    while (argc > 1) {
+        if (XSTRCMP(argv[argc-1], "-rsa") == 0) {
+            alg = TPM_ALG_RSA;
+        }
+        else if (XSTRCMP(argv[argc-1], "-ecc") == 0) {
+            alg = TPM_ALG_ECC;
+        }
+        else {
+            printf("Warning: Unrecognized option: %s\n", argv[argc-1]);
+        }
+
+        argc--;
+    }
+
+    key2 = wolfTPM2_NewKeyBlob();
+    rsaKey3 = wolfTPM2_NewKeyBlob();
+    primary = &storage;
+
+    rc = wolfTPM2_Init(&dev, TPM2_IoCb, NULL);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("wolfTPM2_Init failed 0x%x: %s\n", rc, TPM2_GetRCString(rc));
+        goto exit;
+    }
+
+    /* RSA or ECC (faster) SRK */
+    rc = wolfTPM2_CreateSRK(&dev, &storage, alg, NULL, 0);
+    if (rc != 0) {
+        printf("Failed to wolfTPM2_CreateSRK\n");
+        goto exit;
+    }
+
+    /* Second level key */
+    attributes = (TPMA_OBJECT_restricted |
+             TPMA_OBJECT_sensitiveDataOrigin |
+             TPMA_OBJECT_decrypt |
+             TPMA_OBJECT_userWithAuth |
+             TPMA_OBJECT_noDA);
+
+    /* Generate random seed */
+    XMEMSET(&seedValue, 0, sizeof(seedValue));
+    seedValue.size = TPM2_GetHashDigestSize(TPM_ALG_SHA256);
+    TPM2_GetNonce(seedValue.buffer, seedValue.size);
+#ifdef DEBUG_WOLFTPM
+    printf("Import RSA Seed %d\n", seedValue.size);
+    TPM2_PrintBin(seedValue.buffer, seedValue.size);
+#endif
+
+    rc = wolfTPM2_ImportPrivateKeyBuffer(&dev, &storage, TPM_ALG_RSA, key2,
+        ENCODING_TYPE_PEM, extRSAPrivatePem, (word32)strlen(extRSAPrivatePem),
+        NULL, attributes, &seedValue);
+    if (rc != 0) {
+        printf("Failed to wolfTPM2_RsaPrivateKeyImportPem\n");
+        goto exit;
+    }
+
+    rc = wolfTPM2_LoadKey(&dev, key2, &primary->handle);
+    if (rc != 0) {
+       printf("Failed to wolfTPM2_LoadKey\n");
+       goto exit;
+    }
+
+    /* The 3rd level RSA key */
+    rc = wolfTPM2_GetKeyTemplate_RSA(&publicTemplate3,
+        TPMA_OBJECT_sensitiveDataOrigin |
+        TPMA_OBJECT_userWithAuth |
+        TPMA_OBJECT_sign |
+        TPMA_OBJECT_noDA);
+    if (rc != 0) {
+        printf("Failed to wolfTPM2_GetKeyTemplate_RSA\n");
+        goto exit;
+    }
+    rc = wolfTPM2_CreateKey(&dev, rsaKey3, &key2->handle,
+        &publicTemplate3, NULL, 0);
+    if (rc != TPM_RC_SUCCESS) {
+        printf("wolfTPM2_CreateKey failed for the 3rd level key: %d\n", rc);
+        goto exit;
+    }
+
+    /* load the rsa key */
+    rc = wolfTPM2_LoadKey(&dev, rsaKey3, &key2->handle);
+
+    if (rc != 0) {
+        printf("Failed to wolfTPM2_LoadKey %d\n", rc);
+        goto exit;
+    }
+
+exit:
+    wolfTPM2_UnloadHandle(&dev, &rsaKey3->handle);
+    wolfTPM2_UnloadHandle(&dev, &key2->handle);
+    wolfTPM2_UnloadHandle(&dev, &primary->handle);
+
+    wolfTPM2_FreeKeyBlob(key2);
+    wolfTPM2_FreeKeyBlob(rsaKey3);
+
+    wolfTPM2_Cleanup(&dev);
+
+    (void)userCtx;
+    (void)argc;
+
+
+    return rc;
+}
+#endif /* !WOLFTPM2_NO_WRAPPER && !WOLFTPM2_NO_WOLFCRYPT */
+
+#ifndef NO_MAIN_DRIVER
+int main(int argc, char *argv[])
+{
+    int rc = NOT_COMPILED_IN;
+
+#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT)
+    rc = TPM2_ExternalImport_Example(NULL, argc, argv);
+#else
+    printf("Example for external import and child key creation (not compiled in)\n");
+    (void)argc;
+    (void)argv;
+#endif
+
+    return rc;
+}
+#endif

--- a/examples/keygen/include.am
+++ b/examples/keygen/include.am
@@ -27,6 +27,12 @@ examples_keygen_keyimport_SOURCES      = examples/keygen/keyimport.c \
                                          examples/tpm_test_keys.c
 examples_keygen_keyimport_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
 examples_keygen_keyimport_DEPENDENCIES = src/libwolftpm.la
+
+noinst_PROGRAMS += examples/keygen/external_import
+examples_keygen_external_import_SOURCES      = examples/keygen/external_import.c \
+                                         examples/tpm_test_keys.c
+examples_keygen_external_import_LDADD        = src/libwolftpm.la $(LIB_STATIC_ADD)
+examples_keygen_external_import_DEPENDENCIES = src/libwolftpm.la
 endif
 
 example_keygendir = $(exampledir)/keygen
@@ -34,9 +40,11 @@ dist_example_keygen_DATA = \
   examples/keygen/create_primary.c \
   examples/keygen/keyload.c \
   examples/keygen/keygen.c \
-  examples/keygen/keyimport.c
+  examples/keygen/keyimport.c \
+  examples/keygen/external_import.c
 
 DISTCLEANFILES+= examples/keygen/.libs/create_primary
 DISTCLEANFILES+= examples/keygen/.libs/keyload
 DISTCLEANFILES+= examples/keygen/.libs/keygen
 DISTCLEANFILES+= examples/keygen/.libs/keyimport
+DISTCLEANFILES+= examples/keygen/.libs/external_import

--- a/examples/keygen/keygen.c
+++ b/examples/keygen/keygen.c
@@ -138,7 +138,9 @@ int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[])
     const char *pubFilename = NULL;
 #if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
     const char *nameFile = "ak.name"; /* Name Digest for attestation purposes */
+    #if !defined(NO_RSA)
     const char *pemFilename = NULL;
+    #endif
     FILE *fp;
 #endif
     size_t len = 0;
@@ -374,7 +376,8 @@ int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[])
 #endif
 
     /* Save EK public key as PEM format file to the disk */
-#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM)
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_RSA)
     if (pemFiles) {
         byte pem[MAX_RSA_KEY_BYTES];
         word32 pemSz;

--- a/examples/keygen/keygen.h
+++ b/examples/keygen/keygen.h
@@ -30,6 +30,7 @@ int TPM2_CreatePrimaryKey_Example(void* userCtx, int argc, char *argv[]);
 int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[]);
 int TPM2_Keyload_Example(void* userCtx, int argc, char *argv[]);
 int TPM2_Keyimport_Example(void* userCtx, int argc, char *argv[]);
+int TPM2_ExternalImport_Example(void* userCtx, int argc, char *argv[]);
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -486,6 +486,7 @@ void TPM2_Packet_ParsePoint(TPM2_Packet* packet, TPM2B_ECC_POINT* point)
 void TPM2_Packet_AppendSensitive(TPM2_Packet* packet, TPM2B_SENSITIVE* sensitive)
 {
     int tmpSz = 0;
+    TPMU_SENSITIVE_COMPOSITE* sens = &sensitive->sensitiveArea.sensitive;
 
     TPM2_Packet_MarkU16(packet, &tmpSz);
 
@@ -499,9 +500,24 @@ void TPM2_Packet_AppendSensitive(TPM2_Packet* packet, TPM2B_SENSITIVE* sensitive
     TPM2_Packet_AppendBytes(packet, sensitive->sensitiveArea.seedValue.buffer,
         sensitive->sensitiveArea.seedValue.size);
 
-    TPM2_Packet_AppendU16(packet, sensitive->sensitiveArea.sensitive.any.size);
-    TPM2_Packet_AppendBytes(packet, sensitive->sensitiveArea.sensitive.any.buffer,
-        sensitive->sensitiveArea.sensitive.any.size);
+    switch (sensitive->sensitiveArea.sensitiveType) {
+    case TPM_ALG_RSA:
+        TPM2_Packet_AppendU16(packet, sens->rsa.size);
+        TPM2_Packet_AppendBytes(packet, sens->rsa.buffer, sens->rsa.size);
+        break;
+    case TPM_ALG_ECC:
+        TPM2_Packet_AppendU16(packet, sens->ecc.size);
+        TPM2_Packet_AppendBytes(packet, sens->ecc.buffer, sens->ecc.size);
+        break;
+    case TPM_ALG_KEYEDHASH:
+        TPM2_Packet_AppendU16(packet, sens->bits.size);
+        TPM2_Packet_AppendBytes(packet, sens->bits.buffer, sens->bits.size);
+        break;
+    case TPM_ALG_SYMCIPHER:
+        TPM2_Packet_AppendU16(packet, sens->sym.size);
+        TPM2_Packet_AppendBytes(packet, sens->sym.buffer, sens->sym.size);
+        break;
+    }
 
     TPM2_Packet_PlaceU16(packet, tmpSz);
 }
@@ -583,46 +599,48 @@ void TPM2_Packet_ParsePublicParms(TPM2_Packet* packet, TPMI_ALG_PUBLIC type,
     }
 }
 
-void TPM2_Packet_AppendPublic(TPM2_Packet* packet, TPM2B_PUBLIC* pub)
+void TPM2_Packet_AppendPublicArea(TPM2_Packet* packet, TPMT_PUBLIC* publicArea)
 {
-    int tmpSz = 0;
+    TPM2_Packet_AppendU16(packet, publicArea->type);
+    TPM2_Packet_AppendU16(packet, publicArea->nameAlg);
+    TPM2_Packet_AppendU32(packet, publicArea->objectAttributes);
+    TPM2_Packet_AppendU16(packet, publicArea->authPolicy.size);
+    TPM2_Packet_AppendBytes(packet, publicArea->authPolicy.buffer,
+        publicArea->authPolicy.size);
 
-    TPM2_Packet_MarkU16(packet, &tmpSz);
+    TPM2_Packet_AppendPublicParms(packet, publicArea->type,
+        &publicArea->parameters);
 
-    TPM2_Packet_AppendU16(packet, pub->publicArea.type);
-    TPM2_Packet_AppendU16(packet, pub->publicArea.nameAlg);
-    TPM2_Packet_AppendU32(packet, pub->publicArea.objectAttributes);
-    TPM2_Packet_AppendU16(packet, pub->publicArea.authPolicy.size);
-    TPM2_Packet_AppendBytes(packet, pub->publicArea.authPolicy.buffer,
-        pub->publicArea.authPolicy.size);
-
-    TPM2_Packet_AppendPublicParms(packet, pub->publicArea.type,
-        &pub->publicArea.parameters);
-
-    switch (pub->publicArea.type) {
+    switch (publicArea->type) {
     case TPM_ALG_KEYEDHASH:
-        TPM2_Packet_AppendU16(packet, pub->publicArea.unique.keyedHash.size);
-        TPM2_Packet_AppendBytes(packet, pub->publicArea.unique.keyedHash.buffer,
-            pub->publicArea.unique.keyedHash.size);
+        TPM2_Packet_AppendU16(packet, publicArea->unique.keyedHash.size);
+        TPM2_Packet_AppendBytes(packet, publicArea->unique.keyedHash.buffer,
+            publicArea->unique.keyedHash.size);
         break;
     case TPM_ALG_SYMCIPHER:
-        TPM2_Packet_AppendU16(packet, pub->publicArea.unique.sym.size);
-        TPM2_Packet_AppendBytes(packet, pub->publicArea.unique.sym.buffer,
-            pub->publicArea.unique.sym.size);
+        TPM2_Packet_AppendU16(packet, publicArea->unique.sym.size);
+        TPM2_Packet_AppendBytes(packet, publicArea->unique.sym.buffer,
+            publicArea->unique.sym.size);
         break;
     case TPM_ALG_RSA:
-        TPM2_Packet_AppendU16(packet, pub->publicArea.unique.rsa.size);
-        TPM2_Packet_AppendBytes(packet, pub->publicArea.unique.rsa.buffer,
-            pub->publicArea.unique.rsa.size);
+        TPM2_Packet_AppendU16(packet, publicArea->unique.rsa.size);
+        TPM2_Packet_AppendBytes(packet, publicArea->unique.rsa.buffer,
+            publicArea->unique.rsa.size);
         break;
     case TPM_ALG_ECC:
-        TPM2_Packet_AppendEccPoint(packet, &pub->publicArea.unique.ecc);
+        TPM2_Packet_AppendEccPoint(packet, &publicArea->unique.ecc);
         break;
     default:
         /* TPMS_DERIVE derive; ? */
         break;
     }
+}
+void TPM2_Packet_AppendPublic(TPM2_Packet* packet, TPM2B_PUBLIC* pub)
+{
+    int tmpSz = 0;
 
+    TPM2_Packet_MarkU16(packet, &tmpSz);
+    TPM2_Packet_AppendPublicArea(packet, &pub->publicArea);
     pub->size = TPM2_Packet_PlaceU16(packet, tmpSz);
 }
 void TPM2_Packet_ParsePublic(TPM2_Packet* packet, TPM2B_PUBLIC* pub)

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -1051,14 +1051,13 @@ int wolfTPM2_EncryptSalt(WOLFTPM2_DEV* dev, const WOLFTPM2_KEY* tpmKey,
             rc = NOT_COMPILED_IN;
             break;
     }
-#else
-    (void)salt;
-    (void)encSalt;
-    (void)label;
     rc = NOT_COMPILED_IN;
 #endif /* !WOLFTPM2_NO_WOLFCRYPT */
 
     (void)dev;
+    (void)salt;
+    (void)encSalt;
+    (void)label;
 
     return rc;
 }

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -941,23 +941,24 @@ int wolfTPM2_Cleanup(WOLFTPM2_DEV* dev)
 }
 
 #if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_RSA) && !defined(WC_NO_RNG)
-/* returns both the plaintext and encrypted salt, based on the salt key bPublic. */
-int wolfTPM2_RSA_Salt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
-    TPM2B_DIGEST *salt, TPM2B_ENCRYPTED_SECRET *encSalt,
-    TPMT_PUBLIC *publicArea)
+/* returns both the plaintext and encrypted salt, based on the salt public key */
+static int wolfTPM2_EncryptSalt_RSA(WOLFTPM2_DEV* dev, const WOLFTPM2_KEY* tpmKey,
+    const TPM2B_DIGEST *salt, TPM2B_ENCRYPTED_SECRET *encSalt,
+    const char* label)
 {
     int rc;
     WC_RNG rng;
     enum wc_HashType hashType;
-    const char* label = "SECRET";
     int mgf;
     RsaKey rsaKey;
     int devId;
+    const TPMT_PUBLIC *publicArea;
 
-    if (dev == NULL || salt == NULL || encSalt == NULL || publicArea == NULL) {
+    if (dev == NULL || salt == NULL || encSalt == NULL) {
         return BAD_FUNC_ARG;
     }
 
+    publicArea = &tpmKey->pub.publicArea;
     if (publicArea->nameAlg == TPM_ALG_SHA1) {
         hashType = WC_HASH_TYPE_SHA;
         mgf = WC_MGF1SHA1;
@@ -985,7 +986,7 @@ int wolfTPM2_RSA_Salt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
     wc_RsaSetRNG(&rsaKey, &rng);
 #endif
 
-    rc = wolfTPM2_RsaKey_TpmToWolf(dev, tpmKey, &rsaKey);
+    rc = wolfTPM2_RsaKey_TpmToWolf(dev, (WOLFTPM2_KEY*)tpmKey, &rsaKey);
     if (rc == 0) {
         encSalt->size = publicArea->unique.rsa.size;
         rc = wc_RsaPublicEncrypt_ex(
@@ -1017,8 +1018,9 @@ int wolfTPM2_RSA_Salt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
 }
 #endif /* !WOLFTPM2_NO_WOLFCRYPT && !NO_RSA && !WC_NO_RNG */
 
-int wolfTPM2_EncryptSalt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
-    StartAuthSession_In* in, TPM2B_AUTH* bindAuth, TPM2B_DIGEST* salt)
+int wolfTPM2_EncryptSalt(WOLFTPM2_DEV* dev, const WOLFTPM2_KEY* tpmKey,
+    const TPM2B_DIGEST* salt, TPM2B_ENCRYPTED_SECRET *encSalt,
+    const char* label)
 {
     int rc;
 
@@ -1028,16 +1030,6 @@ int wolfTPM2_EncryptSalt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
     }
 
 #ifndef WOLFTPM2_NO_WOLFCRYPT
-    /* generate a salt */
-    salt->size = TPM2_GetHashDigestSize(in->authHash);
-    if (salt->size <= 0) {
-        return TPM_RC_FAILURE;
-    }
-    rc = TPM2_GetNonce(salt->buffer, salt->size);
-    if (rc != 0) {
-        return rc;
-    }
-
 #ifdef WOLFTPM_DEBUG_VERBOSE
     printf("Session Salt %d\n", salt->size);
     TPM2_PrintBin(salt->buffer, salt->size);
@@ -1052,8 +1044,7 @@ int wolfTPM2_EncryptSalt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
     #endif
     #if !defined(NO_RSA) && !defined(WC_NO_RNG)
         case TPM_ALG_RSA:
-            rc = wolfTPM2_RSA_Salt(dev, tpmKey, salt, &in->encryptedSalt,
-                &tpmKey->pub.publicArea);
+            rc = wolfTPM2_EncryptSalt_RSA(dev, tpmKey, salt, encSalt, label);
             break;
     #endif
         default:
@@ -1061,13 +1052,12 @@ int wolfTPM2_EncryptSalt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
             break;
     }
 #else
-    (void)dev;
-    (void)in;
     (void)salt;
+    (void)encSalt;
+    (void)label;
     rc = NOT_COMPILED_IN;
 #endif /* !WOLFTPM2_NO_WOLFCRYPT */
 
-    (void)bindAuth; /* TODO: Add bind support */
     (void)dev;
 
     return rc;
@@ -1137,8 +1127,16 @@ int wolfTPM2_StartSession(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* session,
         return rc;
     }
 
-    /* Generate and Encrypt salt using "SECRET" */
-    rc = wolfTPM2_EncryptSalt(dev, tpmKey, &authSesIn, bindAuth, &session->salt);
+    /* Generate random salt */
+    session->salt.size = hashDigestSz;
+    rc = TPM2_GetNonce(session->salt.buffer, session->salt.size);
+    if (rc != 0) {
+        return rc;
+    }
+
+    /* Encrypt salt using "SECRET" */
+    rc = wolfTPM2_EncryptSalt(dev, tpmKey, &session->salt,
+        &authSesIn.encryptedSalt, "SECRET");
     if (rc != 0) {
     #ifdef DEBUG_WOLFTPM
         printf("Building encrypted salt failed %d: %s!\n", rc,
@@ -1146,6 +1144,9 @@ int wolfTPM2_StartSession(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* session,
     #endif
         return rc;
     }
+
+    /* TODO: BindAuth */
+    (void)bindAuth;
 
     rc = TPM2_StartAuthSession(&authSesIn, &authSesOut);
     if (rc != TPM_RC_SUCCESS) {
@@ -1555,7 +1556,7 @@ int wolfTPM2_ComputeName(const TPM2B_PUBLIC* pub, TPM2B_NAME* out)
     TPMI_ALG_HASH nameAlg;
 #ifndef WOLFTPM2_NO_WOLFCRYPT
     TPM2_Packet packet;
-    TPM2B_DATA data;
+    TPM2B_TEMPLATE data;
     wc_HashAlg hash;
     enum wc_HashType hashType;
     int hashSz;
@@ -1574,7 +1575,7 @@ int wolfTPM2_ComputeName(const TPM2B_PUBLIC* pub, TPM2B_NAME* out)
     XMEMSET(&packet, 0, sizeof(packet));
     packet.buf = data.buffer;
     packet.size = sizeof(data.buffer);
-    TPM2_Packet_AppendPublic(&packet, (TPM2B_PUBLIC*)pub);
+    TPM2_Packet_AppendPublicArea(&packet, (TPMT_PUBLIC*)&pub->publicArea);
     data.size = packet.pos;
 
     /* Hash data - first two bytes are TPM_ALG_ID */
@@ -1610,69 +1611,98 @@ int wolfTPM2_ComputeName(const TPM2B_PUBLIC* pub, TPM2B_NAME* out)
 }
 
 /* Convert TPM2B_SENSITIVE to TPM2B_PRIVATE */
-int wolfTPM2_SensitiveToPrivate(TPM2B_SENSITIVE* sens, TPM2B_PRIVATE* priv,
+/* TPM2B_PRIVATE format:
+ *   Integrity (UINT16) + Integrity (HMAC Digest) +
+ *   IV (UINT16) + IV +
+ *   Sensitive
+ */
+static int SensitiveToPrivate(TPM2B_SENSITIVE* sens, TPM2B_PRIVATE* priv,
     TPMI_ALG_HASH nameAlg, TPM2B_NAME* name, const WOLFTPM2_KEY* parentKey,
-    TPMT_SYM_DEF_OBJECT* sym, TPM2B_ENCRYPTED_SECRET* symSeed)
+    TPMT_SYM_DEF_OBJECT* sym, TPM2B_ENCRYPTED_SECRET* symSeed, int useIv)
 {
     int rc = 0;
-    int innerWrap = 0;
-    int outerWrap = 0;
-    TPMI_ALG_HASH innerAlg, outerAlg;
-    TPM2_Packet packet;
-    int pos = 0;
-    int digestSz =0;
-    int innerSz = 0;
-    int outerSz = 0;
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && \
+    !defined(NO_AES) && defined(WOLFSSL_AES_CFB) && !defined(NO_HMAC)
+    int outerWrap = 0, innerWrap = 0;
+    int digestSz = 0;
+    int integritySz = 0;
+    int ivSz = 0;
     int sensSz = 0;
+    BYTE* sensitiveData = NULL;
+    TPM2B_IV ivField;
+    TPM2_Packet packet;
+    TPM2B_SYM_KEY symKey;
+    TPM2B_DIGEST hmacKey;
+    Aes enc;
+    Hmac hmac_ctx;
 
-    if (sens == NULL || priv == NULL)
+    if (sens == NULL || priv == NULL) {
         return BAD_FUNC_ARG;
-
-    digestSz = TPM2_GetHashDigestSize(nameAlg);
-
-    if (sym && sym->algorithm != TPM_ALG_NULL) {
-        innerWrap = 1;
-
-        innerAlg = nameAlg;
-        innerSz = sizeof(word16) + digestSz;
-        pos += innerSz;
     }
 
-    if (symSeed && symSeed->size > 0 && parentKey) {
-        outerWrap = 1;
+    /* if using a parent then use it's integrity algorithm */
+    if (parentKey != NULL) {
+        nameAlg = parentKey->pub.publicArea.nameAlg;
+        symKey.size = parentKey->handle.symmetric.keyBits.sym;
+    }
+    else {
+        symKey.size = sym->keyBits.sym;
+    }
 
-        outerAlg = parentKey->pub.publicArea.nameAlg;
-        outerSz = sizeof(word16) + TPM2_GetHashDigestSize(outerAlg);
-        pos += outerSz;
+    digestSz = TPM2_GetHashDigestSize(nameAlg);
+    if (digestSz == 0) {
+    #ifdef DEBUG_WOLFTPM
+        printf("SensitiveToPrivate: Invalid name algorithm %d\n", nameAlg);
+    #endif
+        return TPM_RC_FAILURE;
+    }
+
+    /* Use outer wrap (Integrity then Encrypt) */
+    if (symSeed == NULL) {
+        symSeed = (TPM2B_ENCRYPTED_SECRET*)&sens->sensitiveArea.seedValue;
+    }
+    if (symSeed && symSeed->size > 0) {
+        outerWrap = 1;
+        integritySz = sizeof(word16) + digestSz;
+    }
+
+    /* Use inner wrap (Encrypt then Integrity) */
+    if (sym && sym->algorithm != TPM_ALG_NULL) {
+        innerWrap = 1;
+    }
+
+    /* IV: Generate or use 0 */
+    XMEMSET(&ivField, 0, sizeof(ivField));
+    if (useIv) {
+        /* Encode IV into private buffer */
+        XMEMSET(&packet, 0, sizeof(packet));
+        packet.buf = &priv->buffer[integritySz];
+        packet.size = sizeof(priv->buffer) - integritySz;
+        TPM2_Packet_AppendU16(&packet, ivField.size);
+        TPM2_Packet_AppendBytes(&packet, ivField.buffer, ivField.size);
+        ivSz = packet.pos;
     }
 
     /* Encode sensitive into private buffer */
     XMEMSET(&packet, 0, sizeof(packet));
-    packet.buf = &priv->buffer[pos];
-    packet.size = sizeof(priv->buffer) - pos;
+    packet.buf = &priv->buffer[integritySz + ivSz];
+    packet.size = sizeof(priv->buffer) - (integritySz + ivSz);
     TPM2_Packet_AppendSensitive(&packet, sens);
-    priv->size = packet.pos;
-    /* Calculate the size of the sensitive area for later use */
-    sensSz = packet.pos - innerSz - outerSz;
+    sensSz = packet.pos;
+    priv->size = integritySz + ivSz + sensSz;
+
+    sensitiveData = &priv->buffer[integritySz];
+    sensSz = ivSz + sensSz;
 
     if (innerWrap) {
-    #if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_AES) && \
-        defined(WOLFSSL_AES_CFB)
-        Aes enc;
-        TPM2B_IV ivField;
-        TPM2B_SYM_KEY symKey;
+        /* TODO: Inner wrap support */
+    }
 
-        /* Generate IV */
-        ivField.size = digestSz;
-        rc = TPM2_GetNonce(ivField.buffer, ivField.size);
-        if (rc != 0)
-            return rc;
-
+    if (outerWrap) {
         /* Generate symmetric key for encryption of inner values */
-        symKey.size = (sym->keyBits.sym + 7) / 8; /* round up */
-        rc = TPM2_KDFa(innerAlg, (TPM2B_DATA*)&sens->sensitiveArea.seedValue,
-                  "STORAGE", (TPM2B_NONCE*)name, NULL,
-                  symKey.buffer, symKey.size);
+        symKey.size = (symKey.size + 7) / 8; /* convert to byte and round up */
+        rc = TPM2_KDFa(nameAlg, (TPM2B_DATA*)symSeed, "STORAGE", (TPM2B_NONCE*)name,
+            NULL, symKey.buffer, symKey.size);
         if (rc != symKey.size) {
         #ifdef DEBUG_WOLFTPM
             printf("KDFa STORAGE Gen Error %d\n", rc);
@@ -1684,31 +1714,25 @@ int wolfTPM2_SensitiveToPrivate(TPM2B_SENSITIVE* sens, TPM2B_PRIVATE* priv,
         rc = wc_AesInit(&enc, NULL, INVALID_DEVID);
         if (rc == 0) {
             rc = wc_AesSetKey(&enc, symKey.buffer, symKey.size,
-                              ivField.buffer, AES_ENCRYPTION);
-            /* Encryption in-place */
-            if (rc == 0)
-                rc = wc_AesCfbEncrypt(&enc, &packet.buf[innerSz],
-                    &packet.buf[innerSz], sensSz);
+                ivField.size == 0 ? NULL : ivField.buffer, AES_ENCRYPTION);
+            if (rc == 0) {
+                /* use inline encryption for both IV and sensitive */
+                rc = wc_AesCfbEncrypt(&enc, sensitiveData, sensitiveData, sensSz);
+            }
             wc_AesFree(&enc);
         }
-    #else
-        (void)innerAlg;
-        (void)sensSz;
-    #endif
-    }
+        if (rc != 0) {
+        #ifdef DEBUG_WOLFTPM
+            printf("SensitiveToPrivate AES error %d!\n", rc);
+        #endif
+            return rc;
+        }
 
-    if (outerWrap) {
-    #if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_HMAC)
-        Hmac hmac_ctx;
-        TPM2B_DIGEST hmacKey;
         /* Generate HMAC key for generation of the integrity value */
-        hmacKey.size = TPM2_GetHashDigestSize(outerAlg);
-        if (hmacKey.size == 0)
-            return TPM_RC_FAILURE;
-
-        rc = TPM2_KDFa(outerAlg, (TPM2B_DATA*)&sens->sensitiveArea.seedValue,
-                  "INTEGRITY", NULL, NULL,
-                  hmacKey.buffer, hmacKey.size);
+        hmacKey.size = digestSz;
+        rc = TPM2_KDFa(nameAlg, (TPM2B_DATA*)&sens->sensitiveArea.seedValue,
+                    "INTEGRITY", NULL, NULL,
+                    hmacKey.buffer, hmacKey.size);
         if (rc != hmacKey.size) {
         #ifdef DEBUG_WOLFTPM
             printf("KDFa INTEGRITY Gen Error %d\n", rc);
@@ -1718,37 +1742,56 @@ int wolfTPM2_SensitiveToPrivate(TPM2B_SENSITIVE* sens, TPM2B_PRIVATE* priv,
 
         /* setup HMAC */
         rc = wc_HmacInit(&hmac_ctx, NULL, INVALID_DEVID);
-        if (rc != 0)
+        if (rc == 0) {
+            /* start HMAC */
+            rc = wc_HmacSetKey(&hmac_ctx, TPM2_GetHashType(nameAlg),
+                hmacKey.buffer, hmacKey.size);
+
+            /* consume IV and sensitive area */
+            if (rc == 0)
+                rc = wc_HmacUpdate(&hmac_ctx, sensitiveData, sensSz);
+
+            /* consume name field */
+            if (rc == 0)
+                rc = wc_HmacUpdate(&hmac_ctx, name->name, name->size);
+
+            if (rc == 0)
+                rc = wc_HmacFinal(&hmac_ctx, &priv->buffer[sizeof(word16)]);
+
+            wc_HmacFree(&hmac_ctx);
+        }
+        if (rc != 0) {
+        #ifdef DEBUG_WOLFTPM
+            printf("SensitiveToPrivate HMAC error %d!\n", rc);
+        #endif
             return rc;
-        /* start HMAC */
-        rc = wc_HmacSetKey(&hmac_ctx, outerAlg, hmacKey.buffer, hmacKey.size);
+        }
 
-        /* consume IV area */
-        if (rc == 0)
-            rc = wc_HmacUpdate(&hmac_ctx, &packet.buf[outerSz], innerSz);
-        /* consume sensitive area */
-        if (rc == 0)
-            rc = wc_HmacUpdate(&hmac_ctx, &packet.buf[innerSz], sensSz);
-        /* consume name field */
-        if (rc == 0)
-            rc = wc_HmacUpdate(&hmac_ctx, name->name, name->size);
-
-        /* write result at position after Priv->size and Outer->Size field */
-        if (rc == 0)
-            rc = wc_HmacFinal(&hmac_ctx,
-                &packet.buf[sizeof(word16)+sizeof(word16)]);
-        wc_HmacFree(&hmac_ctx);
-        if (rc != 0)
-            return rc;
-
-        /* store the size of the outer integrity in the Outer->Size field */
-        hmacKey.size = TPM2_Packet_SwapU16(hmacKey.size);
-        XMEMCPY(&packet.buf[sizeof(word16)], &hmacKey.size, sizeof(word16));
-    #endif
+        /* store the size of the integrity */
+        digestSz = TPM2_Packet_SwapU16(digestSz);
+        XMEMCPY(&priv->buffer[0], &digestSz, sizeof(word16));
     }
-    (void)name;
 
+#else
+    rc = NOT_COMPILED_IN;
+    (void)sens;
+    (void)priv;
+    (void)nameAlg;
+    (void)name;
+    (void)parentKey;
+    (void)sym;
+    (void)symSeed;
+    (void)useIv;
+#endif
     return rc;
+}
+
+int wolfTPM2_SensitiveToPrivate(TPM2B_SENSITIVE* sens, TPM2B_PRIVATE* priv,
+    TPMI_ALG_HASH nameAlg, TPM2B_NAME* name, const WOLFTPM2_KEY* parentKey,
+    TPMT_SYM_DEF_OBJECT* sym, TPM2B_ENCRYPTED_SECRET* symSeed)
+{
+    return SensitiveToPrivate(sens, priv, nameAlg, name, parentKey, sym,
+        symSeed, 0);
 }
 
 /* Import external private key */
@@ -1789,9 +1832,23 @@ int wolfTPM2_ImportPrivateKey(WOLFTPM2_DEV* dev, const WOLFTPM2_KEY* parentKey,
     #endif
         return rc;
     }
+
+    /* Encrypt seed if provided */
+    if (sens->sensitiveArea.seedValue.size > 0) {
+        rc = wolfTPM2_EncryptSalt(dev, parentKey,
+            &sens->sensitiveArea.seedValue, &importIn.inSymSeed, "DUPLICATE");
+        if (rc != TPM_RC_SUCCESS) {
+        #ifdef DEBUG_WOLFTPM
+            printf("wolfTPM2_EncryptSalt: failed %d: %s\n", rc,
+                wolfTPM2_GetRCString(rc));
+        #endif
+            return rc;
+        }
+    }
+
     rc = wolfTPM2_SensitiveToPrivate(sens, &importIn.duplicate,
         pub->publicArea.nameAlg, &name, parentKey, &importIn.symmetricAlg,
-        &importIn.inSymSeed);
+        NULL);
     if (rc != TPM_RC_SUCCESS) {
     #ifdef DEBUG_WOLFTPM
         printf("wolfTPM2_SensitiveToPrivate: failed %d: %s\n", rc,
@@ -1901,10 +1958,11 @@ int wolfTPM2_LoadRsaPublicKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
         TPM_ALG_NULL, TPM_ALG_NULL);
 }
 
-int wolfTPM2_ImportRsaPrivateKey(WOLFTPM2_DEV* dev,
+int wolfTPM2_ImportRsaPrivateKeySeed(WOLFTPM2_DEV* dev,
     const WOLFTPM2_KEY* parentKey, WOLFTPM2_KEYBLOB* keyBlob, const byte* rsaPub,
     word32 rsaPubSz, word32 exponent, const byte* rsaPriv, word32 rsaPrivSz,
-    TPMI_ALG_RSA_SCHEME scheme, TPMI_ALG_HASH hashAlg)
+    TPMI_ALG_RSA_SCHEME scheme, TPMI_ALG_HASH hashAlg, TPMA_OBJECT attributes,
+    TPM2B_DIGEST* seedValue)
 {
     TPM2B_PUBLIC pub;
     TPM2B_SENSITIVE sens;
@@ -1920,15 +1978,25 @@ int wolfTPM2_ImportRsaPrivateKey(WOLFTPM2_DEV* dev,
     XMEMSET(&pub, 0, sizeof(pub));
     pub.publicArea.type = TPM_ALG_RSA;
     pub.publicArea.nameAlg = WOLFTPM2_WRAP_DIGEST;
-    pub.publicArea.objectAttributes = (TPMA_OBJECT_sign | TPMA_OBJECT_decrypt |
-        TPMA_OBJECT_userWithAuth | TPMA_OBJECT_noDA);
-    pub.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_NULL;
+    pub.publicArea.objectAttributes = attributes;
     pub.publicArea.parameters.rsaDetail.keyBits = rsaPubSz * 8;
     pub.publicArea.parameters.rsaDetail.exponent = exponent;
     pub.publicArea.parameters.rsaDetail.scheme.scheme = scheme;
     pub.publicArea.parameters.rsaDetail.scheme.details.anySig.hashAlg = hashAlg;
     pub.publicArea.unique.rsa.size = rsaPubSz;
     XMEMCPY(pub.publicArea.unique.rsa.buffer, rsaPub, rsaPubSz);
+
+    /* For fixedParent or (decrypt and restricted) enable symmetric */
+    if ((attributes & TPMA_OBJECT_fixedParent) ||
+           ((attributes & TPMA_OBJECT_decrypt) &&
+            (attributes & TPMA_OBJECT_restricted))) {
+        pub.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_AES;
+        pub.publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 128;
+        pub.publicArea.parameters.rsaDetail.symmetric.mode.aes = TPM_ALG_CFB;
+    }
+    else {
+        pub.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_NULL;
+    }
 
     /* Set up private key */
     XMEMSET(&sens, 0, sizeof(sens));
@@ -1941,7 +2009,33 @@ int wolfTPM2_ImportRsaPrivateKey(WOLFTPM2_DEV* dev,
     sens.sensitiveArea.sensitive.rsa.size = rsaPrivSz;
     XMEMCPY(sens.sensitiveArea.sensitive.rsa.buffer, rsaPriv, rsaPrivSz);
 
+    /* Use Seed */
+    if (seedValue != NULL) {
+        word32 digestSz = TPM2_GetHashDigestSize(pub.publicArea.nameAlg);
+        if (seedValue->size != digestSz) {
+        #ifdef DEBUG_WOLFTPM
+            printf("Import RSA seed size invalid! %d != %d\n",
+                seedValue->size, digestSz);
+        #endif
+            return BAD_FUNC_ARG;
+        }
+        sens.sensitiveArea.seedValue.size = seedValue->size;
+        XMEMCPY(sens.sensitiveArea.seedValue.buffer, seedValue->buffer,
+            seedValue->size);
+    }
+
     return wolfTPM2_ImportPrivateKey(dev, parentKey, keyBlob, &pub, &sens);
+}
+int wolfTPM2_ImportRsaPrivateKey(WOLFTPM2_DEV* dev,
+    const WOLFTPM2_KEY* parentKey, WOLFTPM2_KEYBLOB* keyBlob, const byte* rsaPub,
+    word32 rsaPubSz, word32 exponent, const byte* rsaPriv, word32 rsaPrivSz,
+    TPMI_ALG_RSA_SCHEME scheme, TPMI_ALG_HASH hashAlg)
+{
+    TPMA_OBJECT attributes = (TPMA_OBJECT_sign | TPMA_OBJECT_decrypt |
+        TPMA_OBJECT_userWithAuth | TPMA_OBJECT_noDA);
+    return wolfTPM2_ImportRsaPrivateKeySeed(dev, parentKey, keyBlob,
+        rsaPub, rsaPubSz, exponent, rsaPriv, rsaPrivSz, scheme, hashAlg,
+        attributes, NULL);
 }
 
 int wolfTPM2_LoadRsaPrivateKey_ex(WOLFTPM2_DEV* dev,
@@ -2007,11 +2101,12 @@ int wolfTPM2_LoadEccPublicKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key, int curveId,
     return wolfTPM2_LoadPublicKey(dev, key, &pub);
 }
 
-int wolfTPM2_ImportEccPrivateKey(WOLFTPM2_DEV* dev, const WOLFTPM2_KEY* parentKey,
+int wolfTPM2_ImportEccPrivateKeySeed(WOLFTPM2_DEV* dev, const WOLFTPM2_KEY* parentKey,
     WOLFTPM2_KEYBLOB* keyBlob, int curveId,
     const byte* eccPubX, word32 eccPubXSz,
     const byte* eccPubY, word32 eccPubYSz,
-    const byte* eccPriv, word32 eccPrivSz)
+    const byte* eccPriv, word32 eccPrivSz,
+    TPMA_OBJECT attributes, TPM2B_DIGEST* seedValue)
 {
     TPM2B_PUBLIC pub;
     TPM2B_SENSITIVE sens;
@@ -2031,8 +2126,7 @@ int wolfTPM2_ImportEccPrivateKey(WOLFTPM2_DEV* dev, const WOLFTPM2_KEY* parentKe
     XMEMSET(&pub, 0, sizeof(pub));
     pub.publicArea.type = TPM_ALG_ECC;
     pub.publicArea.nameAlg = WOLFTPM2_WRAP_DIGEST;
-    pub.publicArea.objectAttributes = TPMA_OBJECT_sign | TPMA_OBJECT_decrypt |
-        TPMA_OBJECT_userWithAuth | TPMA_OBJECT_noDA;
+    pub.publicArea.objectAttributes = attributes;
     pub.publicArea.parameters.eccDetail.symmetric.algorithm = TPM_ALG_NULL;
     pub.publicArea.parameters.eccDetail.scheme.scheme = TPM_ALG_NULL;
     pub.publicArea.parameters.eccDetail.scheme.details.ecdsa.hashAlg =
@@ -2055,7 +2149,35 @@ int wolfTPM2_ImportEccPrivateKey(WOLFTPM2_DEV* dev, const WOLFTPM2_KEY* parentKe
     sens.sensitiveArea.sensitive.ecc.size = eccPrivSz;
     XMEMCPY(sens.sensitiveArea.sensitive.ecc.buffer, eccPriv, eccPrivSz);
 
+    /* Use Seed */
+    if (seedValue != NULL) {
+        word32 digestSz = TPM2_GetHashDigestSize(pub.publicArea.nameAlg);
+        if (seedValue->size != digestSz) {
+        #ifdef DEBUG_WOLFTPM
+            printf("Import ECC seed size invalid! %d != %d\n",
+                seedValue->size, digestSz);
+        #endif
+            return BAD_FUNC_ARG;
+        }
+        sens.sensitiveArea.seedValue.size = seedValue->size;
+        XMEMCPY(sens.sensitiveArea.seedValue.buffer, seedValue->buffer,
+            seedValue->size);
+    }
+
     return wolfTPM2_ImportPrivateKey(dev, parentKey, keyBlob, &pub, &sens);
+}
+
+int wolfTPM2_ImportEccPrivateKey(WOLFTPM2_DEV* dev, const WOLFTPM2_KEY* parentKey,
+    WOLFTPM2_KEYBLOB* keyBlob, int curveId,
+    const byte* eccPubX, word32 eccPubXSz,
+    const byte* eccPubY, word32 eccPubYSz,
+    const byte* eccPriv, word32 eccPrivSz)
+{
+    TPMA_OBJECT attributes = (TPMA_OBJECT_sign | TPMA_OBJECT_decrypt |
+        TPMA_OBJECT_userWithAuth | TPMA_OBJECT_noDA);
+    return wolfTPM2_ImportEccPrivateKeySeed(dev, parentKey, keyBlob, curveId,
+        eccPubX, eccPubXSz, eccPubY, eccPubYSz, eccPriv, eccPrivSz, attributes,
+        NULL);
 }
 
 int wolfTPM2_LoadEccPrivateKey(WOLFTPM2_DEV* dev, const WOLFTPM2_KEY* parentKey,
@@ -2124,6 +2246,245 @@ int wolfTPM2_ReadPublicKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 }
 
 #ifndef WOLFTPM2_NO_WOLFCRYPT
+
+#ifndef NO_ASN
+#ifndef NO_RSA
+static int DecodeRsaPrivateDer(TPM2B_PUBLIC* pub, TPM2B_SENSITIVE* sens,
+    const byte* input, word32 inSz, TPMA_OBJECT attributes)
+{
+    int rc = 0;
+    RsaKey key[1];
+    word32 idx = 0;
+    word32 e = 0;
+    byte n[RSA_MAX_SIZE / 8];
+    byte d[RSA_MAX_SIZE / 8];
+    byte p[RSA_MAX_SIZE / 8];
+    byte q[RSA_MAX_SIZE / 8];
+    word32  eSz = (word32)sizeof(e);
+    word32  nSz = (word32)sizeof(n);
+    word32  dSz = (word32)sizeof(d);
+    word32  pSz = (word32)sizeof(p);
+    word32  qSz = (word32)sizeof(q);
+
+    XMEMSET(n, 0, sizeof(n));
+    XMEMSET(d, 0, sizeof(d));
+    XMEMSET(p, 0, sizeof(p));
+    XMEMSET(q, 0, sizeof(q));
+
+    rc = wc_InitRsaKey(key, NULL);
+    if (rc == 0) {
+        rc = wc_RsaPrivateKeyDecode(input, &idx, key, inSz);
+
+        if (rc == 0) {
+            rc = wc_RsaExportKey(key, (byte*)&e, &eSz, n, &nSz, d, &dSz,
+                p, &pSz, q, &qSz);
+        }
+        if (rc == 0 && nSz > sizeof(pub->publicArea.unique.rsa.buffer))
+            rc = BUFFER_E;
+        if (rc == 0 && qSz > sizeof(sens->sensitiveArea.sensitive.rsa.buffer))
+            rc = BUFFER_E;
+        if (rc == 0) {
+            /* Set up public key */
+            pub->publicArea.type = TPM_ALG_RSA;
+            pub->publicArea.nameAlg = WOLFTPM2_WRAP_DIGEST;
+            pub->publicArea.objectAttributes = attributes;
+            pub->publicArea.parameters.rsaDetail.keyBits = nSz * 8;
+            pub->publicArea.parameters.rsaDetail.exponent = e;
+            pub->publicArea.parameters.rsaDetail.scheme.scheme = TPM_ALG_NULL;
+            pub->publicArea.parameters.rsaDetail.scheme.details.anySig.hashAlg = TPM_ALG_NULL;
+            pub->publicArea.unique.rsa.size = nSz;
+            XMEMCPY(pub->publicArea.unique.rsa.buffer, n, nSz);
+
+            /* For fixedParent or (decrypt and restricted) enable symmetric */
+            if ((attributes & TPMA_OBJECT_fixedParent) ||
+                ((attributes & TPMA_OBJECT_decrypt) &&
+                    (attributes & TPMA_OBJECT_restricted))) {
+                pub->publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_AES;
+                pub->publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 128;
+                pub->publicArea.parameters.rsaDetail.symmetric.mode.aes = TPM_ALG_CFB;
+            }
+            else {
+                pub->publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_NULL;
+            }
+
+            /* Set up private key */
+            sens->sensitiveArea.sensitiveType = TPM_ALG_RSA;
+            sens->sensitiveArea.sensitive.rsa.size = qSz;
+            XMEMCPY(sens->sensitiveArea.sensitive.rsa.buffer, q, qSz);
+        }
+        wc_FreeRsaKey(key);
+    }
+
+    return rc;
+}
+#endif
+#ifdef HAVE_ECC
+static int DecodeEccPrivateDer(TPM2B_PUBLIC* pub, TPM2B_SENSITIVE* sens,
+    const byte* input, word32 inSz, TPMA_OBJECT attributes)
+{
+    int rc;
+    int curveId = 0;
+    word32 idx = 0;
+    ecc_key key[1];
+    byte    d[WOLFTPM2_WRAP_ECC_KEY_BITS / 8];
+    byte    qx[WOLFTPM2_WRAP_ECC_KEY_BITS / 8];
+    byte    qy[WOLFTPM2_WRAP_ECC_KEY_BITS / 8];
+    word32  dSz = sizeof(d);
+    word32  qxSz = sizeof(qx);
+    word32  qySz = sizeof(qy);
+
+    XMEMSET(d, 0, sizeof(d));
+    XMEMSET(qx, 0, sizeof(qx));
+    XMEMSET(qy, 0, sizeof(qy));
+
+    rc = wc_ecc_init(key);
+    if (rc == 0) {
+        rc = wc_EccPrivateKeyDecode(input, &idx, key, inSz);
+        if (rc == 0) {
+            curveId = TPM2_GetTpmCurve(key->dp->id);
+
+            rc = wc_ecc_export_private_raw(key, qx, &qxSz, qy, &qySz, d, &dSz);
+        }
+        if (rc == 0 && qxSz > sizeof(pub->publicArea.unique.ecc.x.buffer))
+            rc = BUFFER_E;
+        if (rc == 0 && qySz > sizeof(pub->publicArea.unique.ecc.y.buffer))
+            rc = BUFFER_E;
+        if (rc == 0 && dSz > sizeof(sens->sensitiveArea.sensitive.ecc.buffer))
+            rc = BUFFER_E;
+        if (rc == 0) {
+            /* Set up public key */
+            pub->publicArea.type = TPM_ALG_ECC;
+            pub->publicArea.nameAlg = WOLFTPM2_WRAP_DIGEST;
+            pub->publicArea.objectAttributes = attributes;
+            pub->publicArea.parameters.eccDetail.symmetric.algorithm = TPM_ALG_NULL;
+            pub->publicArea.parameters.eccDetail.scheme.scheme = TPM_ALG_NULL;
+            pub->publicArea.parameters.eccDetail.scheme.details.ecdsa.hashAlg =
+                WOLFTPM2_WRAP_DIGEST;
+            pub->publicArea.parameters.eccDetail.curveID = curveId;
+            pub->publicArea.parameters.eccDetail.kdf.scheme = TPM_ALG_NULL;
+            pub->publicArea.unique.ecc.x.size = qxSz;
+            XMEMCPY(pub->publicArea.unique.ecc.x.buffer, qx, qxSz);
+            pub->publicArea.unique.ecc.y.size = qySz;
+            XMEMCPY(pub->publicArea.unique.ecc.y.buffer, qy, qySz);
+
+            /* For fixedParent or (decrypt and restricted) enable symmetric */
+            if ((attributes & TPMA_OBJECT_fixedParent) ||
+                ((attributes & TPMA_OBJECT_decrypt) &&
+                    (attributes & TPMA_OBJECT_restricted))) {
+                pub->publicArea.parameters.eccDetail.symmetric.algorithm = TPM_ALG_AES;
+                pub->publicArea.parameters.eccDetail.symmetric.keyBits.aes = 128;
+                pub->publicArea.parameters.eccDetail.symmetric.mode.aes = TPM_ALG_CFB;
+            }
+            else {
+                pub->publicArea.parameters.eccDetail.symmetric.algorithm = TPM_ALG_NULL;
+            }
+
+            /* Set up private key */
+            sens->sensitiveArea.sensitiveType = TPM_ALG_ECC;
+            sens->sensitiveArea.sensitive.ecc.size = dSz;
+            XMEMCPY(sens->sensitiveArea.sensitive.ecc.buffer, d, dSz);
+        }
+
+        wc_ecc_free(key);
+    }
+
+    return rc;
+}
+#endif /* HAVE_ECC */
+
+int wolfTPM2_ImportPrivateKeyBuffer(WOLFTPM2_DEV* dev,
+    const WOLFTPM2_KEY* parentKey, int keyType, WOLFTPM2_KEYBLOB* keyBlob,
+    int encodingType, const char* buf, word32 bufSz, char* pass,
+    TPMA_OBJECT attributes, TPM2B_DIGEST* seedValue)
+{
+    int rc = 0;
+    byte* derBuf;
+    word32 derSz;
+    TPM2B_PUBLIC pub;
+    TPM2B_SENSITIVE sens;
+
+    if (dev == NULL || parentKey == NULL || keyBlob == NULL || buf == NULL ||
+            bufSz == 0) {
+        return BAD_FUNC_ARG;
+    }
+
+    XMEMSET(&pub, 0, sizeof(pub));
+    XMEMSET(&sens, 0, sizeof(sens));
+
+    if (encodingType == ENCODING_TYPE_PEM) {
+    #if !defined(WOLFTPM2_NO_HEAP) && defined(WOLFSSL_PEM_TO_DER)
+        /* der size is base 64 decode length */
+        derSz = bufSz * 3 / 4 + 1;
+        derBuf = (byte*)XMALLOC(derSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (derBuf == NULL)
+            return MEMORY_E;
+        rc = wc_KeyPemToDer((byte*)buf, bufSz, derBuf, derSz, pass);
+        if (rc >= 0) {
+            derSz = rc;
+            rc = 0;
+        }
+    #else
+        return NOT_COMPILED_IN;
+    #endif
+    }
+    else {
+        derBuf = (byte*)buf;
+        derSz = bufSz;
+    }
+
+    /* Handle DER Import */
+    if (keyType == TPM_ALG_RSA) {
+    #ifndef NO_RSA
+        rc = DecodeRsaPrivateDer(&pub, &sens, derBuf, derSz, attributes);
+    #else
+        rc = NOT_COMPILED_IN;
+    #endif
+    }
+    else if (keyType == TPM_ALG_ECC) {
+    #ifdef HAVE_ECC
+        rc = DecodeEccPrivateDer(&pub, &sens, derBuf, derSz, attributes);
+    #else
+        rc = NOT_COMPILED_IN;
+    #endif
+    }
+
+    if (rc == 0) {
+        /* Set up private key */
+        if (keyBlob->handle.auth.size > 0) {
+            sens.sensitiveArea.authValue.size = keyBlob->handle.auth.size;
+            XMEMCPY(sens.sensitiveArea.authValue.buffer, keyBlob->handle.auth.buffer,
+                keyBlob->handle.auth.size);
+        }
+
+        /* Use Seed */
+        if (seedValue != NULL) {
+            word32 digestSz = TPM2_GetHashDigestSize(pub.publicArea.nameAlg);
+            if (seedValue->size != digestSz) {
+            #ifdef DEBUG_WOLFTPM
+                printf("Import RSA seed size invalid! %d != %d\n",
+                    seedValue->size, digestSz);
+            #endif
+                return BAD_FUNC_ARG;
+            }
+            sens.sensitiveArea.seedValue.size = seedValue->size;
+            XMEMCPY(sens.sensitiveArea.seedValue.buffer, seedValue->buffer,
+                seedValue->size);
+        }
+
+        /* Import Private Key */
+        rc = wolfTPM2_ImportPrivateKey(dev, parentKey, keyBlob, &pub, &sens);
+    }
+
+#if !defined(WOLFTPM2_NO_HEAP) && defined(WOLFSSL_PEM_TO_DER)
+    if (derBuf != (byte*)buf) {
+        XFREE(derBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+#endif
+
+    return rc;
+}
+#endif /* !NO_ASN */
+
 #ifndef NO_RSA
 #ifndef NO_ASN
 int wolfTPM2_RsaPrivateKeyImportDer(WOLFTPM2_DEV* dev,
@@ -2180,40 +2541,14 @@ int wolfTPM2_RsaPrivateKeyImportPem(WOLFTPM2_DEV* dev,
     const char* input, word32 inSz, char* pass,
     TPMI_ALG_RSA_SCHEME scheme, TPMI_ALG_HASH hashAlg)
 {
-    int rc = 0;
-    byte* derBuf;
-    word32 derSz;
-
-    if (dev == NULL || parentKey == NULL || keyBlob == NULL || input == NULL ||
-            inSz == 0) {
-        return BAD_FUNC_ARG;
-    }
-
-    /* der size is base 64 decode length */
-    derSz = inSz * 3 / 4 + 1;
-
-    derBuf = (byte*)XMALLOC(derSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (derBuf == NULL)
-        return MEMORY_E;
-
-    rc = wc_KeyPemToDer((byte*)input, inSz, derBuf, derSz, pass);
-
-    /* returns the number of bytes */
-    if (rc > 0) {
-        rc = wolfTPM2_RsaPrivateKeyImportDer(dev, parentKey, keyBlob, derBuf,
-            (word32)rc, scheme, hashAlg);
-    }
-    /* shouldn't be possible to have a 0 length der, check anyways */
-    else if (rc == 0) {
-        rc = BAD_FUNC_ARG;
-    }
-
-    XFREE(derBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-
-    return rc;
+    (void)scheme;
+    (void)hashAlg;
+    return wolfTPM2_ImportPrivateKeyBuffer(dev, parentKey, TPM_ALG_RSA, keyBlob,
+        ENCODING_TYPE_PEM, input, inSz, pass, 0, NULL);
 }
 
 #endif /* !WOLFTPM2_NO_HEAP && WOLFSSL_PEM_TO_DER */
+
 
 int wolfTPM2_RsaKey_TpmToWolf(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
     RsaKey* wolfKey)

--- a/wolftpm/tpm2_packet.h
+++ b/wolftpm/tpm2_packet.h
@@ -96,6 +96,7 @@ WOLFTPM_LOCAL void TPM2_Packet_AppendSensitive(TPM2_Packet* packet, TPM2B_SENSIT
 WOLFTPM_LOCAL void TPM2_Packet_AppendSensitiveCreate(TPM2_Packet* packet, TPM2B_SENSITIVE_CREATE* sensitive);
 WOLFTPM_LOCAL void TPM2_Packet_AppendPublicParms(TPM2_Packet* packet, TPMI_ALG_PUBLIC type, TPMU_PUBLIC_PARMS* parameters);
 WOLFTPM_LOCAL void TPM2_Packet_ParsePublicParms(TPM2_Packet* packet, TPMI_ALG_PUBLIC type, TPMU_PUBLIC_PARMS* parameters);
+WOLFTPM_LOCAL void TPM2_Packet_AppendPublicArea(TPM2_Packet* packet, TPMT_PUBLIC* publicArea);
 WOLFTPM_LOCAL void TPM2_Packet_AppendPublic(TPM2_Packet* packet, TPM2B_PUBLIC* pub);
 WOLFTPM_LOCAL void TPM2_Packet_ParsePublic(TPM2_Packet* packet, TPM2B_PUBLIC* pub);
 WOLFTPM_LOCAL void TPM2_Packet_AppendSignature(TPM2_Packet* packet, TPMT_SIGNATURE* sig);

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -116,6 +116,10 @@ typedef int64_t  INT64;
         /* The wc_HashFree was added in v3.15.4, so use stub to allow building */
         #define wc_HashFree(h, t) (0)
     #endif
+
+    #define ENCODING_TYPE_PEM  1 /* CTC_FILETYPE_PEM */
+    #define ENCODING_TYPE_ASN1 2 /* CTC_FILETYPE_ASN1 */
+
 #else
 
     #include <stdio.h>
@@ -139,6 +143,9 @@ typedef int64_t  INT64;
 
     /* Errors from wolfssl/error-ssl.h */
     #define SOCKET_ERROR_E        -308  /* error state on socket    */
+
+    #define ENCODING_TYPE_PEM  CTC_FILETYPE_PEM
+    #define ENCODING_TYPE_ASN1 CTC_FILETYPE_ASN1
 
 #ifndef WOLFTPM_CUSTOM_TYPES
     #ifndef WOLFTPM2_NO_HEAP

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -1117,6 +1117,29 @@ WOLFTPM_API int wolfTPM2_SensitiveToPrivate(TPM2B_SENSITIVE* sens, TPM2B_PRIVATE
     TPMT_SYM_DEF_OBJECT* sym, TPM2B_ENCRYPTED_SECRET* symSeed);
 
 #ifndef WOLFTPM2_NO_WOLFCRYPT
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Helper function to import PEM/DER or RSA/ECC private key
+
+    \return TPM_RC_SUCCESS: successful
+    \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a TPM2_DEV struct
+    \param parentKey pointer to a WOLFTPM2_KEY struct, pointing to a Primary Key or TPM Hierarchy
+    \param keyBlob pointer to a struct of WOLFTPM2_KEYBLOB type, to import the rsa key to
+    \param encodingType ENCODING_TYPE_PEM or ENCODING_TYPE_ASN1 (DER)
+    \param input buffer holding the rsa pem
+    \param inSz length of the input pem buffer
+    \param pass optional password of the key
+    \param objectAttributes integer value of TPMA_OBJECT type, can contain one or more attributes, e.g. TPMA_OBJECT_fixedTPM
+    \param seedValue Optional (use NULL) or supply a custom seed for KDF (use 32 bytes for SHA2-256)
+*/
+WOLFTPM_API int wolfTPM2_ImportPrivateKeyBuffer(WOLFTPM2_DEV* dev,
+    const WOLFTPM2_KEY* parentKey, int keyType, WOLFTPM2_KEYBLOB* keyBlob,
+    int encodingType, const char* input, word32 inSz, char* pass,
+    TPMA_OBJECT objectAttributes, TPM2B_DIGEST* seedValue);
+
 #ifndef NO_RSA
 /*!
     \ingroup wolfTPM2_Wrappers
@@ -1159,29 +1182,6 @@ WOLFTPM_API int wolfTPM2_RsaPrivateKeyImportPem(WOLFTPM2_DEV* dev,
     const WOLFTPM2_KEY* parentKey, WOLFTPM2_KEYBLOB* keyBlob,
     const char* input, word32 inSz, char* pass,
     TPMI_ALG_RSA_SCHEME scheme, TPMI_ALG_HASH hashAlg);
-
-/*!
-    \ingroup wolfTPM2_Wrappers
-    \brief Helper function to import PEM/DER or RSA/ECC private key
-
-    \return TPM_RC_SUCCESS: successful
-    \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)
-    \return BAD_FUNC_ARG: check the provided arguments
-
-    \param dev pointer to a TPM2_DEV struct
-    \param parentKey pointer to a WOLFTPM2_KEY struct, pointing to a Primary Key or TPM Hierarchy
-    \param keyBlob pointer to a struct of WOLFTPM2_KEYBLOB type, to import the rsa key to
-    \param encodingType ENCODING_TYPE_PEM or ENCODING_TYPE_ASN1 (DER)
-    \param input buffer holding the rsa pem
-    \param inSz length of the input pem buffer
-    \param pass optional password of the key
-    \param objectAttributes integer value of TPMA_OBJECT type, can contain one or more attributes, e.g. TPMA_OBJECT_fixedTPM
-    \param seedValue Optional (use NULL) or supply a custom seed for KDF (use 32 bytes for SHA2-256)
-*/
-WOLFTPM_API int wolfTPM2_ImportPrivateKeyBuffer(WOLFTPM2_DEV* dev,
-    const WOLFTPM2_KEY* parentKey, int keyType, WOLFTPM2_KEYBLOB* keyBlob,
-    int encodingType, const char* input, word32 inSz, char* pass,
-    TPMA_OBJECT objectAttributes, TPM2B_DIGEST* seedValue);
 
 /*!
     \ingroup wolfTPM2_Wrappers
@@ -1278,7 +1278,8 @@ WOLFTPM_API int wolfTPM2_RsaKey_WolfToTpm_ex(WOLFTPM2_DEV* dev,
 */
 WOLFTPM_API int wolfTPM2_RsaKey_PubPemToTpm(WOLFTPM2_DEV* dev,
     WOLFTPM2_KEY* tpmKey, const byte* pem, word32 pemSz);
-#endif
+#endif /* !NO_RSA */
+
 #ifdef HAVE_ECC
 /*!
     \ingroup wolfTPM2_Wrappers
@@ -1353,8 +1354,8 @@ WOLFTPM_API int wolfTPM2_EccKey_WolfToTpm_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* pa
 */
 WOLFTPM_API int wolfTPM2_EccKey_WolfToPubPoint(WOLFTPM2_DEV* dev, ecc_key* wolfKey,
     TPM2B_ECC_POINT* pubPoint);
-#endif
-#endif
+#endif /* HAVE_ECC */
+#endif /* !WOLFTPM2_NO_WOLFCRYPT */
 
 /*!
     \ingroup wolfTPM2_Wrappers

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -792,6 +792,13 @@ WOLFTPM_API int wolfTPM2_ImportRsaPrivateKey(WOLFTPM2_DEV* dev,
     const byte* rsaPriv, word32 rsaPrivSz,
     TPMI_ALG_RSA_SCHEME scheme, TPMI_ALG_HASH hashAlg);
 
+WOLFTPM_API int wolfTPM2_ImportRsaPrivateKeySeed(WOLFTPM2_DEV* dev,
+    const WOLFTPM2_KEY* parentKey, WOLFTPM2_KEYBLOB* keyBlob,
+    const byte* rsaPub, word32 rsaPubSz, word32 exponent,
+    const byte* rsaPriv, word32 rsaPrivSz,
+    TPMI_ALG_RSA_SCHEME scheme, TPMI_ALG_HASH hashAlg,
+    TPMA_OBJECT attributes, TPM2B_DIGEST* seedValue);
+
 /*!
     \ingroup wolfTPM2_Wrappers
     \brief Helper function to import and load an external RSA private key in one step
@@ -899,10 +906,17 @@ WOLFTPM_API int wolfTPM2_LoadEccPublicKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     \sa wolfTPM2_LoadPrivateKey
 */
 WOLFTPM_API int wolfTPM2_ImportEccPrivateKey(WOLFTPM2_DEV* dev,
-    const WOLFTPM2_KEY* parentKey, WOLFTPM2_KEYBLOB* keyBlob,
-    int curveId, const byte* eccPubX, word32 eccPubXSz,
+    const WOLFTPM2_KEY* parentKey, WOLFTPM2_KEYBLOB* keyBlob, int curveId,
+    const byte* eccPubX, word32 eccPubXSz,
     const byte* eccPubY, word32 eccPubYSz,
     const byte* eccPriv, word32 eccPrivSz);
+
+WOLFTPM_API int wolfTPM2_ImportEccPrivateKeySeed(WOLFTPM2_DEV* dev,
+    const WOLFTPM2_KEY* parentKey, WOLFTPM2_KEYBLOB* keyBlob, int curveId,
+    const byte* eccPubX, word32 eccPubXSz,
+    const byte* eccPubY, word32 eccPubYSz,
+    const byte* eccPriv, word32 eccPrivSz,
+    TPMA_OBJECT attributes, TPM2B_DIGEST* seedValue);
 
 /*!
     \ingroup wolfTPM2_Wrappers
@@ -1092,6 +1106,13 @@ WOLFTPM_API int wolfTPM2_RsaPrivateKeyImportPem(WOLFTPM2_DEV* dev,
     const WOLFTPM2_KEY* parentKey, WOLFTPM2_KEYBLOB* keyBlob,
     const char* input, word32 inSz, char* pass,
     TPMI_ALG_RSA_SCHEME scheme, TPMI_ALG_HASH hashAlg);
+
+
+WOLFTPM_API int wolfTPM2_ImportPrivateKeyBuffer(WOLFTPM2_DEV* dev,
+    const WOLFTPM2_KEY* parentKey, int keyType, WOLFTPM2_KEYBLOB* keyBlob,
+    int encodingType, const char* buf, word32 bufSz, char* pass,
+    TPMA_OBJECT attributes, TPM2B_DIGEST* seedValue);
+
 
 /*!
     \ingroup wolfTPM2_Wrappers
@@ -2598,11 +2619,10 @@ WOLFTPM_API int wolfTPM2_CSR_Generate(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 #define wolfTPM2_GetRCString  TPM2_GetRCString
 #define wolfTPM2_GetCurveSize TPM2_GetCurveSize
 
-/* for salted auth sessions */
-WOLFTPM_LOCAL int wolfTPM2_RSA_Salt(struct WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
-    TPM2B_DIGEST *salt, TPM2B_ENCRYPTED_SECRET *encSalt, TPMT_PUBLIC *publicArea);
-WOLFTPM_LOCAL int wolfTPM2_EncryptSalt(struct WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
-    StartAuthSession_In* in, TPM2B_AUTH* bindAuth, TPM2B_DIGEST* salt);
+/* for encrypting salt used in auth sessions and external key import */
+WOLFTPM_LOCAL int wolfTPM2_EncryptSalt(WOLFTPM2_DEV* dev, const WOLFTPM2_KEY* tpmKey,
+    const TPM2B_DIGEST* salt, TPM2B_ENCRYPTED_SECRET *encSalt,
+    const char* label);
 
 
 #ifdef WOLFTPM_CRYPTOCB

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -812,7 +812,8 @@ WOLFTPM_API int wolfTPM2_ImportRsaPrivateKey(WOLFTPM2_DEV* dev,
     \param rsaPrivSz integer value of word32 type, specifying the private material buffer size
     \param scheme value of TPMI_ALG_RSA_SCHEME type, specifying the RSA scheme
     \param hashAlg integer value of TPMI_ALG_HASH type, specifying a supported TPM 2.0 hash algorithm
-    \param seedValue Optional (use NULL) or supply a custom seed for KDF (use 32 bytes for SHA2-256)
+    \param seedSz Optional (use NULL) or supply a custom seed for KDF
+    \param seed Size of the seed (use 32 bytes for SHA2-256)
 
     \sa wolfTPM2_ImportRsaPrivateKey
     \sa wolfTPM2_LoadRsaPrivateKey
@@ -824,7 +825,7 @@ WOLFTPM_API int wolfTPM2_ImportRsaPrivateKeySeed(WOLFTPM2_DEV* dev,
     const byte* rsaPub, word32 rsaPubSz, word32 exponent,
     const byte* rsaPriv, word32 rsaPrivSz,
     TPMI_ALG_RSA_SCHEME scheme, TPMI_ALG_HASH hashAlg,
-    TPMA_OBJECT attributes, TPM2B_DIGEST* seedValue);
+    TPMA_OBJECT attributes, byte* seed, word32 seedSz);
 
 /*!
     \ingroup wolfTPM2_Wrappers
@@ -957,7 +958,8 @@ WOLFTPM_API int wolfTPM2_ImportEccPrivateKey(WOLFTPM2_DEV* dev,
     \param eccPubYSz integer value of word32 type, specifying the point Y buffer size
     \param eccPriv pointer to a byte buffer containing the private material
     \param eccPrivSz integer value of word32 type, specifying the private material size
-    \param seedValue Optional (use NULL) or supply a custom seed for KDF (use 32 bytes for SHA2-256)
+    \param seedSz Optional (use NULL) or supply a custom seed for KDF
+    \param seed Size of the seed (use 32 bytes for SHA2-256)
 
     \sa wolfTPM2_ImportEccPrivateKey
     \sa wolfTPM2_LoadEccPrivateKey
@@ -969,7 +971,7 @@ WOLFTPM_API int wolfTPM2_ImportEccPrivateKeySeed(WOLFTPM2_DEV* dev,
     const byte* eccPubX, word32 eccPubXSz,
     const byte* eccPubY, word32 eccPubYSz,
     const byte* eccPriv, word32 eccPrivSz,
-    TPMA_OBJECT attributes, TPM2B_DIGEST* seedValue);
+    TPMA_OBJECT attributes, byte* seed, word32 seedSz);
 
 /*!
     \ingroup wolfTPM2_Wrappers
@@ -1133,12 +1135,13 @@ WOLFTPM_API int wolfTPM2_SensitiveToPrivate(TPM2B_SENSITIVE* sens, TPM2B_PRIVATE
     \param inSz length of the input pem buffer
     \param pass optional password of the key
     \param objectAttributes integer value of TPMA_OBJECT type, can contain one or more attributes, e.g. TPMA_OBJECT_fixedTPM
-    \param seedValue Optional (use NULL) or supply a custom seed for KDF (use 32 bytes for SHA2-256)
+    \param seedSz Optional (use NULL) or supply a custom seed for KDF
+    \param seed Size of the seed (use 32 bytes for SHA2-256)
 */
 WOLFTPM_API int wolfTPM2_ImportPrivateKeyBuffer(WOLFTPM2_DEV* dev,
     const WOLFTPM2_KEY* parentKey, int keyType, WOLFTPM2_KEYBLOB* keyBlob,
     int encodingType, const char* input, word32 inSz, char* pass,
-    TPMA_OBJECT objectAttributes, TPM2B_DIGEST* seedValue);
+    TPMA_OBJECT objectAttributes, byte* seed, word32 seedSz);
 
 #ifndef NO_RSA
 /*!

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -782,6 +782,7 @@ WOLFTPM_API int wolfTPM2_LoadRsaPublicKey_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* ke
     \param scheme value of TPMI_ALG_RSA_SCHEME type, specifying the RSA scheme
     \param hashAlg integer value of TPMI_ALG_HASH type, specifying a supported TPM 2.0 hash algorithm
 
+    \sa wolfTPM2_ImportRsaPrivateKeySeed
     \sa wolfTPM2_LoadRsaPrivateKey
     \sa wolfTPM2_LoadRsaPrivateKey_ex
     \sa wolfTPM2_LoadPrivateKey
@@ -792,6 +793,32 @@ WOLFTPM_API int wolfTPM2_ImportRsaPrivateKey(WOLFTPM2_DEV* dev,
     const byte* rsaPriv, word32 rsaPrivSz,
     TPMI_ALG_RSA_SCHEME scheme, TPMI_ALG_HASH hashAlg);
 
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Import an external RSA private key with custom seed
+
+    \return TPM_RC_SUCCESS: successful
+    \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)
+    \return BAD_FUNC_ARG: check the provided arguments
+    \return BUFFER_E: arguments size is larger than what the TPM buffers allow
+
+    \param dev pointer to a TPM2_DEV struct
+    \param parentKey pointer to a struct of WOLFTPM2_HANDLE type (can be NULL for external keys and the key will be imported under the OWNER hierarchy)
+    \param keyBlob pointer to an empty struct of WOLFTPM2_KEYBLOB type
+    \param rsaPub pointer to a byte buffer, containing the public part of the RSA key
+    \param rsaPubSz integer value of word32 type, specifying the public part buffer size
+    \param exponent integer value of word32 type, specifying the RSA exponent
+    \param rsaPriv pointer to a byte buffer, containing the private material of the RSA key
+    \param rsaPrivSz integer value of word32 type, specifying the private material buffer size
+    \param scheme value of TPMI_ALG_RSA_SCHEME type, specifying the RSA scheme
+    \param hashAlg integer value of TPMI_ALG_HASH type, specifying a supported TPM 2.0 hash algorithm
+    \param seedValue Optional (use NULL) or supply a custom seed for KDF (use 32 bytes for SHA2-256)
+
+    \sa wolfTPM2_ImportRsaPrivateKey
+    \sa wolfTPM2_LoadRsaPrivateKey
+    \sa wolfTPM2_LoadRsaPrivateKey_ex
+    \sa wolfTPM2_LoadPrivateKey
+*/
 WOLFTPM_API int wolfTPM2_ImportRsaPrivateKeySeed(WOLFTPM2_DEV* dev,
     const WOLFTPM2_KEY* parentKey, WOLFTPM2_KEYBLOB* keyBlob,
     const byte* rsaPub, word32 rsaPubSz, word32 exponent,
@@ -901,6 +928,7 @@ WOLFTPM_API int wolfTPM2_LoadEccPublicKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     \param eccPriv pointer to a byte buffer containing the private material
     \param eccPrivSz integer value of word32 type, specifying the private material size
 
+    \sa wolfTPM2_ImportEccPrivateKeySeed
     \sa wolfTPM2_LoadEccPrivateKey
     \sa wolfTPM2_LoadEccPrivateKey_ex
     \sa wolfTPM2_LoadPrivateKey
@@ -911,6 +939,31 @@ WOLFTPM_API int wolfTPM2_ImportEccPrivateKey(WOLFTPM2_DEV* dev,
     const byte* eccPubY, word32 eccPubYSz,
     const byte* eccPriv, word32 eccPrivSz);
 
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Helper function to import the private material of an external ECC key
+
+    \return TPM_RC_SUCCESS: successful
+    \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a TPM2_DEV struct
+    \param parentKey pointer to a struct of WOLFTPM2_HANDLE type (can be NULL for external keys and the key will be imported under the OWNER hierarchy)
+    \param keyBlob pointer to an empty struct of WOLFTPM2_KEYBLOB type
+    \param curveId integer value, one of the accepted TPM_ECC_CURVE values
+    \param eccPubX pointer to a byte buffer containing the public material of point X
+    \param eccPubXSz integer value of word32 type, specifying the point X buffer size
+    \param eccPubY pointer to a byte buffer containing the public material of point Y
+    \param eccPubYSz integer value of word32 type, specifying the point Y buffer size
+    \param eccPriv pointer to a byte buffer containing the private material
+    \param eccPrivSz integer value of word32 type, specifying the private material size
+    \param seedValue Optional (use NULL) or supply a custom seed for KDF (use 32 bytes for SHA2-256)
+
+    \sa wolfTPM2_ImportEccPrivateKey
+    \sa wolfTPM2_LoadEccPrivateKey
+    \sa wolfTPM2_LoadEccPrivateKey_ex
+    \sa wolfTPM2_LoadPrivateKey
+*/
 WOLFTPM_API int wolfTPM2_ImportEccPrivateKeySeed(WOLFTPM2_DEV* dev,
     const WOLFTPM2_KEY* parentKey, WOLFTPM2_KEYBLOB* keyBlob, int curveId,
     const byte* eccPubX, word32 eccPubXSz,
@@ -1107,12 +1160,28 @@ WOLFTPM_API int wolfTPM2_RsaPrivateKeyImportPem(WOLFTPM2_DEV* dev,
     const char* input, word32 inSz, char* pass,
     TPMI_ALG_RSA_SCHEME scheme, TPMI_ALG_HASH hashAlg);
 
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Helper function to import PEM/DER or RSA/ECC private key
 
+    \return TPM_RC_SUCCESS: successful
+    \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a TPM2_DEV struct
+    \param parentKey pointer to a WOLFTPM2_KEY struct, pointing to a Primary Key or TPM Hierarchy
+    \param keyBlob pointer to a struct of WOLFTPM2_KEYBLOB type, to import the rsa key to
+    \param encodingType ENCODING_TYPE_PEM or ENCODING_TYPE_ASN1 (DER)
+    \param input buffer holding the rsa pem
+    \param inSz length of the input pem buffer
+    \param pass optional password of the key
+    \param objectAttributes integer value of TPMA_OBJECT type, can contain one or more attributes, e.g. TPMA_OBJECT_fixedTPM
+    \param seedValue Optional (use NULL) or supply a custom seed for KDF (use 32 bytes for SHA2-256)
+*/
 WOLFTPM_API int wolfTPM2_ImportPrivateKeyBuffer(WOLFTPM2_DEV* dev,
     const WOLFTPM2_KEY* parentKey, int keyType, WOLFTPM2_KEYBLOB* keyBlob,
-    int encodingType, const char* buf, word32 bufSz, char* pass,
-    TPMA_OBJECT attributes, TPM2B_DIGEST* seedValue);
-
+    int encodingType, const char* input, word32 inSz, char* pass,
+    TPMA_OBJECT objectAttributes, TPM2B_DIGEST* seedValue);
 
 /*!
     \ingroup wolfTPM2_Wrappers


### PR DESCRIPTION
* Fix for import of private key with seed. 
* Added new API `wolfTPM2_ImportPrivateKeyBuffer` for importing private key ECC/RSA in either PEM or DER(ASN.1). 

ZD 16249