### PR TITLE
Fixes to avoid struct assignment and C++ build fixes

### DIFF
--- a/examples/boot/secret_seal.c
+++ b/examples/boot/secret_seal.c
@@ -108,7 +108,7 @@ int TPM2_Boot_SecretSeal_Example(void* userCtx, int argc, char *argv[])
     TPM_ALG_ID paramEncAlg = TPM_ALG_CFB;
     TPM_ALG_ID alg = TPM_ALG_RSA, srkAlg;
     TPM_ALG_ID pcrAlg = USE_PCR_ALG;
-    TPMT_PUBLIC template;
+    TPMT_PUBLIC sealTemplate;
     byte secret[MAX_SYM_DATA+1]; /* for NULL term */
     word32 secretSz = 0;
     const char* publicKeyFile = NULL;
@@ -264,11 +264,11 @@ int TPM2_Boot_SecretSeal_Example(void* userCtx, int argc, char *argv[])
     printHexString(policyDigest, policyDigestSz, policyDigestSz);
 
     /* Create a new key for sealing using signing auth for external key */
-    wolfTPM2_GetKeyTemplate_KeySeal(&template, pcrAlg);
-    template.authPolicy.size = policyDigestSz;
-    XMEMCPY(template.authPolicy.buffer, policyDigest, policyDigestSz);
+    wolfTPM2_GetKeyTemplate_KeySeal(&sealTemplate, pcrAlg);
+    sealTemplate.authPolicy.size = policyDigestSz;
+    XMEMCPY(sealTemplate.authPolicy.buffer, policyDigest, policyDigestSz);
     rc = wolfTPM2_CreateKeySeal_ex(&dev, &sealBlob, &storage.handle,
-        &template, NULL, 0, pcrAlg, NULL, 0, secret, secretSz);
+        &sealTemplate, NULL, 0, pcrAlg, NULL, 0, secret, secretSz);
     if (rc != 0) goto exit;
     printf("Sealed keyed hash (pub %d, priv %d bytes):\n",
         sealBlob.pub.size, sealBlob.priv.size);

--- a/examples/pcr/policy_sign.c
+++ b/examples/pcr/policy_sign.c
@@ -141,7 +141,9 @@ static int PolicySign(TPM_ALG_ID alg, const char* keyFile, const char* password,
             }
             if (rc == 0) {
                 /* ASN.1 encode hash */
-                int oid = wc_HashGetOID(TPM2_GetHashType(hashAlg));
+                int oid;
+                oid = TPM2_GetHashType(hashAlg);
+                oid = wc_HashGetOID((enum wc_HashType)oid);
                 rc = wc_EncodeSignature(encHash, hash, hashSz, oid);
                 if (rc > 0) {
                     hashSz = rc;

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -980,7 +980,8 @@ static int TPM2_KDFe(
     UINT32           keySz        /* IN: size of generated key in bytes */
 )
 {
-    int ret, hashType;
+    int ret;
+    enum wc_HashType hashType;
     wc_HashAlg hash_ctx;
     word32 counter = 0;
     int hLen, copyLen, lLen = 0;
@@ -992,9 +993,10 @@ static int TPM2_KDFe(
     if (key == NULL || Z == NULL)
         return BAD_FUNC_ARG;
 
-    hashType = TPM2_GetHashType(hashAlg);
-    if (hashType == WC_HASH_TYPE_NONE)
+    ret = TPM2_GetHashType(hashAlg);
+    if (ret == WC_HASH_TYPE_NONE)
         return NOT_COMPILED_IN;
+    hashType = (enum wc_HashType)ret;
 
     hLen = TPM2_GetHashDigestSize(hashAlg);
     if ( (hLen <= 0) || (hLen > WC_MAX_DIGEST_SIZE))

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -5955,14 +5955,18 @@ static void wolfTPM2_CopyPubT(TPMT_PUBLIC* out, const TPMT_PUBLIC* in)
             &in->parameters.eccDetail.symmetric);
         out->parameters.eccDetail.scheme.scheme =
             in->parameters.eccDetail.scheme.scheme;
-        if (out->parameters.eccDetail.scheme.scheme != TPM_ALG_NULL)
+        if (out->parameters.eccDetail.scheme.scheme != TPM_ALG_NULL) {
             out->parameters.eccDetail.scheme.details.any.hashAlg =
                 in->parameters.eccDetail.scheme.details.any.hashAlg;
+        }
         out->parameters.eccDetail.curveID =
             in->parameters.eccDetail.curveID;
-        out->parameters.eccDetail.kdf =
-            in->parameters.eccDetail.kdf;
-
+        out->parameters.eccDetail.kdf.scheme =
+            in->parameters.eccDetail.kdf.scheme;
+        if (out->parameters.eccDetail.kdf.scheme != TPM_ALG_NULL) {
+            out->parameters.eccDetail.kdf.details.any.hashAlg =
+                in->parameters.eccDetail.kdf.details.any.hashAlg;
+        }
         wolfTPM2_CopyEccParam(&out->unique.ecc.x,
             &in->unique.ecc.x);
         wolfTPM2_CopyEccParam(&out->unique.ecc.y,

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -870,7 +870,8 @@ int wolfTPM2_SetAuthSession(WOLFTPM2_DEV* dev, int index,
 
         /* define the symmetric algorithm */
         session->authHash = tpmSession->authHash;
-        session->symmetric = tpmSession->handle.symmetric;
+        XMEMCPY(&session->symmetric, &tpmSession->handle.symmetric,
+            sizeof(TPMT_SYM_DEF));
 
         /* fresh nonce generated in TPM2_CommandProcess based on this size */
         session->nonceCaller.size = TPM2_GetHashDigestSize(WOLFTPM2_WRAP_DIGEST);

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -440,7 +440,7 @@ static void test_wolfTPM2_PCRPolicy(void)
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 int secondRunner = 0;
 
-static void test_wolfTPM2_thread_local_storage_work_thread(void* args)
+static void* test_wolfTPM2_thread_local_storage_work_thread(void* args)
 {
     TPM2_CTX tpm2Ctx;
 
@@ -466,6 +466,7 @@ static void test_wolfTPM2_thread_local_storage_work_thread(void* args)
     pthread_mutex_unlock(&mutex);
 
     (void)args;
+    return NULL;
 }
 #endif /* HAVE_THREAD_LS && HAVE_PTHREAD */
 
@@ -476,9 +477,9 @@ static void test_wolfTPM2_thread_local_storage(void)
     pthread_t thread_2;
 
     pthread_create(&thread_1, NULL,
-        (void*)&test_wolfTPM2_thread_local_storage_work_thread, NULL);
+        test_wolfTPM2_thread_local_storage_work_thread, NULL);
     pthread_create(&thread_2, NULL,
-        (void*)&test_wolfTPM2_thread_local_storage_work_thread, NULL);
+        test_wolfTPM2_thread_local_storage_work_thread, NULL);
 
     pthread_join(thread_1, NULL);
     pthread_join(thread_2, NULL);


### PR DESCRIPTION
Which can result is unaligned access (use memcpy). ZD 16788
Also fixes for building with C++.