### PR TITLE
Fixes for using endorsement hierarchy

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -1,0 +1,44 @@
+name: WolfTPM CMake Build Tests
+
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+#pull wolfTPM
+    - uses: actions/checkout@master
+
+# Install cmake
+    - name: Install cmake
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake
+
+#pull and build wolfssl
+    - uses: actions/checkout@master
+      with:
+        repository: wolfssl/wolfssl
+        path: wolfssl
+    - name: Build wolfssl
+      working-directory: ./wolfssl
+      run: |
+        mkdir build
+        cd build
+        cmake -DWOLFSSL_TPM=yes ..
+        make
+        sudo make install
+
+#build wolftpm
+    - name: Build wolfTPM
+      run: |
+        mkdir build
+        cd build
+        cmake -DWOLFTPM_INTERFACE=SWTPM ..
+        make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set(TPM_SOURCES
     src/tpm2_tis.c
     src/tpm2_winapi.c
     src/tpm2_wrap.c
+    src/tpm2_cryptocb.c
     hal/tpm_io.c
     )
 

--- a/README.md
+++ b/README.md
@@ -791,9 +791,10 @@ Connection: close
 
 ## Todo
 
-* Key Generation and Attestation examples using endorsement hierarchy "-eh" are broken.
-* Update to v1.59 of specification (adding CertifyX509)
+* Add support for Endorsement certificates (EK Credential Profile).
+* Update to v1.59 of specification (adding CertifyX509).
 * Inner wrap support for SensitiveToPrivate.
+* Firmware upgrade support on TPM's.
 
 ## Support
 

--- a/examples/keygen/keygen.c
+++ b/examples/keygen/keygen.c
@@ -357,14 +357,13 @@ int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[])
         /* Store primary public key */
         XMEMCPY(&primaryBlob.pub, &primary->pub, sizeof(primaryBlob.pub));
         rc |= writeKeyBlob(pubFilename, &primaryBlob);
+
         /* Write AK's Name digest */
-        fp = XFOPEN(nameFile, "wb");
-        if (fp != XBADFILE) {
-            XFWRITE((BYTE*)&newKeyBlob.name, 1, sizeof(newKeyBlob.name), fp);
-            printf("Wrote AK Name digest\n");
-            XFCLOSE(fp);
-        }
+        rc |= writeBin(nameFile, (byte*)&newKeyBlob.handle.name,
+            sizeof(newKeyBlob.handle.name));
+        printf("Wrote AK Name digest\n");
     }
+    if (rc != TPM_RC_SUCCESS) goto exit;
 #else
     if (alg == TPM_ALG_SYMCIPHER) {
         printf("The Public Part of a symmetric key contains only meta data\n");

--- a/examples/pcr/policy.c
+++ b/examples/pcr/policy.c
@@ -154,7 +154,6 @@ int TPM2_PCR_Policy_Test(void* userCtx, int argc, char *argv[])
         XMEMCPY(cmdIn.pcrPolicy.pcrDigest.buffer, digest, digestLen);
     }
     TPM2_SetupPCRSel(&cmdIn.pcrPolicy.pcrs, TPM_ALG_SHA256, pcrIndex);
