### PR TITLE
Handle unknown `TPM2_GetCapability` type and fix bad printf

### DIFF
--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -891,7 +891,6 @@ TPM_RC TPM2_GetCapability(GetCapability_In* in, GetCapability_Out* out)
                     printf("Unknown capability type 0x%x\n",
                         (unsigned int)out->capabilityData.capability);
             #endif
-                    rc = -1;
                     break;
             }
         }

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -1266,7 +1266,7 @@ int wolfTPM2_EncryptSecret(WOLFTPM2_DEV* dev, const WOLFTPM2_KEY* tpmKey,
     }
 
 #ifdef WOLFTPM_DEBUG_VERBOSE
-    printf("Encrypt Secret %d: %d bytes\n", data->size);
+    printf("Encrypt Secret %d: %d bytes\n", rc, data->size);
     TPM2_PrintBin(data->buffer, data->size);
 #endif
 #endif /* !WOLFTPM2_NO_WOLFCRYPT */


### PR DESCRIPTION
Fixed bad printf. Don't error on unknown `TPM2_GetCapability` type.