### PR TITLE
Added PKCS7 ECC support to example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -110,10 +110,14 @@ The script creates the following X.509 files (also in .pem format):
 
 Example signs and verifies data with PKCS #7 using a TPM based key.
 
-* Must first run:
-1. `./examples/csr/csr`
-2. `./certs/certreq.sh`
-3. `./examples/pkcs7/pkcs7`
+```sh
+./examples/keygen/keygen rsa_test_blob.raw -rsa -t
+./examples/keygen/keygen ecc_test_blob.raw -ecc -t
+./examples/csr/csr
+./certs/certreq.sh
+./examples/pkcs7/pkcs7
+./examples/pkcs7/pkcs7 -ecc
+```
 
 The result is displayed to stdout on the console.
 

--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -187,6 +187,10 @@ if [ $WOLFCRYPT_ENABLE -eq 1 ]; then
     ./examples/pkcs7/pkcs7 >> run.out
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "pkcs7 failed! $RESULT" && exit 1
+
+    ./examples/pkcs7/pkcs7 -ecc >> run.out
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "pkcs7 ecc failed! $RESULT" && exit 1
 fi
 
 # TLS Tests

--- a/src/tpm2_cryptocb.c
+++ b/src/tpm2_cryptocb.c
@@ -248,8 +248,14 @@ int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
             word32 rsLen = sizeof(sigRS), keySz;
             word32 inlen = info->pk.eccsign.inlen;
 
-            /* truncate input to match key size */
+            /* get key size from wolf signing key */
             keySz = wc_ecc_size(info->pk.eccsign.key);
+            if (keySz == 0) {
+                /* if not populated fallback to key size for TPM key */
+                keySz = TPM2_GetCurveSize(
+                   tlsCtx->eccKey->pub.publicArea.parameters.eccDetail.curveID);
+            }
+            /* truncate input to match key size */
             if (inlen > keySz)
                 inlen = keySz;
 

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -1189,6 +1189,24 @@ WOLFTPM_API int wolfTPM2_ImportPublicKeyBuffer(WOLFTPM2_DEV* dev, int keyType,
     WOLFTPM2_KEY* key, int encodingType, const char* input, word32 inSz,
     TPMA_OBJECT objectAttributes);
 
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Helper function to export a TPM RSA/ECC public key with PEM/DER formatting
+
+    \return TPM_RC_SUCCESS: successful - populates key->pub
+    \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)
+    \return BUFFER_E: insufficient space in provided buffer
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a TPM2_DEV struct
+    \param tpmKey pointer to a WOLFTPM2_KEY with populated key
+    \param encodingType ENCODING_TYPE_PEM or ENCODING_TYPE_ASN1 (DER)
+    \param out buffer to export public key
+    \param outSz pointer to length of the out buffer
+*/
+WOLFTPM_API int wolfTPM2_ExportPublicKeyBuffer(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
+    int encodingType, byte* out, word32* outSz);
+
 #ifndef NO_RSA
 /*!
     \ingroup wolfTPM2_Wrappers
@@ -1252,8 +1270,8 @@ WOLFTPM_API int wolfTPM2_RsaKey_TpmToWolf(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKe
 
 /*!
     \ingroup wolfTPM2_Wrappers
-    \brief Convert a public RSA TPM key to PEM format public key
-    Note: pem and tempBuf must be different buffers, of equal size
+    \brief Convert a public RSA TPM key to PEM format public key.
+    Note: This API is a wrapper around wolfTPM2_ExportPublicKeyBuffer
 
     \return TPM_RC_SUCCESS: successful
     \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)
@@ -1264,6 +1282,7 @@ WOLFTPM_API int wolfTPM2_RsaKey_TpmToWolf(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKe
     \param pem pointer to an array of byte type, used as temporary storage for PEM conversation
     \param pemSz pointer to integer variable, to store the used buffer size
 
+    \sa wolfTPM2_ExportPublicKeyBuffer
     \sa wolfTPM2_RsaKey_TpmToWolf
     \sa wolfTPM2_RsaKey_WolfToTpm
 */


### PR DESCRIPTION
* Added PKCS7 ECC support to example.
* Added wrapper function to export TPM public key as DER/ASN.1 or PEM.
* Fix for crypto callback ECC sign to handle getting keySz for unknown cases (like PKCS7 without privateKey set).
* Fixed keygen and csr to use ECC SRK.

Fixes ZD 16675