### PR TITLE
Seal with RSA fix, PCR extend auth and improvements to NVRAM examples

### DIFF
--- a/examples/boot/secure_rot.c
+++ b/examples/boot/secure_rot.c
@@ -44,8 +44,7 @@ static void usage(void)
 {
     printf("Expected usage:\n");
     printf("./examples/boot/secure_rot [-nvindex] [-write=/-hash=] [-authhex=/-authstr=] [-sha384] [-lock]\n");
-    printf("* -nvindex=[handle] (default 0x%x)\n",
-        TPM2_DEMO_NV_SECURE_ROT_INDEX);
+    printf("* -nvindex=[handle] (default 0x%x)\n", TPM2_DEMO_NV_SECURE_ROT_INDEX);
     printf("* -hash=hash: Hex string digest to write\n");
     printf("* -write=filename: DER formatted public key to write\n");
     printf("* -authstr=password/-authhex=hexstring: Optional password for NV\n");

--- a/examples/keygen/keygen.c
+++ b/examples/keygen/keygen.c
@@ -202,7 +202,7 @@ int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[])
         else if (XSTRNCMP(argv[argc-1], "-unique=", XSTRLEN("-unique=")) == 0) {
             uniqueStr = argv[argc-1] + XSTRLEN("-unique=");
         }
-        else {
+        else if (argv[argc-1][0] == '-') {
             printf("Warning: Unrecognized option: %s\n", argv[argc-1]);
         }
 

--- a/examples/keygen/keyimport.c
+++ b/examples/keygen/keyimport.c
@@ -110,7 +110,7 @@ int TPM2_Keyimport_Example(void* userCtx, int argc, char *argv[])
         else if (XSTRNCMP(argv[argc-1], "-key=", XSTRLEN("-key=")) == 0) {
             impFile = (const char*)(argv[argc-1] + XSTRLEN("-key="));
         }
-        else {
+        else if (argv[argc-1][0] == '-') {
             printf("Warning: Unrecognized option: %s\n", argv[argc-1]);
         }
 

--- a/examples/seal/seal.c
+++ b/examples/seal/seal.c
@@ -82,7 +82,7 @@ int TPM2_Seal_Example(void* userCtx, int argc, char *argv[])
         else if (XSTRCMP(argv[argc-1], "-xor") == 0) {
             paramEncAlg = TPM_ALG_XOR;
         }
-        else {
+        else if (argv[argc-1][0] == '-') {
             printf("Warning: Unrecognized option: %s\n", argv[argc-1]);
         }
         argc--;

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -5587,7 +5587,6 @@ void TPM2_SetupPCRSelArray(TPML_PCR_SELECTION* pcr, TPM_ALG_ID alg,
     byte* pcrArray, word32 pcrArraySz)
 {
     int i;
-
     for (i = 0; i < (int)pcrArraySz; i++) {
         TPM2_SetupPCRSel(pcr, alg, (int)pcrArray[i]);
     }

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -2156,7 +2156,8 @@ int wolfTPM2_LoadRsaPublicKey_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 
     XMEMSET(&pub, 0, sizeof(pub));
     pub.publicArea.type = TPM_ALG_RSA;
-    pub.publicArea.nameAlg = TPM_ALG_NULL;
+    /* make sure nameAlg is set for ticket */
+    pub.publicArea.nameAlg = WOLFTPM2_WRAP_DIGEST;
     pub.publicArea.objectAttributes = (TPMA_OBJECT_sign | TPMA_OBJECT_decrypt |
         TPMA_OBJECT_userWithAuth | TPMA_OBJECT_noDA | TPMA_OBJECT_stClear);
     pub.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_NULL;
@@ -2311,6 +2312,7 @@ int wolfTPM2_LoadEccPublicKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key, int curveId,
 
     XMEMSET(&pub, 0, sizeof(pub));
     pub.publicArea.type = TPM_ALG_ECC;
+    /* make sure nameAlg is set for ticket */
     pub.publicArea.nameAlg = WOLFTPM2_WRAP_DIGEST;
     pub.publicArea.objectAttributes = TPMA_OBJECT_sign | TPMA_OBJECT_noDA;
     pub.publicArea.parameters.eccDetail.symmetric.algorithm = TPM_ALG_NULL;

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -3890,6 +3890,7 @@ int wolfTPM2_ResetPCR(WOLFTPM2_DEV* dev, int pcrIndex)
     return rc;
 }
 
+/* TODO: Version that can read up to 8 PCR's at a time */
 int wolfTPM2_ReadPCR(WOLFTPM2_DEV* dev, int pcrIndex, int hashAlg, byte* digest,
     int* pDigestLen)
 {
@@ -3940,6 +3941,11 @@ int wolfTPM2_ExtendPCR(WOLFTPM2_DEV* dev, int pcrIndex, int hashAlg,
 
     if (dev == NULL || digestLen > TPM_MAX_DIGEST_SIZE) {
         return BAD_FUNC_ARG;
+    }
+
+    /* set session auth to blank */
+    if (dev->ctx.session) {
+        wolfTPM2_SetAuthPassword(dev, 0, NULL);
     }
 
     XMEMSET(&pcrExtend, 0, sizeof(pcrExtend));


### PR DESCRIPTION
* Fix for sealing with RSA (the nameAlg must be set).
* Make sure PCR extend has the session auth cleared. 
* Added -nvhandle argument to nvram examples.