### PR TITLE
Add TPM crypto callback support for RSA key generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Mfg NTC (0), Vendor NPCT75x"!!4rls, Fw 7.2 (131072), FIPS 140-2 1, CC-EAL4 0
 git clone https://github.com/wolfSSL/wolfssl.git
 cd wolfssl
 ./autogen.sh
-./configure --enable-certgen --enable-certreq --enable-certext --enable-pkcs7 --enable-cryptocb --enable-aescfb
+./configure --enable-wolftpm
 make
 sudo make install
 sudo ldconfig

--- a/examples/pcr/policy_sign.c
+++ b/examples/pcr/policy_sign.c
@@ -109,7 +109,7 @@ static int PolicySign(TPM_ALG_ID alg, const char* keyFile, const char* password,
     if (rc == 0) {
         /* handle PEM conversion to DER */
         if (encType == ENCODING_TYPE_PEM) {
-        #if !defined(WOLFTPM2_NO_HEAP) && defined(WOLFSSL_PEM_TO_DER)
+        #ifdef WOLFTPM2_PEM_DECODE
             /* der size is base 64 decode length */
             word32 derSz = (word32)bufSz * 3 / 4 + 1;
             byte* derBuf = (byte*)XMALLOC(derSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);

--- a/examples/pcr/policy_sign.c
+++ b/examples/pcr/policy_sign.c
@@ -185,12 +185,16 @@ static int PolicySign(TPM_ALG_ID alg, const char* keyFile, const char* password,
                     rc = wc_ecc_sign_hash_ex(hash, hashSz, &rng, &key.ecc, &r, &s);
                 }
                 if (rc == 0) {
-                    word32 keySz = key.ecc.dp->size;
-                    mp_to_unsigned_bin(&r, sig);
-                    mp_to_unsigned_bin(&s, sig + keySz);
+                    word32 keySz = key.ecc.dp->size, rSz, sSz;
+                    *sigSz = keySz * 2;
+                    XMEMSET(sig, 0, *sigSz);
+                    /* export sign r/s - zero pad to key size */
+                    rSz = mp_unsigned_bin_size(&r);
+                    mp_to_unsigned_bin(&r, &sig[keySz - rSz]);
+                    sSz = mp_unsigned_bin_size(&s);
+                    mp_to_unsigned_bin(&s, &sig[keySz + (keySz - sSz)]);
                     mp_clear(&r);
                     mp_clear(&s);
-                    *sigSz = keySz * 2;
                 }
             }
             wc_ecc_free(&key.ecc);

--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -180,13 +180,14 @@ fi
 echo -e "TLS tests"
 generate_port() { # function to produce a random port number
     if [[ "$OSTYPE" == "linux"* ]]; then
-        port=$(($(od -An -N2 /dev/urandom) % (65535-49512) + 49512))
+        port=$(($(od -An -N2 /dev/urandom) % (65535-49152) + 49152))
     elif [[ "$OSTYPE" == "darwin"* ]]; then
-        port=$(($(od -An -N2 /dev/random) % (65535-49512) + 49512))
+        port=$(($(od -An -N2 /dev/random) % (65535-49152) + 49152))
     else
         echo "Unknown OS TYPE"
         exit 1
     fi
+    echo -e "Using port $port"
     echo -e "Using port $port" >> run.out
 }
 
@@ -198,7 +199,7 @@ run_tpm_tls_client() { # Usage: run_tpm_tls_client [ecc/rsa] [tpmargs]]
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "tls server $1 $2 failed! $RESULT" && exit 1
     popd >> run.out
-    sleep 0.4
+    sleep 0.5
     ./examples/tls/tls_client -p=$port -$1 $2 2>&1 >> run.out
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "tpm tls client $1 $2 failed! $RESULT" && exit 1
@@ -211,7 +212,7 @@ run_tpm_tls_server() { # Usage: run_tpm_tls_server [ecc/rsa] [tpmargs]]
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "tpm tls server $1 $2 failed! $RESULT" && exit 1
     pushd $WOLFSSL_PATH >> run.out
-    sleep 0.4
+    sleep 0.5
     ./examples/client/client -p $port -g -A ./certs/tpm-ca-$1-cert.pem 2>&1 >> $PWD/run.out
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "tls client $1 $2 failed! $RESULT" && exit 1

--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -179,14 +179,7 @@ fi
 # TLS Tests RSA
 echo -e "TLS tests"
 generate_port() { # function to produce a random port number
-    if [[ "$OSTYPE" == "linux"* ]]; then
-        port=$(($(od -An -N2 /dev/urandom) % (65535-49152) + 49152))
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-        port=$(($(od -An -N2 /dev/random) % (65535-49152) + 49152))
-    else
-        echo "Unknown OS TYPE"
-        exit 1
-    fi
+    port=11111
     echo -e "Using port $port"
     echo -e "Using port $port" >> run.out
 }
@@ -195,11 +188,11 @@ run_tpm_tls_client() { # Usage: run_tpm_tls_client [ecc/rsa] [tpmargs]]
     echo -e "TLS test (TPM as client) $1 $2"
     generate_port
     pushd $WOLFSSL_PATH >> run.out
-    ./examples/server/server -p $port -g -A ./certs/tpm-ca-$1-cert.pem 2>&1 >> $PWD/run.out &
+    ./examples/server/server -p $port -w -g -A ./certs/tpm-ca-$1-cert.pem 2>&1 >> $PWD/run.out &
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "tls server $1 $2 failed! $RESULT" && exit 1
     popd >> run.out
-    sleep 0.5
+    sleep 0.1
     ./examples/tls/tls_client -p=$port -$1 $2 2>&1 >> run.out
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "tpm tls client $1 $2 failed! $RESULT" && exit 1
@@ -208,12 +201,14 @@ run_tpm_tls_client() { # Usage: run_tpm_tls_client [ecc/rsa] [tpmargs]]
 run_tpm_tls_server() { # Usage: run_tpm_tls_server [ecc/rsa] [tpmargs]]
     echo -e "TLS test (TPM as server) $1 $2"
     generate_port
+
     ./examples/tls/tls_server -p=$port -$1 $2 2>&1 >> run.out &
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "tpm tls server $1 $2 failed! $RESULT" && exit 1
     pushd $WOLFSSL_PATH >> run.out
-    sleep 0.5
-    ./examples/client/client -p $port -g -A ./certs/tpm-ca-$1-cert.pem 2>&1 >> $PWD/run.out
+    sleep 0.1
+
+    ./examples/client/client -p $port -w -g -A ./certs/tpm-ca-$1-cert.pem 2>&1 >> $PWD/run.out
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "tls client $1 $2 failed! $RESULT" && exit 1
     popd >> run.out

--- a/examples/tls/tls_common.h
+++ b/examples/tls/tls_common.h
@@ -237,12 +237,14 @@ static inline int SetupSocketAndListen(SockIoCbCtx* sockIoCtx, word32 port)
         printf("setsockopt SO_REUSEADDR failed\n");
         return -1;
     }
+#ifdef SO_REUSEPORT
     optval = 1;
     if (setsockopt(sockIoCtx->listenFd, SOL_SOCKET, SO_REUSEPORT,
                    (void*)&optval, sizeof(optval)) == -1) {
         printf("setsockopt SO_REUSEPORT failed\n");
         return -1;
     }
+#endif
 
     /* Connect to the server */
     if (bind(sockIoCtx->listenFd, (struct sockaddr*)&servAddr,

--- a/examples/tls/tls_common.h
+++ b/examples/tls/tls_common.h
@@ -209,7 +209,7 @@ static inline int SockIOSend(WOLFSSL* ssl, char* buff, int sz, void* ctx)
 static inline int SetupSocketAndListen(SockIoCbCtx* sockIoCtx, word32 port)
 {
     struct sockaddr_in servAddr;
-    int optval  = 1;
+    int optval;
 
 #ifdef _WIN32
     WSADATA wsd;
@@ -230,17 +230,24 @@ static inline int SetupSocketAndListen(SockIoCbCtx* sockIoCtx, word32 port)
         return -1;
     }
 
-    /* allow reuse */
+    /* allow reuse of port and address */
+    optval = 1;
     if (setsockopt(sockIoCtx->listenFd, SOL_SOCKET, SO_REUSEADDR,
                    (void*)&optval, sizeof(optval)) == -1) {
         printf("setsockopt SO_REUSEADDR failed\n");
+        return -1;
+    }
+    optval = 1;
+    if (setsockopt(sockIoCtx->listenFd, SOL_SOCKET, SO_REUSEPORT,
+                   (void*)&optval, sizeof(optval)) == -1) {
+        printf("setsockopt SO_REUSEPORT failed\n");
         return -1;
     }
 
     /* Connect to the server */
     if (bind(sockIoCtx->listenFd, (struct sockaddr*)&servAddr,
                                                     sizeof(servAddr)) == -1) {
-        printf("ERROR: failed to bind\n");
+        printf("ERROR: failed to bind! errno %d\n", errno);
         return -1;
     }
 

--- a/examples/tls/tls_server.c
+++ b/examples/tls/tls_server.c
@@ -137,6 +137,7 @@ int TPM2_TLS_ServerArgs(void* userCtx, int argc, char *argv[])
     XMEMSET(&storageKey, 0, sizeof(storageKey));
     XMEMSET(&sockIoCtx, 0, sizeof(sockIoCtx));
     sockIoCtx.fd = -1;
+    sockIoCtx.listenFd = -1;
     XMEMSET(&tpmCtx, 0, sizeof(tpmCtx));
 #ifndef NO_RSA
     XMEMSET(&rsaKey, 0, sizeof(rsaKey));
@@ -534,11 +535,15 @@ exit:
         printf("Failure %d (0x%x): %s\n", rc, rc, wolfTPM2_GetRCString(rc));
     }
 
-    wolfSSL_shutdown(ssl);
+    /* Bidirectional shutdown */
+    while (wolfSSL_shutdown(ssl) == SSL_SHUTDOWN_NOT_DONE) {
+        printf("Shutdown not complete\n");
+    }
 
-    CloseAndCleanupSocket(&sockIoCtx);
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
+
+    CloseAndCleanupSocket(&sockIoCtx);
 
     wolfTPM2_UnloadHandle(&dev, &storageKey.handle);
 #ifndef NO_RSA

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -2952,7 +2952,9 @@ TPM_RC TPM2_Sign(Sign_In* in, Sign_Out* out)
         TPM2_Packet_AppendBytes(&packet, in->digest.buffer, in->digest.size);
 
         TPM2_Packet_AppendU16(&packet, in->inScheme.scheme);
-        TPM2_Packet_AppendU16(&packet, in->inScheme.details.any.hashAlg);
+        if (in->inScheme.scheme != TPM_ALG_NULL) {
+            TPM2_Packet_AppendU16(&packet, in->inScheme.details.any.hashAlg);
+        }
 
         TPM2_Packet_AppendU16(&packet, in->validation.tag);
         TPM2_Packet_AppendU32(&packet, in->validation.hierarchy);

--- a/src/tpm2_cryptocb.c
+++ b/src/tpm2_cryptocb.c
@@ -164,7 +164,11 @@ int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
             int curve_id;
 
             /* Make sure an ECDH key has been set and curve is supported */
-            rc = TPM2_GetTpmCurve(info->pk.eckg.curveId);
+            curve_id = info->pk.eckg.curveId;
+            if (curve_id == 0 && info->pk.eckg.key->dp != NULL) {
+                curve_id = info->pk.eckg.key->dp->id; /* use dp */
+            }
+            rc = TPM2_GetTpmCurve(curve_id);
             if (rc < 0 || tlsCtx->ecdhKey == NULL || tlsCtx->eccKey == NULL) {
                 return exit_rc;
             }

--- a/src/tpm2_cryptocb.c
+++ b/src/tpm2_cryptocb.c
@@ -240,9 +240,15 @@ int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
                     rc = wolfTPM2_VerifyHash(tlsCtx->dev, &eccPub,
                         sigRS, rLen + sLen,
                         info->pk.eccverify.hash, info->pk.eccverify.hashlen);
-
-                    if (rc == 0 && info->pk.eccverify.res) {
-                        *info->pk.eccverify.res = 1;
+                    if (info->pk.eccverify.res) {
+                        if ((rc & TPM_RC_SIGNATURE) == TPM_RC_SIGNATURE) {
+                            /* mark invalid signature */
+                            *info->pk.eccverify.res = 0;
+                            rc = 0;
+                        }
+                        else if (rc == 0) {
+                            *info->pk.eccverify.res = 1;
+                        }
                     }
 
                     wolfTPM2_UnloadHandle(tlsCtx->dev, &eccPub.handle);

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -2717,9 +2717,7 @@ int wolfTPM2_ImportPublicKeyBuffer(WOLFTPM2_DEV* dev, int keyType,
     }
 
     if (encodingType == ENCODING_TYPE_PEM) {
-    #if !defined(WOLFTPM2_NO_HEAP) && defined(WOLFSSL_PEM_TO_DER) && \
-        (defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_PUB_PEM_TO_DER)) && \
-        !defined(NO_ASN)
+    #ifdef WOLFTPM2_PEM_DECODE
         /* der size is base 64 decode length */
         derSz = inSz * 3 / 4 + 1;
         derBuf = (byte*)XMALLOC(derSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -2755,7 +2753,7 @@ int wolfTPM2_ImportPublicKeyBuffer(WOLFTPM2_DEV* dev, int keyType,
     #endif
     }
 
-#if !defined(WOLFTPM2_NO_HEAP) && defined(WOLFSSL_PEM_TO_DER)
+#ifdef WOLFTPM2_PEM_DECODE
     if (derBuf != (byte*)input) {
         XFREE(derBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     }
@@ -2785,7 +2783,7 @@ int wolfTPM2_ImportPrivateKeyBuffer(WOLFTPM2_DEV* dev,
     XMEMSET(&sens, 0, sizeof(sens));
 
     if (encodingType == ENCODING_TYPE_PEM) {
-    #if !defined(WOLFTPM2_NO_HEAP) && defined(WOLFSSL_PEM_TO_DER)
+    #ifdef WOLFTPM2_PEM_DECODE
         /* der size is base 64 decode length */
         derSz = inSz * 3 / 4 + 1;
         derBuf = (byte*)XMALLOC(derSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -2856,7 +2854,7 @@ int wolfTPM2_ImportPrivateKeyBuffer(WOLFTPM2_DEV* dev,
         rc = wolfTPM2_ImportPrivateKey(dev, parentKey, keyBlob, pub, &sens);
     }
 
-#if !defined(WOLFTPM2_NO_HEAP) && defined(WOLFSSL_PEM_TO_DER)
+#ifdef WOLFTPM2_PEM_DECODE
     if (derBuf != (byte*)input) {
         XFREE(derBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     }
@@ -2915,8 +2913,7 @@ int wolfTPM2_RsaPrivateKeyImportDer(WOLFTPM2_DEV* dev,
 }
 #endif /* !NO_ASN */
 
-#if !defined(WOLFTPM2_NO_HEAP) && defined(WOLFSSL_PEM_TO_DER)
-
+#ifdef WOLFTPM2_PEM_DECODE
 int wolfTPM2_RsaPrivateKeyImportPem(WOLFTPM2_DEV* dev,
     const WOLFTPM2_KEY* parentKey, WOLFTPM2_KEYBLOB* keyBlob,
     const char* input, word32 inSz, char* pass,
@@ -2927,8 +2924,7 @@ int wolfTPM2_RsaPrivateKeyImportPem(WOLFTPM2_DEV* dev,
     return wolfTPM2_ImportPrivateKeyBuffer(dev, parentKey, TPM_ALG_RSA, keyBlob,
         ENCODING_TYPE_PEM, input, inSz, pass, 0, NULL, 0);
 }
-
-#endif /* !WOLFTPM2_NO_HEAP && WOLFSSL_PEM_TO_DER */
+#endif /* WOLFTPM2_PEM_DECODE */
 
 
 int wolfTPM2_RsaKey_TpmToWolf(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
@@ -3097,17 +3093,14 @@ int wolfTPM2_RsaKey_PubPemToTpm(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
     const byte* pem, word32 pemSz)
 {
     int rc = TPM_RC_FAILURE;
-#if !defined(WOLFTPM2_NO_WOLFCRYPT) && defined(WOLFSSL_PEM_TO_DER) && \
-    (defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_PUB_PEM_TO_DER))
+#ifdef WOLFTPM2_PEM_DECODE
     RsaKey rsaKey;
 #endif
 
     if (dev == NULL || tpmKey == NULL || pem == NULL)
         return BAD_FUNC_ARG;
 
-#if !defined(WOLFTPM2_NO_WOLFCRYPT) && defined(WOLFSSL_PEM_TO_DER) && \
-    (defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_PUB_PEM_TO_DER)) && \
-    !defined(NO_ASN)
+#ifdef WOLFTPM2_PEM_DECODE
     /* Prepare wolfCrypt key structure */
     rc = wc_InitRsaKey(&rsaKey, NULL);
     if (rc == 0) {

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -4519,12 +4519,13 @@ int wolfTPM2_NVDelete(WOLFTPM2_DEV* dev, TPM_HANDLE authHandle,
 #ifndef WOLFTPM2_NO_WOLFCRYPT
 struct WC_RNG* wolfTPM2_GetRng(WOLFTPM2_DEV* dev)
 {
+    WC_RNG* rng = NULL;
     if (dev) {
     #ifdef WOLFTPM2_USE_WOLF_RNG
-        return &dev->ctx.rng;
+        (void)TPM2_GetWolfRng(&rng);
     #endif
     }
-    return NULL;
+    return rng;
 }
 #endif
 

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -5280,8 +5280,8 @@ int wolfTPM2_ChangePlatformAuth(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* session)
 /* --- BEGIN Utility Functions -- */
 /******************************************************************************/
 
-static int GetKeyTemplateRSA(TPMT_PUBLIC* publicTemplate,
-    TPM_ALG_ID nameAlg, TPMA_OBJECT objectAttributes, int keyBits, int exponent,
+int GetKeyTemplateRSA(TPMT_PUBLIC* publicTemplate,
+    TPM_ALG_ID nameAlg, TPMA_OBJECT objectAttributes, int keyBits, long exponent,
     TPM_ALG_ID sigScheme, TPM_ALG_ID sigHash)
 {
     if (publicTemplate == NULL)
@@ -5293,7 +5293,7 @@ static int GetKeyTemplateRSA(TPMT_PUBLIC* publicTemplate,
     publicTemplate->nameAlg = nameAlg;
     publicTemplate->objectAttributes = objectAttributes;
     publicTemplate->parameters.rsaDetail.keyBits = keyBits;
-    publicTemplate->parameters.rsaDetail.exponent = exponent;
+    publicTemplate->parameters.rsaDetail.exponent = (UINT32)exponent;
     publicTemplate->parameters.rsaDetail.scheme.scheme = sigScheme;
     publicTemplate->parameters.rsaDetail.scheme.details.anySig.hashAlg = sigHash;
     /* For fixedParent or (decrypt and restricted) enable symmetric */
@@ -5311,7 +5311,7 @@ static int GetKeyTemplateRSA(TPMT_PUBLIC* publicTemplate,
     return TPM_RC_SUCCESS;
 }
 
-static int GetKeyTemplateECC(TPMT_PUBLIC* publicTemplate,
+int GetKeyTemplateECC(TPMT_PUBLIC* publicTemplate,
     TPM_ALG_ID nameAlg, TPMA_OBJECT objectAttributes, TPM_ECC_CURVE curve,
     TPM_ALG_ID sigScheme, TPM_ALG_ID sigHash)
 {

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -999,7 +999,7 @@ static int TPM2_KDFe(
     hashType = (enum wc_HashType)ret;
 
     hLen = TPM2_GetHashDigestSize(hashAlg);
-    if ( (hLen <= 0) || (hLen > WC_MAX_DIGEST_SIZE))
+    if ((hLen <= 0) || (hLen > WC_MAX_DIGEST_SIZE))
         return NOT_COMPILED_IN;
 
     /* get label length if provided, including null termination */
@@ -1021,37 +1021,32 @@ static int TPM2_KDFe(
         TPM2_Packet_U32ToByteArray(counter, uint32Buf);
         ret = wc_HashUpdate(&hash_ctx, hashType, uint32Buf,
             (word32)sizeof(uint32Buf));
-        if (ret != 0)
-            goto exit;
-
         /* add Z */
-        ret = wc_HashUpdate(&hash_ctx, hashType, Z->buffer, Z->size);
-
+        if (ret == 0) {
+            ret = wc_HashUpdate(&hash_ctx, hashType, Z->buffer, Z->size);
+        }
         /* add label */
-        if (label != NULL) {
+        if (ret == 0 && label != NULL) {
             ret = wc_HashUpdate(&hash_ctx, hashType, (byte*)label, lLen);
-            if (ret != 0)
-                goto exit;
         }
 
         /* add partyUInfo */
-        if (partyUInfo != NULL && partyUInfo->size > 0) {
+        if (ret == 0 && partyUInfo != NULL && partyUInfo->size > 0) {
             ret = wc_HashUpdate(&hash_ctx, hashType, partyUInfo->buffer,
                 partyUInfo->size);
-            if (ret != 0)
-                goto exit;
         }
 
         /* add partyVInfo */
-        if (partyVInfo != NULL && partyVInfo->size > 0) {
+        if (ret == 0 && partyVInfo != NULL && partyVInfo->size > 0) {
             ret = wc_HashUpdate(&hash_ctx, hashType, partyVInfo->buffer,
                 partyVInfo->size);
-            if (ret != 0)
-                goto exit;
         }
 
         /* get result */
-        ret = wc_HashFinal(&hash_ctx, hashType, hash);
+        if (ret == 0) {
+            ret = wc_HashFinal(&hash_ctx, hashType, hash);
+        }
+
         if (ret != 0)
             goto exit;
 

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -328,7 +328,7 @@ static void test_wolfTPM2_CSR(void)
 #endif
 }
 
-#ifndef WOLFTPM2_NO_WOLFCRYPT
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && defined(WOLFTPM2_PEM_DECODE)
 static WOLFTPM2_KEY authKey; /* also used for test_wolfTPM2_PCRPolicy */
 
 static void test_wolfTPM_ImportPublicKey(void)
@@ -364,9 +364,7 @@ static void test_wolfTPM_ImportPublicKey(void)
         pemPublicKey, (word32)XSTRLEN(pemPublicKey),
         attributes
     );
-    if (rc != 0 && rc != NOT_COMPILED_IN) {
-        AssertIntEQ(rc, 0);
-    }
+    AssertIntEQ(rc, 0);
 
     wolfTPM2_Cleanup(&dev);
 }
@@ -435,7 +433,7 @@ static void test_wolfTPM2_PCRPolicy(void)
 
     wolfTPM2_Cleanup(&dev);
 }
-#endif /* !WOLFTPM2_NO_WOLFCRYPT */
+#endif /* !WOLFTPM2_NO_WOLFCRYPT && WOLFTPM2_PEM_DECODE */
 
 #if defined(HAVE_THREAD_LS) && defined(HAVE_PTHREAD)
 #include <pthread.h>
@@ -507,7 +505,7 @@ int unit_tests(int argc, char *argv[])
     test_TPM2_KDFa();
     test_wolfTPM2_ReadPublicKey();
     test_wolfTPM2_CSR();
-    #ifndef WOLFTPM2_NO_WOLFCRYPT
+    #if !defined(WOLFTPM2_NO_WOLFCRYPT) && defined(WOLFTPM2_PEM_DECODE)
     test_wolfTPM_ImportPublicKey();
     test_wolfTPM2_PCRPolicy();
     #endif

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -364,7 +364,9 @@ static void test_wolfTPM_ImportPublicKey(void)
         pemPublicKey, (word32)XSTRLEN(pemPublicKey),
         attributes
     );
-    AssertIntEQ(rc, 0);
+    if (rc != 0 && rc != NOT_COMPILED_IN) {
+        AssertIntEQ(rc, 0);
+    }
 
     wolfTPM2_Cleanup(&dev);
 }

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -650,6 +650,11 @@ typedef int64_t  INT64;
     #define WOLFTPM2_CERT_GEN
 #endif
 
+#if !defined(WOLFTPM2_NO_HEAP) && defined(WOLFSSL_PEM_TO_DER) && \
+    (defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_PUB_PEM_TO_DER)) && \
+    !defined(NO_ASN)
+    #define WOLFTPM2_PEM_DECODE
+#endif
 
 /* ---------------------------------------------------------------------------*/
 /* ENDIANESS HELPERS */

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -2870,6 +2870,9 @@ typedef struct TpmCryptoDevCtx {
     WOLFTPM2_DEV* dev;
 #ifndef NO_RSA
     WOLFTPM2_KEY* rsaKey;  /* RSA */
+    #ifdef WOLFSSL_KEY_GEN
+    WOLFTPM2_KEYBLOB* rsaKeyGen;  /* RSA KeyGen */
+    #endif
 #endif
 #ifdef HAVE_ECC
     WOLFTPM2_KEY* eccKey;  /* ECDSA */
@@ -3386,6 +3389,15 @@ WOLFTPM_API int wolfTPM2_PolicyPCRMake(TPM_ALG_ID pcrAlg,
 WOLFTPM_API int wolfTPM2_PolicyAuthorizeMake(TPM_ALG_ID pcrAlg,
     const TPM2B_PUBLIC* pub, byte* digest, word32* digestSz,
     const byte* policyRef, word32 policyRefSz);
+
+
+/* Internal API's */
+WOLFTPM_LOCAL int GetKeyTemplateRSA(TPMT_PUBLIC* publicTemplate,
+    TPM_ALG_ID nameAlg, TPMA_OBJECT objectAttributes, int keyBits, long exponent,
+    TPM_ALG_ID sigScheme, TPM_ALG_ID sigHash);
+WOLFTPM_LOCAL int GetKeyTemplateECC(TPMT_PUBLIC* publicTemplate,
+    TPM_ALG_ID nameAlg, TPMA_OBJECT objectAttributes, TPM_ECC_CURVE curve,
+    TPM_ALG_ID sigScheme, TPM_ALG_ID sigHash);
 
 #ifdef __cplusplus
     }  /* extern "C" */


### PR DESCRIPTION
Required for https://github.com/wolfSSL/wolfPKCS11/pull/23

* Add TPM crypto callback support for RSA key generation
* Allow import of wolf ECC marked as private only (`ECC_PRIVATEKEY_ONLY`).
* Properly translate a TPM ECC signature verify error for compatibility.
* Fixes for building wolfCrypt without PEM to DER support.
* Improve the ECC key import scheme for signing.
* Improve logic for finding TPM curve in ECC key generation. A call to wc_ecc_make_key can use curve_id 0 (to detect), but we can get it from the "dp".
* Fix to make sure leading ECC sign leading zeros are removed when not required.
* Fix leading zero issue on verify.
* Fix for ECC encrypt secret integrity check failed due to zero pad issue.
* Fix for policy_sign issue when r or s is less than key size (needs zero padding).
* Support ECC KeyGen for signing or derive based on callback context eccKey or ecdhKey population.
* Cleanup KDF function return code checking to avoid scan-build warning.