### PR TITLE
No locking option, compiler warnings and STM IO improvements

### DIFF
--- a/hal/tpm_io_st.c
+++ b/hal/tpm_io_st.c
@@ -145,7 +145,9 @@
     }
 
 #else /* STM32 CubeMX Hal SPI */
+    #ifndef STM32_CUBEMX_SPI_TIMEOUT
     #define STM32_CUBEMX_SPI_TIMEOUT 250
+    #endif
     #ifndef USE_SPI_CS_PORT
     #define USE_SPI_CS_PORT GPIOA
     #endif
@@ -218,6 +220,11 @@
 
         if (status == HAL_OK)
             ret = TPM_RC_SUCCESS;
+#ifdef WOLFTPM_DEBUG_VERBOSE
+        else {
+            printf("SPI Failed: Xfer %d, Status=0x%x\n", xferSz, status);
+        }
+#endif
 
         (void)ctx;
 

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -58,7 +58,7 @@ static volatile int gWolfCryptRefCount = 0;
 /******************************************************************************/
 static TPM_RC TPM2_AcquireLock(TPM2_CTX* ctx)
 {
-#if defined(WOLFTPM2_NO_WOLFCRYPT) || defined(SINGLE_THREADED)
+#if defined(WOLFTPM2_NO_WOLFCRYPT) || defined(WOLFTPM_NO_LOCK)
     (void)ctx;
 #else
     int ret;
@@ -86,7 +86,7 @@ static TPM_RC TPM2_AcquireLock(TPM2_CTX* ctx)
 
 static void TPM2_ReleaseLock(TPM2_CTX* ctx)
 {
-#if defined(WOLFTPM2_NO_WOLFCRYPT) || defined(SINGLE_THREADED)
+#if defined(WOLFTPM2_NO_WOLFCRYPT) || defined(WOLFTPM_NO_LOCK)
     (void)ctx;
 #else
     ctx->lockCount--;
@@ -143,7 +143,7 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
 
 #ifdef WOLFTPM_DEBUG_VERBOSE
     printf("CommandProcess: Handles (Auth %d, In %d), CmdSz %d, AuthSz %d, ParamSz %d, EncSz %d\n",
-        info->authCnt, info->inHandleCnt, cmdSz, authSz, paramSz, encParamSz);
+        info->authCnt, info->inHandleCnt, (int)cmdSz, (int)authSz, paramSz, encParamSz);
 #else
     (void)paramSz;
 #endif
@@ -282,7 +282,7 @@ static int TPM2_ResponseProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
 
 #ifdef WOLFTPM_DEBUG_VERBOSE
     printf("ResponseProcess: Handles (Out %d), RespSz %d, ParamSz %d, DecSz %d, AuthSz %d\n",
-        info->outHandleCnt, respSz, paramSz, decParamSz, respSz - authPos);
+        info->outHandleCnt, (int)respSz, (int)paramSz, (int)decParamSz, (int)(respSz - authPos));
 #endif
 
     for (i=0; i<info->authCnt; i++) {
@@ -662,7 +662,7 @@ TPM_RC TPM2_Cleanup(TPM2_CTX* ctx)
         wc_FreeRng(&ctx->rng);
     }
     #endif
-    #ifndef SINGLE_THREADED
+    #ifndef WOLFTPM_NO_LOCK
     if (ctx->hwLockInit) {
         ctx->hwLockInit = 0;
         wc_FreeMutex(&ctx->hwLock);

--- a/src/tpm2_param_enc.c
+++ b/src/tpm2_param_enc.c
@@ -399,7 +399,7 @@ int TPM2_CalcCpHash(TPMI_ALG_HASH authHash, TPM_CC cmdCode,
     }
 
 #ifdef WOLFTPM_DEBUG_VERBOSE
-    printf("cpHash: cmd %x, size %d\n", cmdCode, hash->size);
+    printf("cpHash: cmd %x, size %d\n", (unsigned int)cmdCode, hash->size);
     TPM2_PrintBin(hash->buffer, hash->size);
 #endif
 
@@ -448,7 +448,7 @@ int TPM2_CalcRpHash(TPMI_ALG_HASH authHash,
     }
 
 #ifdef WOLFTPM_DEBUG_VERBOSE
-    printf("rpHash: cmd %x, size %d\n", cmdCode, hash->size);
+    printf("rpHash: cmd %x, size %d\n", (unsigned int)cmdCode, hash->size);
     TPM2_PrintBin(hash->buffer, hash->size);
 #endif
 

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1710,7 +1710,7 @@ typedef struct TPM2_CTX {
     struct wolfTPM_winContext winCtx;
 #endif
 #ifndef WOLFTPM2_NO_WOLFCRYPT
-#ifndef SINGLE_THREADED
+#ifndef WOLFTPM_NO_LOCK
     wolfSSL_Mutex hwLock;
     int lockCount;
 #endif
@@ -1733,7 +1733,7 @@ typedef struct TPM2_CTX {
     byte rid;
     /* Informational Bits - use unsigned int for best compiler compatibility */
 #ifndef WOLFTPM2_NO_WOLFCRYPT
-    #ifndef SINGLE_THREADED
+    #ifndef WOLFTPM_NO_LOCK
     unsigned int hwLockInit:1;
     #endif
     #ifndef WC_NO_RNG

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -264,6 +264,11 @@ typedef int64_t  INT64;
     #define printf XPRINTF
 #endif
 
+/* check if locking / mutex should be enabled */
+#if defined(SINGLE_THREADED)
+    #undef  WOLFTPM_NO_LOCK
+    #define WOLFTPM_NO_LOCK
+#endif
 
 
 /* ---------------------------------------------------------------------------*/


### PR DESCRIPTION
* Fixes for compiler type warnings.
* Add `WOLFTPM_NO_LOCK` to support way to disable locking mutex when not single threaded.
* Improve STM IO options/logging.