### PR TITLE
Improvements/fixes to NV auth and session auth set/unset

### DIFF
--- a/examples/boot/secure_rot.c
+++ b/examples/boot/secure_rot.c
@@ -228,6 +228,7 @@ int TPM2_Boot_SecureROT_Example(void* userCtx, int argc, char *argv[])
                 printf("Warning: NV Index 0x%x already exists!\n", nvIndex);
                 rc = 0;
             }
+            wolfTPM2_SetAuthHandle(&dev, 0, &nv.handle);
         }
         if (rc == 0) {
             /* Write digest to NV */

--- a/examples/gpio/gpio_config.c
+++ b/examples/gpio/gpio_config.c
@@ -240,6 +240,7 @@ int TPM2_GPIO_Config_Example(void* userCtx, int argc, char *argv[])
         printf("Creating NV Index for GPIO acccess failed\n");
         goto exit;
     }
+    wolfTPM2_SetAuthHandle(&dev, 0, &nv.handle);
     printf("NV Index for GPIO access created\n");
 
     /* GPIO configured as an input, requires an extra configuration step */
@@ -413,9 +414,10 @@ int TPM2_GPIO_Config_Example(void* userCtx, int argc, char *argv[])
     rc = wolfTPM2_NVCreateAuth(&dev, &parent, &nv, nvIndex, nvAttributes,
                                sizeof(BYTE), (byte*)gNvAuth, sizeof(gNvAuth)-1);
     if (rc != 0 && rc != TPM_RC_NV_DEFINED) {
-        printf("Creating NV Index for GPIO acccess failed\n");
+        printf("Creating NV Index for GPIO access failed\n");
         goto exit;
     }
+    wolfTPM2_SetAuthHandle(&dev, 0, &nv.handle);
     printf("NV Index for GPIO access created\n");
 
     (void)gpioInput; /* not used */

--- a/examples/nvram/counter.c
+++ b/examples/nvram/counter.c
@@ -156,6 +156,8 @@ int TPM2_NVRAM_Counter_Example(void* userCtx, int argc, char *argv[])
             nvAttributes, 8, (byte*)gNvAuth, sizeof(gNvAuth)-1);
         if (rc != 0) goto exit;
 
+        wolfTPM2_SetAuthHandle(&dev, 0, &nv.handle);
+
         rc = wolfTPM2_NVReadPublic(&dev, nvIndex, &nvPublic);
     }
     if (rc != TPM_RC_SUCCESS) {

--- a/examples/nvram/policy_nv.c
+++ b/examples/nvram/policy_nv.c
@@ -186,6 +186,8 @@ int TPM2_NVRAM_PolicyNV_Example(void* userCtx, int argc, char *argv[])
         nvAttributes, (word32)bufLen, auth.buffer, auth.size);
     if (rc != 0 && rc != TPM_RC_NV_DEFINED) goto exit;
 
+    wolfTPM2_SetAuthHandle(&dev, 0, &nv.handle);
+
     printf("Storing data at TPM NV index 0x%x with password protection\n\n",
         nvIndex);
 

--- a/examples/nvram/read.c
+++ b/examples/nvram/read.c
@@ -216,6 +216,10 @@ int TPM2_NVRAM_Read_Example(void* userCtx, int argc, char *argv[])
         printf("Successfully read private key part from NV\n\n");
     }
 
+    /* auth 0 is owner, no auth */
+    wolfTPM2_SetAuthPassword(&dev, 0, NULL);
+    wolfTPM2_UnsetAuth(&dev, 1);
+
     parent.hndl = authHandle;
     rc = wolfTPM2_NVDeleteAuth(&dev, &parent, nvIndex);
     if (rc != 0) goto exit;

--- a/examples/nvram/store.c
+++ b/examples/nvram/store.c
@@ -169,6 +169,8 @@ int TPM2_NVRAM_Store_Example(void* userCtx, int argc, char *argv[])
         nvAttributes, TPM2_DEMO_NV_TEST_SIZE, (byte*)gNvAuth, sizeof(gNvAuth)-1);
     if (rc != 0 && rc != TPM_RC_NV_DEFINED) goto exit;
 
+    wolfTPM2_SetAuthHandle(&dev, 0, &nv.handle);
+
     printf("Storing key at TPM NV index 0x%x with password protection\n\n",
              nvIndex);
 

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -710,6 +710,8 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
             nvAttributes, TPM2_DEMO_NV_TEST_SIZE, (byte*)gNvAuth, sizeof(gNvAuth)-1);
         if (rc != 0 && rc != TPM_RC_NV_DEFINED) goto exit;
 
+        wolfTPM2_SetAuthHandle(&dev, 0, &nv.handle);
+
         message.size = TPM2_DEMO_NV_TEST_SIZE; /* test message 0x11,0x11,etc */
         XMEMSET(message.buffer, 0x11, message.size);
         rc = wolfTPM2_NVWriteAuth(&dev, &nv, TPM2_DEMO_NV_TEST_AUTH_INDEX,

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -369,6 +369,25 @@ WOLFTPM_API int wolfTPM2_UnsetAuth(WOLFTPM2_DEV* dev, int index);
 
 /*!
     \ingroup wolfTPM2_Wrappers
+    \brief Clears one of the TPM Authorization session slots, pointed by its index
+    number and saves the nonce from the TPM so the session can continue to be used
+    again with wolfTPM2_SetAuthSession
+
+    \return TPM_RC_SUCCESS: successful
+    \return TPM_RC_FAILURE: unable to get lock on the TPM2 Context
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a TPM2_DEV struct
+    \param index integer value, specifying the TPM Authorization slot, between zero and three
+    \param session pointer to a WOLFTPM2_SESSION struct used with wolfTPM2_StartSession and wolfTPM2_SetAuthSession
+
+    \sa wolfTPM2_StartSession
+    \sa wolfTPM2_SetAuthSession
+*/
+WOLFTPM_API int wolfTPM2_UnsetAuthSession(WOLFTPM2_DEV* dev, int index, WOLFTPM2_SESSION* session);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
     \brief Sets a TPM Authorization slot using the provided index, session handle, attributes and auth
     \note It is recommended to use one of the other wolfTPM2 wrappers, like wolfTPM2_SetAuthPassword.
     Because the wolfTPM2_SetAuth wrapper provides complete control over the TPM Authorization slot for


### PR DESCRIPTION
* Fix bug with NV name after first write (only appears when using HMAC session).
* Add new API `wolfTPM2_UnsetAuthSession` to unset auth index for a session and save off the nonce from the TPM. This allows auth to be unset/set again with the same session.
* Cleanup in the NV API's for unsetting of the auth to be handled by caller, not in API.