### PR TITLE
Adding error fix for Jenkins Test: nightly-wolfTPM-examples-V2

### DIFF
--- a/certs/certreq.sh
+++ b/certs/certreq.sh
@@ -7,6 +7,7 @@ echo Run ./examples/csr/csr first to generate the CSR
 # Make sure required CA files exist and are populated
 rm -f ./certs/index.*
 touch ./certs/index.txt
+touch ./certs/index.txt.attr
 if [ ! -f ./certs/serial ]; then
 	echo 3650 > ./certs/serial
 fi


### PR DESCRIPTION
This pr is meant to fix the error that happens for our internal jenkins test: nightly-wolfTPM-examples-V2

All that is needed is the existence of index.txt.attr file.

test 1814 runs without this file being added
test 1815 runs to succession with this file being added