-    //TPM2_SetupPCRSel(&cmdIn.pcrPolicy.pcrs, TPM_ALG_SHA384, pcrIndex);
     rc = TPM2_PolicyPCR(&cmdIn.pcrPolicy);
     if (rc != TPM_RC_SUCCESS) {
         printf("TPM2_PolicyPCR failed 0x%x: %s\n", rc,

--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -39,7 +39,7 @@ fi
 
 
 # Key Generation Tests
-echo -e "Ken Generation Tests"
+echo -e "Key Generation Tests"
 ./examples/keygen/keygen keyblob.bin -rsa >> run.out
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "keygen rsa failed! $RESULT" && exit 1

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -5540,7 +5540,7 @@ const char* TPM2_GetRCString(int rc)
     /* for negative return codes use wolfCrypt */
     if (rc < 0) {
         switch (rc) {
-            TPM_RC_STR(TPM_RC_TIMEOUT, "Hardware timeout");
+            TPM_RC_STR(TPM_RC_TIMEOUT,           "Hardware timeout");
             default:
                 break;
         }
@@ -5555,127 +5555,173 @@ const char* TPM2_GetRCString(int rc)
     #else
         switch (rc) {
             /* copy of the error code strings from wolfCrypt */
-            TPM_RC_STR(BAD_FUNC_ARG, "Bad function argument");
-            TPM_RC_STR(BUFFER_E, "Buffer error, output too small or input too big");
-            TPM_RC_STR(NOT_COMPILED_IN, "Feature not compiled in");
-            TPM_RC_STR(BAD_MUTEX_E, "Bad mutex, operation failed");
-            TPM_RC_STR(WC_TIMEOUT_E, "Timeout error");
+            TPM_RC_STR(BAD_FUNC_ARG,             "Bad function argument");
+            TPM_RC_STR(BUFFER_E,                 "Buffer error, output too small or input too big");
+            TPM_RC_STR(NOT_COMPILED_IN,          "Feature not compiled in");
+            TPM_RC_STR(BAD_MUTEX_E,              "Bad mutex, operation failed");
+            TPM_RC_STR(MEMORY_E,                 "Out of memory error");
+            TPM_RC_STR(LENGTH_ONLY_E,            "Output length only set, not for other use error");
+            TPM_RC_STR(WC_TIMEOUT_E,             "Timeout error");
+
             default:
                 break;
         }
     #endif
     }
-    else if (rc == 0) {
+    else if (rc == TPM_RC_SUCCESS) {
         return "Success";
     }
 
-    if (rc & RC_VER1) {
-        int rc_fm0 = rc & RC_MAX_FM0;
-
-        switch (rc_fm0) {
-            TPM_RC_STR(TPM_RC_SUCCESS, "Success");
-            TPM_RC_STR(TPM_RC_BAD_TAG, "Bad Tag");
-            TPM_RC_STR(TPM_RC_INITIALIZE, "TPM not initialized by TPM2_Startup or already initialized");
-            TPM_RC_STR(TPM_RC_FAILURE, "Commands not being accepted because of a TPM failure");
-            TPM_RC_STR(TPM_RC_SEQUENCE, "Improper use of a sequence handle");
-            TPM_RC_STR(TPM_RC_DISABLED, "The command is disabled");
-            TPM_RC_STR(TPM_RC_EXCLUSIVE, "Command failed because audit sequence required exclusivity");
-            TPM_RC_STR(TPM_RC_AUTH_TYPE, "Authorization handle is not correct for command");
-            TPM_RC_STR(TPM_RC_AUTH_MISSING, "Command requires an authorization session for handle and it is not present");
-            TPM_RC_STR(TPM_RC_POLICY, "Policy failure in math operation or an invalid authPolicy value");
-            TPM_RC_STR(TPM_RC_PCR, "PCR check fail");
-            TPM_RC_STR(TPM_RC_PCR_CHANGED, "PCR have changed since checked");
-            TPM_RC_STR(TPM_RC_UPGRADE, "Indicates that the TPM is in field upgrade mode");
-            TPM_RC_STR(TPM_RC_TOO_MANY_CONTEXTS, "Context ID counter is at maximum");
-            TPM_RC_STR(TPM_RC_AUTH_UNAVAILABLE, "The authValue or authPolicy is not available for selected entity");
-            TPM_RC_STR(TPM_RC_REBOOT, "A _TPM_Init and Startup(CLEAR) is required before the TPM can resume operation");
-            TPM_RC_STR(TPM_RC_UNBALANCED, "The protection algorithms (hash and symmetric) are not reasonably balanced");
-            TPM_RC_STR(TPM_RC_COMMAND_SIZE, "Command commandSize value is inconsistent with contents of the command buffer");
-            TPM_RC_STR(TPM_RC_COMMAND_CODE, "Command code not supported");
-            TPM_RC_STR(TPM_RC_AUTHSIZE, "The value of authorizationSize is out of range or the number of octets in the Authorization Area is greater than required");
-            TPM_RC_STR(TPM_RC_AUTH_CONTEXT, "Use of an authorization session with a context command or another command that cannot have an authorization session");
-            TPM_RC_STR(TPM_RC_NV_RANGE, "NV offset+size is out of range");
-            TPM_RC_STR(TPM_RC_NV_SIZE, "Requested allocation size is larger than allowed");
-            TPM_RC_STR(TPM_RC_NV_LOCKED, "NV access locked");
-            TPM_RC_STR(TPM_RC_NV_AUTHORIZATION, "NV access authorization fails in command actions");
-            TPM_RC_STR(TPM_RC_NV_UNINITIALIZED, "An NV Index is used before being initialized or the state saved by TPM2_Shutdown(STATE) could not be restored");
-            TPM_RC_STR(TPM_RC_NV_SPACE, "Insufficient space for NV allocation");
-            TPM_RC_STR(TPM_RC_NV_DEFINED, "NV Index or persistent object already defined");
-            TPM_RC_STR(TPM_RC_BAD_CONTEXT, "Context in TPM2_ContextLoad() is not valid");
-            TPM_RC_STR(TPM_RC_CPHASH, "The cpHash value already set or not correct for use");
-            TPM_RC_STR(TPM_RC_PARENT, "Handle for parent is not a valid parent");
-            TPM_RC_STR(TPM_RC_NEEDS_TEST, "Some function needs testing");
-            TPM_RC_STR(TPM_RC_NO_RESULT, "Cannot process a request due to an unspecified problem");
-            TPM_RC_STR(TPM_RC_SENSITIVE, "The sensitive area did not unmarshal correctly after decryption");
-        default:
-            break;
-        }
-    }
-
-    if (rc & RC_FMT1) {
-        int rc_fmt1 = rc & RC_MAX_FMT1;
-
-        switch (rc_fmt1) {
-            TPM_RC_STR(TPM_RC_ASYMMETRIC, "Asymmetric algorithm not supported or not correct");
-            TPM_RC_STR(TPM_RC_ATTRIBUTES, "Inconsistent attributes");
-            TPM_RC_STR(TPM_RC_HASH, "Hash algorithm not supported or not appropriate");
-            TPM_RC_STR(TPM_RC_VALUE, "Value is out of range or is not correct for the context");
-            TPM_RC_STR(TPM_RC_HIERARCHY, "Hierarchy is not enabled or is not correct for the use");
-            TPM_RC_STR(TPM_RC_KEY_SIZE, "Key size is not supported");
-            TPM_RC_STR(TPM_RC_MGF, "Mask generation function not supported");
-            TPM_RC_STR(TPM_RC_MODE, "Mode of operation not supported");
-            TPM_RC_STR(TPM_RC_TYPE, "The type of the value is not appropriate for the use");
-            TPM_RC_STR(TPM_RC_HANDLE, "The handle is not correct for the use");
-            TPM_RC_STR(TPM_RC_KDF, "Unsupported key derivation function or function not appropriate for use");
-            TPM_RC_STR(TPM_RC_RANGE, "Value was out of allowed range");
-            TPM_RC_STR(TPM_RC_AUTH_FAIL, "The authorization HMAC check failed and DA counter incremented");
-            TPM_RC_STR(TPM_RC_NONCE, "Invalid nonce size or nonce value mismatch");
-            TPM_RC_STR(TPM_RC_PP, "Authorization requires assertion of PP");
-            TPM_RC_STR(TPM_RC_SCHEME, "Unsupported or incompatible scheme");
-            TPM_RC_STR(TPM_RC_SIZE, "Structure is the wrong size");
-            TPM_RC_STR(TPM_RC_SYMMETRIC, "Unsupported symmetric algorithm or key size, or not appropriate for instance");
-            TPM_RC_STR(TPM_RC_TAG, "Incorrect structure tag");
-            TPM_RC_STR(TPM_RC_SELECTOR, "Union selector is incorrect");
-            TPM_RC_STR(TPM_RC_INSUFFICIENT, "The TPM was unable to unmarshal a value because there were not enough octets in the input buffer");
-            TPM_RC_STR(TPM_RC_SIGNATURE, "The signature is not valid");
-            TPM_RC_STR(TPM_RC_KEY, "Key fields are not compatible with the selected use");
-            TPM_RC_STR(TPM_RC_POLICY_FAIL, "A policy check failed");
-            TPM_RC_STR(TPM_RC_INTEGRITY, "Integrity check failed");
-            TPM_RC_STR(TPM_RC_TICKET, "Invalid ticket");
-            TPM_RC_STR(TPM_RC_RESERVED_BITS, "Reserved bits not set to zero as required");
-            TPM_RC_STR(TPM_RC_BAD_AUTH, "Authorization failure without DA implications");
-            TPM_RC_STR(TPM_RC_EXPIRED, "The policy has expired");
-            TPM_RC_STR(TPM_RC_POLICY_CC, "The commandCode in the policy is not the commandCode of the command or the command code in a policy command references a command that is not implemented");
-            TPM_RC_STR(TPM_RC_BINDING, "Public and sensitive portions of an object are not cryptographically bound");
-            TPM_RC_STR(TPM_RC_CURVE, "Curve not supported");
-            TPM_RC_STR(TPM_RC_ECC_POINT, "Point is not on the required curve");
-        default:
-            break;
-        }
-    }
-
-    if (rc & RC_WARN) {
+    if ((rc & RC_WARN) && (rc & RC_FMT1) == 0) {
         int rc_warn = rc & RC_MAX_WARN;
 
         switch (rc_warn) {
-            TPM_RC_STR(TPM_RC_CONTEXT_GAP, "Gap for context ID is too large");
-            TPM_RC_STR(TPM_RC_OBJECT_MEMORY, "Out of memory for object contexts");
-            TPM_RC_STR(TPM_RC_SESSION_MEMORY, "Out of memory for session contexts");
-            TPM_RC_STR(TPM_RC_MEMORY, "Out of shared object/session memory or need space for internal operations");
-            TPM_RC_STR(TPM_RC_SESSION_HANDLES, "Out of session handles; a session must be flushed before a new session may be created");
-            TPM_RC_STR(TPM_RC_OBJECT_HANDLES, "Out of object handles");
-            TPM_RC_STR(TPM_RC_LOCALITY, "Bad locality");
-            TPM_RC_STR(TPM_RC_YIELDED, "The TPM has suspended operation on the command");
-            TPM_RC_STR(TPM_RC_CANCELED, "The command was canceled");
-            TPM_RC_STR(TPM_RC_TESTING, "TPM is performing self-tests");
-            TPM_RC_STR(TPM_RC_NV_RATE, "The TPM is rate-limiting accesses to prevent wearout of NV");
-            TPM_RC_STR(TPM_RC_LOCKOUT, "Authorizations for objects subject to DA protection are not allowed at this time because the TPM is in DA lockout mode");
-            TPM_RC_STR(TPM_RC_RETRY, "The TPM was not able to start the command");
-            TPM_RC_STR(TPM_RC_NV_UNAVAILABLE, "The command may require writing of NV and NV is not current accessible");
-            TPM_RC_STR(TPM_RC_NOT_USED, "This value is reserved and shall not be returned by the TPM");
+            TPM_RC_STR(TPM_RC_CONTEXT_GAP,       "Gap for context ID is too large");
+            TPM_RC_STR(TPM_RC_OBJECT_MEMORY,     "Out of memory for object contexts");
+            TPM_RC_STR(TPM_RC_SESSION_MEMORY,    "Out of memory for session contexts");
+            TPM_RC_STR(TPM_RC_MEMORY,            "Out of shared object/session memory or need space for internal operations");
+            TPM_RC_STR(TPM_RC_SESSION_HANDLES,   "Out of session handles; a session must be flushed before a new session may be created");
+            TPM_RC_STR(TPM_RC_OBJECT_HANDLES,    "Out of object handles");
+            TPM_RC_STR(TPM_RC_LOCALITY,          "Bad locality");
+            TPM_RC_STR(TPM_RC_YIELDED,           "The TPM has suspended operation on the command");
+            TPM_RC_STR(TPM_RC_CANCELED,          "The command was canceled");
+            TPM_RC_STR(TPM_RC_TESTING,           "TPM is performing self-tests");
+            TPM_RC_STR(TPM_RC_NV_RATE,           "The TPM is rate-limiting accesses to prevent wearout of NV");
+            TPM_RC_STR(TPM_RC_LOCKOUT,           "Authorizations for objects subject to DA protection are not allowed at "
+                                                    "this time because the TPM is in DA lockout mode");
+            TPM_RC_STR(TPM_RC_RETRY,             "The TPM was not able to start the command");
+            TPM_RC_STR(TPM_RC_NV_UNAVAILABLE,    "The command may require writing of NV and NV is not current accessible");
+            TPM_RC_STR(TPM_RC_NOT_USED,          "This value is reserved and shall not be returned by the TPM");
         default:
             break;
         }
+    }
+
+    else if ((rc & RC_VER1) && (rc & RC_FMT1) == 0) {
+        int rc_fm0 = rc & RC_MAX_FM0;
+
+        switch (rc_fm0) {
+            TPM_RC_STR(TPM_RC_BAD_TAG,           "Bad Tag");
+            TPM_RC_STR(TPM_RC_INITIALIZE,        "TPM not initialized by TPM2_Startup or already initialized");
+            TPM_RC_STR(TPM_RC_FAILURE,           "Commands not being accepted because of a TPM failure");
+            TPM_RC_STR(TPM_RC_SEQUENCE,          "Improper use of a sequence handle");
+            TPM_RC_STR(TPM_RC_DISABLED,          "The command is disabled");
+            TPM_RC_STR(TPM_RC_EXCLUSIVE,         "Command failed because audit sequence required exclusivity");
+            TPM_RC_STR(TPM_RC_AUTH_TYPE,         "Authorization handle is not correct for command");
+            TPM_RC_STR(TPM_RC_AUTH_MISSING,      "Command requires an authorization session for handle and it is not present");
+            TPM_RC_STR(TPM_RC_POLICY,            "Policy failure in math operation or an invalid authPolicy value");
+            TPM_RC_STR(TPM_RC_PCR,               "PCR check fail");
+            TPM_RC_STR(TPM_RC_PCR_CHANGED,       "PCR have changed since checked");
+            TPM_RC_STR(TPM_RC_UPGRADE,           "Indicates that the TPM is in field upgrade mode");
+            TPM_RC_STR(TPM_RC_TOO_MANY_CONTEXTS, "Context ID counter is at maximum");
+            TPM_RC_STR(TPM_RC_AUTH_UNAVAILABLE,  "The authValue or authPolicy is not available for selected entity");
+            TPM_RC_STR(TPM_RC_REBOOT,            "A _TPM_Init and Startup(CLEAR) is required before the TPM can resume operation");
+            TPM_RC_STR(TPM_RC_UNBALANCED,        "The protection algorithms (hash and symmetric) are not reasonably balanced");
+            TPM_RC_STR(TPM_RC_COMMAND_SIZE,      "Command commandSize value is inconsistent with contents of the command buffer");
+            TPM_RC_STR(TPM_RC_COMMAND_CODE,      "Command code not supported");
+            TPM_RC_STR(TPM_RC_AUTHSIZE,          "The value of authorizationSize is out of range or the number of octets "
+                                                    "in the Authorization Area is greater than required");
+            TPM_RC_STR(TPM_RC_AUTH_CONTEXT,      "Use of an authorization session with a context command or another command "
+                                                    "that cannot have an authorization session");
+            TPM_RC_STR(TPM_RC_NV_RANGE,          "NV offset+size is out of range");
+            TPM_RC_STR(TPM_RC_NV_SIZE,           "Requested allocation size is larger than allowed");
+            TPM_RC_STR(TPM_RC_NV_LOCKED,         "NV access locked");
+            TPM_RC_STR(TPM_RC_NV_AUTHORIZATION,  "NV access authorization fails in command actions");
+            TPM_RC_STR(TPM_RC_NV_UNINITIALIZED,  "An NV Index is used before being initialized or the state saved by "
+                                                    "TPM2_Shutdown(STATE) could not be restored");
+            TPM_RC_STR(TPM_RC_NV_SPACE,          "Insufficient space for NV allocation");
+            TPM_RC_STR(TPM_RC_NV_DEFINED,        "NV Index or persistent object already defined");
+            TPM_RC_STR(TPM_RC_BAD_CONTEXT,       "Context in TPM2_ContextLoad() is not valid");
+            TPM_RC_STR(TPM_RC_CPHASH,            "The cpHash value already set or not correct for use");
+            TPM_RC_STR(TPM_RC_PARENT,            "Handle for parent is not a valid parent");
+            TPM_RC_STR(TPM_RC_NEEDS_TEST,        "Some function needs testing");
+            TPM_RC_STR(TPM_RC_NO_RESULT,         "Cannot process a request due to an unspecified problem");
+            TPM_RC_STR(TPM_RC_SENSITIVE,         "The sensitive area did not unmarshal correctly after decryption");
+        default:
+            break;
+        }
+    }
+
+    /* Format-One Response Codes */
+    else if (rc & RC_FMT1) {
+        int rc_fmt1 = rc & RC_MAX_FMT1;
+
+        /* Bits:
+         *   0-5: Error Number
+         *     6: 1=Parameter Number, 0=Session or Handle
+         *     7: Format selector
+         *  8-11: Number of handle, session or parameter
+         *    11: 1=Handle
+         */
+        if (rc & 0x40) { /* bit 6 */
+            /* bits 8-11 */
+            int param_num = (rc & 0xF00) >> 8;
+        #ifdef DEBUG_WOLFTPM
+            printf("Error: Parameter Number %d\n", param_num);
+        #endif
+            (void)param_num;
+        }
+        else if (rc & 0x800) { /* bit 11 */
+            /* bits 8-10 */
+            int session_num = (rc & 0x700) >> 8;
+        #ifdef DEBUG_WOLFTPM
+            printf("Error: Session Number %d\n", session_num);
+        #endif
+            (void)session_num;
+        }
+        else {
+            /* bits 8-10 */
+            int handle_num = (rc & 0x700) >> 8;
+        #ifdef DEBUG_WOLFTPM
+            printf("Error: Handle Number %d\n", handle_num);
+        #endif
+            (void)handle_num;
+        }
+
+        switch (rc_fmt1) {
+            TPM_RC_STR(TPM_RC_ASYMMETRIC,        "Asymmetric algorithm not supported or not correct");
+            TPM_RC_STR(TPM_RC_ATTRIBUTES,        "Inconsistent attributes");
+            TPM_RC_STR(TPM_RC_HASH,              "Hash algorithm not supported or not appropriate");
+            TPM_RC_STR(TPM_RC_VALUE,             "Value is out of range or is not correct for the context");
+            TPM_RC_STR(TPM_RC_HIERARCHY,         "Hierarchy is not enabled or is not correct for the use");
+            TPM_RC_STR(TPM_RC_KEY_SIZE,          "Key size is not supported");
+            TPM_RC_STR(TPM_RC_MGF,               "Mask generation function not supported");
+            TPM_RC_STR(TPM_RC_MODE,              "Mode of operation not supported");
+            TPM_RC_STR(TPM_RC_TYPE,              "The type of the value is not appropriate for the use");
+            TPM_RC_STR(TPM_RC_HANDLE,            "The handle is not correct for the use");
+            TPM_RC_STR(TPM_RC_KDF,               "Unsupported key derivation function or function not appropriate for use");
+            TPM_RC_STR(TPM_RC_RANGE,             "Value was out of allowed range");
+            TPM_RC_STR(TPM_RC_AUTH_FAIL,         "The authorization HMAC check failed and DA counter incremented");
+            TPM_RC_STR(TPM_RC_NONCE,             "Invalid nonce size or nonce value mismatch");
+            TPM_RC_STR(TPM_RC_PP,                "Authorization requires assertion of PP");
+            TPM_RC_STR(TPM_RC_SCHEME,            "Unsupported or incompatible scheme");
+            TPM_RC_STR(TPM_RC_SIZE,              "Structure is the wrong size");
+            TPM_RC_STR(TPM_RC_SYMMETRIC,         "Unsupported symmetric algorithm or key size, or not appropriate for instance");
+            TPM_RC_STR(TPM_RC_TAG,               "Incorrect structure tag");
+            TPM_RC_STR(TPM_RC_SELECTOR,          "Union selector is incorrect");
+            TPM_RC_STR(TPM_RC_INSUFFICIENT,      "The TPM was unable to unmarshal a value because there were not enough "
+                                                    "octets in the input buffer");
+            TPM_RC_STR(TPM_RC_SIGNATURE,         "The signature is not valid");
+            TPM_RC_STR(TPM_RC_KEY,               "Key fields are not compatible with the selected use");
+            TPM_RC_STR(TPM_RC_POLICY_FAIL,       "A policy check failed");
+            TPM_RC_STR(TPM_RC_INTEGRITY,         "Integrity check failed");
+            TPM_RC_STR(TPM_RC_TICKET,            "Invalid ticket");
+            TPM_RC_STR(TPM_RC_RESERVED_BITS,     "Reserved bits not set to zero as required");
+            TPM_RC_STR(TPM_RC_BAD_AUTH,          "Authorization failure without DA implications");
+            TPM_RC_STR(TPM_RC_EXPIRED,           "The policy has expired");
+            TPM_RC_STR(TPM_RC_POLICY_CC,         "The commandCode in the policy is not the commandCode of the command or "
+                                                    "the command code in a policy command references a command that is "
+                                                    "not implemented");
+            TPM_RC_STR(TPM_RC_BINDING,           "Public and sensitive portions of an object are not cryptographically bound");
+            TPM_RC_STR(TPM_RC_CURVE,             "Curve not supported");
+            TPM_RC_STR(TPM_RC_ECC_POINT,         "Point is not on the required curve");
+        default:
+            break;
+        }
+    }
+
+    else if (rc & 0x400) { /* bit 10 */
+        return "Vendor defined response code";
     }
 
     return "Unknown";

--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -330,6 +330,12 @@ int TPM2_GetCmdAuthCount(TPM2_CTX* ctx, const CmdInfo_t* info)
                  (sessionAttributes & TPMA_SESSION_audit))
                 authSessCount++;
         }
+
+        /* Allow policy auth */
+        else if (authReq && TPM2_IS_POLICY_SESSION(sessionHandle) &&
+                sessionAttributes == 0) {
+            authSessCount++;
+        }
         else if (!authReq) {
             /* we cannot accept further authentications */
             break;

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -1763,7 +1763,7 @@ int wolfTPM2_CreateLoadedKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEYBLOB* keyBlob,
 
     wolfTPM2_CopyPub(&keyBlob->pub, &createLoadedOut.outPublic);
     wolfTPM2_CopyPriv(&keyBlob->priv, &createLoadedOut.outPrivate);
-    wolfTPM2_CopyName(&keyBlob->name, &createLoadedOut.name);
+    wolfTPM2_CopyName(&keyBlob->handle.name, &createLoadedOut.name);
 
     return rc;
 }

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -822,11 +822,18 @@ int wolfTPM2_SetAuthHandle(WOLFTPM2_DEV* dev, int index,
 {
     const TPM2B_AUTH* auth = NULL;
     const TPM2B_NAME* name = NULL;
-    /* don't set auth for policy session */
-    if (dev->ctx.session == NULL || handle->policyAuth) {
-        return 0;
+    if (dev == NULL || index >= MAX_SESSION_NUM) {
+        return BAD_FUNC_ARG;
     }
+
     if (handle) {
+        /* don't set auth for policy session, just name */
+        if (handle->policyAuth) {
+            TPM2_AUTH_SESSION* session = &dev->session[index];
+            session->name.size = handle->name.size;
+            XMEMCPY(session->name.name, handle->name.name, handle->name.size);
+            return TPM_RC_SUCCESS;
+        }
         auth = &handle->auth;
         name = &handle->name;
     }
@@ -892,12 +899,14 @@ int wolfTPM2_SetAuthSession(WOLFTPM2_DEV* dev, int index,
         XMEMCPY(session->nonceTPM.buffer, tpmSession->nonceTPM.buffer,
             session->nonceTPM.size);
 
-        /* Parameter Encryption session will have an hmac added later.
+        /* Parameter Encryption or Policy session will have an HMAC added later.
          * Reserve space, the same way it was done for nonceCaller above.
          */
-        if (session->sessionHandle != TPM_RS_PW &&
-            ((session->sessionAttributes & TPMA_SESSION_encrypt) ||
-             (session->sessionAttributes & TPMA_SESSION_decrypt))) {
+        if ((session->sessionHandle != TPM_RS_PW &&
+                ((session->sessionAttributes & TPMA_SESSION_encrypt) ||
+                 (session->sessionAttributes & TPMA_SESSION_decrypt)))
+             || TPM2_IS_POLICY_SESSION(session->sessionHandle))
+        {
             session->auth.size = TPM2_GetHashDigestSize(session->authHash);
         }
     }

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1640,7 +1640,7 @@ typedef struct TPM2_AUTH_SESSION {
 #define TPM_20_NV_INDEX_EK_NONCE       (TPM_20_PLATFORM_MFG_NV_SPACE + 3)
 #define TPM_20_NV_INDEX_EK_TEMPLATE    (TPM_20_PLATFORM_MFG_NV_SPACE + 4)
 
-/* Predetermined TPM 2.0 Endorsement policy auth template */
+/* Predetermined TPM 2.0 Endorsement policy auth template for SHA2-256 */
 static const BYTE TPM_20_EK_AUTH_POLICY[] = {
     0x83, 0x71, 0x97, 0x67, 0x44, 0x84, 0xb3, 0xf8, 0x1a, 0x90, 0xcc,
     0x8d, 0x46, 0xa5, 0xd7, 0x24, 0xfd, 0x52, 0xd7, 0x6e, 0x06, 0x52,

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -63,7 +63,6 @@ typedef struct WOLFTPM2_KEY {
 typedef struct WOLFTPM2_KEYBLOB {
     WOLFTPM2_HANDLE   handle;
     TPM2B_PUBLIC      pub;
-    TPM2B_NAME        name;
     TPM2B_PRIVATE     priv;
 } WOLFTPM2_KEYBLOB;
 


### PR DESCRIPTION
* Fixes for attestation with endorsement key. 
* Enable the broken endorsement tests.
* Fix native test `TPM2_PolicyPCR`.
* Remove the `WOLFTPM2_KEYBLOB.name` (deprecated) and is in `handle.name` now.
* Improve `TPM2_GetRCString` error rendering to correctly resolve RC_WARN. Add parameter, session and handle debug information. Refactor line length / alignment. Remove duplicate "success".
* Fix CMake build broken since cryptocb refactor in PR #304.
* Added CI tests for CMake.

Fixes https://github.com/wolfSSL/wolfTPM/issues/282