### PR TITLE
Cleanups: Match HAL IO function and inclusion of CMakeList.txt in "make dist"

### DIFF
--- a/IDE/STM32CUBE/wolftpm_test.c
+++ b/IDE/STM32CUBE/wolftpm_test.c
@@ -48,7 +48,7 @@ void wolfTPMTest(const void* argument)
     printf("Running wolfTPM Wrap Test...\n");
 
     /* Run wolfTPM wrap test */
-    ret = TPM2_Wrapper_Test(argument);
+    ret = TPM2_Wrapper_Test((void*)argument);
 
     printf("wolfTPM wrap test: Return code %d\n", ret);
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -46,6 +46,7 @@ EXTRA_DIST+= README.md
 EXTRA_DIST+= ChangeLog.md
 EXTRA_DIST+= LICENSE
 EXTRA_DIST+= autogen.sh
+EXTRA_DIST+= CMakeLists.txt
 
 TEST_EXTENSIONS=.test
 TESTS += $(check_PROGRAMS)

--- a/hal/tpm_io.c
+++ b/hal/tpm_io.c
@@ -107,8 +107,8 @@ static int TPM2_IoCb_SPI(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
 
 
 #ifdef WOLFTPM_ADV_IO
-int TPM2_IoCb(TPM2_CTX* ctx, int isRead, word32 addr, byte* buf,
-    word16 size, void* userCtx)
+int TPM2_IoCb(TPM2_CTX* ctx, INT32 isRead, UINT32 addr,
+    BYTE* buf, UINT16 size, void* userCtx)
 {
     int ret = TPM_RC_FAILURE;
 #if !defined(WOLFTPM_I2C) && !defined(WOLFTPM_MMIO)
@@ -185,8 +185,8 @@ int TPM2_IoCb(TPM2_CTX* ctx, int isRead, word32 addr, byte* buf,
 #else
 
 /* IO Callback */
-int TPM2_IoCb(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
-    word16 xferSz, void* userCtx)
+int TPM2_IoCb(TPM2_CTX* ctx, const BYTE* txBuf, BYTE* rxBuf,
+    UINT16 xferSz, void* userCtx)
 {
     int ret = TPM_RC_FAILURE;
 

--- a/hal/tpm_io.h
+++ b/hal/tpm_io.h
@@ -66,11 +66,11 @@
 #ifdef WOLFTPM_EXAMPLE_HAL
 
 #ifdef WOLFTPM_ADV_IO
-WOLFTPM_API int TPM2_IoCb(TPM2_CTX* ctx, int isRead, word32 addr, byte* buf, word16 size,
-    void* userCtx);
+WOLFTPM_API int TPM2_IoCb(TPM2_CTX* ctx, INT32 isRead, UINT32 addr,
+    BYTE* buf, UINT16 size, void* userCtx);
 #else
-WOLFTPM_API int TPM2_IoCb(TPM2_CTX* ctx, const byte* txBuf, byte* rxBuf,
-    word16 xferSz, void* userCtx);
+WOLFTPM_API int TPM2_IoCb(TPM2_CTX* ctx, const BYTE* txBuf, BYTE* rxBuf,
+    UINT16 xferSz, void* userCtx);
 #endif
 
 /* Platform support, in alphabetical order */

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -6042,7 +6042,7 @@ void TPM2_PrintAuth(const TPMS_AUTH_COMMAND* authCmd)
         return;
 
     printf("authCmd:\n");
-    printf("sessionHandle=0x%08X\n", authCmd->sessionHandle);
+    printf("sessionHandle=0x%08X\n", (unsigned int)authCmd->sessionHandle);
     printf("nonceSize=%u nonceBuffer:\n", authCmd->nonce.size);
     TPM2_PrintBin(authCmd->nonce.buffer, authCmd->nonce.size);
     printf("sessionAttributes=0x%02X\n", authCmd->sessionAttributes);
@@ -6062,7 +6062,7 @@ void TPM2_PrintPublicArea(const TPM2B_PUBLIC* pub)
     printf("  Type: %s (0x%X), name: %s (0x%X), objAttr: 0x%X, authPolicy sz: %d\n",
         TPM2_GetAlgName(pub->publicArea.type), pub->publicArea.type,
         TPM2_GetAlgName(pub->publicArea.nameAlg), pub->publicArea.nameAlg,
-        pub->publicArea.objectAttributes,
+        (unsigned int)pub->publicArea.objectAttributes,
         pub->publicArea.authPolicy.size);
     #ifdef WOLFTPM_DEBUG_VERBOSE
     TPM2_PrintBin(pub->publicArea.authPolicy.buffer, pub->publicArea.authPolicy.size);
@@ -6107,7 +6107,7 @@ void TPM2_PrintPublicArea(const TPM2B_PUBLIC* pub)
                 pub->publicArea.parameters.rsaDetail.scheme.details.anySig.hashAlg);
             printf("       keyBits: %d, exponent: 0x%X, unique size %d\n",
                 pub->publicArea.parameters.rsaDetail.keyBits,
-                pub->publicArea.parameters.rsaDetail.exponent,
+                (unsigned int)pub->publicArea.parameters.rsaDetail.exponent,
                 pub->publicArea.unique.rsa.size);
             #ifdef WOLFTPM_DEBUG_VERBOSE
             TPM2_PrintBin(pub->publicArea.unique.rsa.buffer, pub->publicArea.unique.rsa.size);


### PR DESCRIPTION
* Fix for HAL IO prototype to match (`TPM2HalIoCb` and `TPM2_IoCb`). ZD 16675
* Add CMakeList.txt to autoconf, so its in the "make dist" commercial bundles.