### PR TITLE
Remove error-ssl.h

### DIFF
--- a/examples/tpm_test_keys.c
+++ b/examples/tpm_test_keys.c
@@ -458,7 +458,7 @@ int loadFile(const char* fname, byte** buf, size_t* bufLen)
         #endif
         }
         else if (*buf != NULL && fileSz > (ssize_t)*bufLen) {
-            ret = INPUT_SIZE_E;
+            ret = BUFFER_E;
         }
         *bufLen = (size_t)fileSz;
         if (ret == 0) {

--- a/src/tpm2_swtpm.c
+++ b/src/tpm2_swtpm.c
@@ -64,7 +64,7 @@ static TPM_RC SwTpmTransmit(TPM2_CTX* ctx, const void* buffer, ssize_t bufSz)
 
     wrc = write(ctx->tcpCtx.fd, buffer, bufSz);
     if (bufSz != wrc) {
-        rc = SOCKET_ERROR_E;
+        rc = TPM_RC_FAILURE;
     }
 
 #ifdef WOLFTPM_DEBUG_VERBOSE
@@ -100,7 +100,7 @@ static TPM_RC SwTpmReceive(TPM2_CTX* ctx, void* buffer, size_t rxSz)
                        " = %s\n", ctx->tcpCtx.fd, errno, strerror(errno));
             }
             #endif
-            rc = SOCKET_ERROR_E;
+            rc = TPM_RC_FAILURE;
             break;
         }
 
@@ -118,7 +118,7 @@ static TPM_RC SwTpmReceive(TPM2_CTX* ctx, void* buffer, size_t rxSz)
 
 static TPM_RC SwTpmConnect(TPM2_CTX* ctx, const char* host, const char* port)
 {
-    TPM_RC rc = SOCKET_ERROR_E;
+    TPM_RC rc = TPM_RC_FAILURE;
     struct addrinfo hints;
     struct addrinfo *result, *rp;
     int s;
@@ -183,7 +183,7 @@ static TPM_RC SwTpmDisconnect(TPM2_CTX* ctx)
     #endif
 
     if (0 != close(ctx->tcpCtx.fd)) {
-        rc = SOCKET_ERROR_E;
+        rc = TPM_RC_FAILURE;
 
         #ifdef WOLFTPM_DEBUG_VERBOSE
         printf("Failed to close fd %d, got errno %d ="
@@ -198,7 +198,6 @@ static TPM_RC SwTpmDisconnect(TPM2_CTX* ctx)
 
 /* Talk to a TPM through socket
  * return TPM_RC_SUCCESS on success,
- *        SOCKET_ERROR_E on socket errors,
  *        TPM_RC_FAILURE on other errors
  */
 int TPM2_SWTPM_SendCommand(TPM2_CTX* ctx, TPM2_Packet* packet)
@@ -251,7 +250,7 @@ int TPM2_SWTPM_SendCommand(TPM2_CTX* ctx, TPM2_Packet* packet)
             printf("Response size(%d) larger than command buffer(%d)\n",
                    rspSz, packet->pos);
             #endif
-            rc = SOCKET_ERROR_E;
+            rc = TPM_RC_FAILURE;
         }
     }
 

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -6489,7 +6489,7 @@ int wolfTPM2_GetPolicyDigest(WOLFTPM2_DEV* dev, TPM_HANDLE sessionHandle,
             rc = LENGTH_ONLY_E;
         }
         else if (policyGetDigestOut->policyDigest.size > *policyDigestSz) {
-            rc = INPUT_SIZE_E;
+            rc = BUFFER_E;
         }
         else {
             XMEMCPY(policyDigest, policyGetDigestOut->policyDigest.buffer,

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -96,7 +96,6 @@ typedef int64_t  INT64;
     #include <wolfssl/wolfcrypt/types.h>
     #include <wolfssl/wolfcrypt/logging.h>
     #include <wolfssl/wolfcrypt/error-crypt.h>
-    #include <wolfssl/error-ssl.h>
     #include <wolfssl/wolfcrypt/hash.h>
     #include <wolfssl/wolfcrypt/rsa.h>
     #include <wolfssl/wolfcrypt/ecc.h>
@@ -151,10 +150,6 @@ typedef int64_t  INT64;
     #define BAD_FUNC_ARG          -173  /* Bad function argument provided */
     #define NOT_COMPILED_IN       -174  /* Feature not compiled in */
     #define LENGTH_ONLY_E         -202  /* Returning output length only */
-    #define INPUT_SIZE_E          -412  /* input size too big error */
-
-    /* Errors from wolfssl/error-ssl.h */
-    #define SOCKET_ERROR_E        -308  /* error state on socket    */
 
     #define ENCODING_TYPE_PEM  CTC_FILETYPE_PEM
     #define ENCODING_TYPE_ASN1 CTC_FILETYPE_ASN1


### PR DESCRIPTION
This PR removes the inclusion and utilization of error-ssl.h errors.




