### PR TITLE
Fixes and improvements for wolfTPM CSR wrappers

### DIFF
--- a/.github/workflows/make-test-swtpm.yml
+++ b/.github/workflows/make-test-swtpm.yml
@@ -52,6 +52,25 @@ jobs:
       run: |
         make check
         WOLFSSL_PATH=./wolfssl ./examples/run_examples.sh
+    - name: make install
+      run: sudo make install
+
+# build and test CSharp wrapper
+    - name: Install mono
+      run: |
+        sudo apt-get install -y mono-mcs mono-tools-devel nunit nunit-console
+    - name: Build CSharp wrapper
+      working-directory: ./wrapper/CSharp
+      run: |
+        mcs wolfTPM.cs wolfTPM-tests.cs -r:/usr/lib/cli/nunit.framework-2.6.3/nunit.framework.dll -t:library
+    - name: Run self test
+      working-directory: ./wrapper/CSharp
+      run: |
+        LD_LIBRARY_PATH=../../src/.libs/:../../wolfssl/src/.libs/ nunit-console wolfTPM.dll -run=tpm_csharp_test.WolfTPMTest.TrySelfTest
+    - name: Run unit tests
+      working-directory: ./wrapper/CSharp
+      run: |
+        LD_LIBRARY_PATH=../../src/.libs/:../../wolfssl/src/.libs/ nunit-console wolfTPM.dll
 
 #test no wolfcrypt
     - name: configure no wolfCrypt

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -6335,6 +6335,10 @@ int wolfTPM2_CSR_SetKeyUsage(WOLFTPM2_DEV* dev, WOLFTPM2_CSR* csr,
 
     /* add Extended Key Usage */
     rc = wc_SetExtKeyUsage(&csr->req, keyUsage);
+    if (rc == EXTKEYUSAGE_E) {
+        /* try setting key usage values */
+        rc = wc_SetKeyUsage(&csr->req, keyUsage);
+    }
 #else
     if (keyUsage != NULL) {
     #ifdef DEBUG_WOLFTPM

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -6247,7 +6247,7 @@ static int CSR_KeySetup(WOLFTPM2_DEV* dev, WOLFTPM2_CSR* csr, WOLFTPM2_KEY* key,
                 csr->req.sigType = CTC_SHA256wECDSA;
             }
         }
-        else if (csr->req.sigType == 0) {
+        else if (sigType != 0) {
             csr->req.sigType = sigType;
         }
     }

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -2670,7 +2670,10 @@ WOLFTPM_API int wolfTPM2_CSR_SetCustomExt(WOLFTPM2_DEV* dev, WOLFTPM2_CSR* csr,
 /*!
     \ingroup wolfTPM2_Wrappers
     \brief Helper for Certificate Signing Request (CSR) generation to set a
-        key usage for a WOLFTPM2_CSR structure.
+        extended key usage or key usage for a WOLFTPM2_CSR structure.
+        Pass either extended key usage or key usage values.
+        Mixed string types are not supported, however you can call `wolfTPM2_CSR_SetKeyUsage`
+        twice (once for extended key usage strings and once for standard key usage strings).
 
     \return TPM_RC_SUCCESS: successful
     \return BAD_FUNC_ARG: check the provided arguments
@@ -2678,7 +2681,8 @@ WOLFTPM_API int wolfTPM2_CSR_SetCustomExt(WOLFTPM2_DEV* dev, WOLFTPM2_CSR* csr,
     \param dev pointer to a TPM2_DEV struct (not used)
     \param csr pointer to a WOLFTPM2_CSR structure
     \param keyUsage string list of comma separated key usage attributes.
-        Possible values: any, serverAuth, clientAuth, codeSigning, emailProtection, timeStamping and OCSPSigning
+        Possible Extended Key Usage values: any, serverAuth, clientAuth, codeSigning, emailProtection, timeStamping and OCSPSigning
+        Possible Key Usage values: digitalSignature, nonRepudiation, contentCommitment, keyEncipherment, dataEncipherment, keyAgreement, keyCertSign, cRLSign, encipherOnly, decipherOnly
         Default: "serverAuth,clientAuth,codeSigning"
 
     \sa wolfTPM2_CSR_SetSubject


### PR DESCRIPTION
* Fix for trying to use a custom wolfTPM CSR `sigType`. The `csr->req.sigType` was being initialized to CTC_SHA256wRSA, and not allowing override.
* Add wrapper support for setting key usage (not just extended key usage).
* Fix support for ECC 384-bit only support. Tested with: `./configure --enable-wolftpm CFLAGS="-DECC_USER_CURVES -DNO_ECC256 -DHAVE_ECC384" --disable-examples --disable-crypttests && make`
* Add CI tests for CSharp wrappers.