### PR TITLE
Fix for config.h

### DIFF
--- a/IDE/OPENSTM32/Inc/wolftpm_example.h
+++ b/IDE/OPENSTM32/Inc/wolftpm_example.h
@@ -27,10 +27,6 @@
 #include <stm32f4xx.h>
 #include <cmsis_os.h>
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
 #ifndef WOLFSSL_USER_SETTINGS
 	#include <wolfssl/options.h>
 #endif

--- a/IDE/OPENSTM32/Src/wolftpm_example.c
+++ b/IDE/OPENSTM32/Src/wolftpm_example.c
@@ -19,6 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include "wolftpm_example.h"
 

--- a/examples/attestation/activate_credential.c
+++ b/examples/attestation/activate_credential.c
@@ -23,6 +23,10 @@
  * and extract the secret for challenge response to an attestation server
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #include <stdio.h>

--- a/examples/attestation/make_credential.c
+++ b/examples/attestation/make_credential.c
@@ -21,6 +21,10 @@
 
 /* This example shows how to create a challenge for Remote Attestation */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #ifndef WOLFTPM2_NO_WRAPPER

--- a/examples/bench/bench.c
+++ b/examples/bench/bench.c
@@ -22,6 +22,10 @@
 /* This example shows benchmarks using the TPM2 wrapper API's in
     TPM2_Wrapper_Bench() below. */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>
 

--- a/examples/boot/secret_seal.c
+++ b/examples/boot/secret_seal.c
@@ -22,6 +22,9 @@
 /* Example for using TPM to seal a secret using an external key based on PCR(s)
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>

--- a/examples/boot/secret_unseal.c
+++ b/examples/boot/secret_unseal.c
@@ -22,6 +22,9 @@
 /* Example for using TPM to seal a secret using an external key based on PCR(s)
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>

--- a/examples/boot/secure_rot.c
+++ b/examples/boot/secure_rot.c
@@ -22,6 +22,9 @@
 /* Example for using TPM for secure boot root of trust
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>

--- a/examples/csr/csr.c
+++ b/examples/csr/csr.c
@@ -19,6 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>

--- a/examples/gpio/gpio_config.c
+++ b/examples/gpio/gpio_config.c
@@ -20,7 +20,12 @@
  */
 
 /* This examples demonstrates the use of GPIO available on some TPM modules.
- * Support tested with STM ST33 and Nuvoton NPCT750 FW 7.2.3.0 or later */
+ * Support tested with STM ST33 and Nuvoton NPCT750 FW 7.2.3.0 or later
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2_wrap.h>
 

--- a/examples/gpio/gpio_read.c
+++ b/examples/gpio/gpio_read.c
@@ -25,6 +25,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #include <examples/gpio/gpio.h>

--- a/examples/gpio/gpio_set.c
+++ b/examples/gpio/gpio_set.c
@@ -25,6 +25,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #include <stdio.h>

--- a/examples/keygen/create_primary.c
+++ b/examples/keygen/create_primary.c
@@ -21,6 +21,10 @@
 
 /* Tool and example for creating and storing primary keys using TPM2.0 */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #include <stdio.h>

--- a/examples/keygen/external_import.c
+++ b/examples/keygen/external_import.c
@@ -20,7 +20,12 @@
  */
 
 /* Example for importing an external RSA key with seed and creating a
- * child key under it. */
+ * child key under it.
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2_wrap.h>
 

--- a/examples/keygen/keygen.c
+++ b/examples/keygen/keygen.c
@@ -21,6 +21,10 @@
 
 /* Tool and example for creating, storing and loading keys using TPM2.0 */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #include <stdio.h>

--- a/examples/keygen/keyimport.c
+++ b/examples/keygen/keyimport.c
@@ -21,6 +21,10 @@
 
 /* Tool and example for creating, storing and loading keys using TPM2.0 */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #include <stdio.h>

--- a/examples/keygen/keyload.c
+++ b/examples/keygen/keyload.c
@@ -21,6 +21,9 @@
 
 /* Tool and example for creating, storing and loading keys using TPM2.0 */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 /* use ANSI stdio for support of format strings, must be set before
  * including stdio.h

--- a/examples/management/flush.c
+++ b/examples/management/flush.c
@@ -21,6 +21,10 @@
 
 /* This is a helper tool for reseting the value of a TPM2.0 PCR */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #include <examples/management/flush.h>

--- a/examples/native/native_test.c
+++ b/examples/native/native_test.c
@@ -21,6 +21,10 @@
 
 /* This example shows using the TPM2_ specification API's in TPM2_Native_Test() */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_param_enc.h>
 

--- a/examples/nvram/counter.c
+++ b/examples/nvram/counter.c
@@ -24,7 +24,11 @@
  * NB: This example uses Parameter Encryption to protect
  *     the Password Authorization of the TPM NVRAM Index
  *
- **/
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2_wrap.h>
 

--- a/examples/nvram/policy_nv.c
+++ b/examples/nvram/policy_nv.c
@@ -24,7 +24,11 @@
  * NB: This example uses Parameter Encryption to protect the password of the
  *     TPM NVRAM Index, where the private and public parts of a TPM key is stored
  *
- **/
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2_wrap.h>
 

--- a/examples/nvram/read.c
+++ b/examples/nvram/read.c
@@ -24,7 +24,11 @@
  * NB: This example uses Parameter Encryption to protect
  *     the Password Authorization of the TPM NVRAM Index
  *
- **/
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2_wrap.h>
 

--- a/examples/nvram/store.c
+++ b/examples/nvram/store.c
@@ -24,7 +24,11 @@
  * NB: This example uses Parameter Encryption to protect the password of the
  *     TPM NVRAM Index, where the private and public parts of a TPM key is stored
  *
- **/
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2_wrap.h>
 

--- a/examples/pcr/extend.c
+++ b/examples/pcr/extend.c
@@ -21,6 +21,10 @@
 
 /* This is a helper tool for extending hash into a TPM2.0 PCR */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #ifndef WOLFTPM2_NO_WRAPPER

--- a/examples/pcr/policy.c
+++ b/examples/pcr/policy.c
@@ -21,6 +21,10 @@
 
 /* This is a helper tool for setting policies on a TPM 2.0 PCR */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #include <stdio.h>

--- a/examples/pcr/policy_sign.c
+++ b/examples/pcr/policy_sign.c
@@ -22,6 +22,9 @@
 /* Example for signing PCR(s) to create a policy for unsealing a secret
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>

--- a/examples/pcr/quote.c
+++ b/examples/pcr/quote.c
@@ -23,6 +23,10 @@
  * PCR measurement. PCR values are used as basis for system integrity.
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #ifndef WOLFTPM2_NO_WRAPPER

--- a/examples/pcr/read_pcr.c
+++ b/examples/pcr/read_pcr.c
@@ -21,6 +21,10 @@
 
 /* This is a helper tool for reading the value of a TPM2.0 PCR */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #include <stdio.h>

--- a/examples/pkcs7/pkcs7.c
+++ b/examples/pkcs7/pkcs7.c
@@ -19,6 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>

--- a/examples/seal/seal.c
+++ b/examples/seal/seal.c
@@ -21,6 +21,10 @@
 
 /* Example for TPM 2.0 sealing a user secret using TPM key */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #include <stdio.h>

--- a/examples/seal/unseal.c
+++ b/examples/seal/unseal.c
@@ -21,6 +21,10 @@
 
 /* This example demonstrates how to extract the data from a TPM seal object */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #include <stdio.h>

--- a/examples/timestamp/clock_set.c
+++ b/examples/timestamp/clock_set.c
@@ -21,6 +21,10 @@
 
 /* This example shows how to increment the TPM2 clock */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #include <stdio.h>

--- a/examples/timestamp/signed_timestamp.c
+++ b/examples/timestamp/signed_timestamp.c
@@ -23,6 +23,10 @@
  * generate a signed timestamp from the TPM using a Attestation Identity Key.
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #include <stdio.h>

--- a/examples/tls/tls_client.c
+++ b/examples/tls/tls_client.c
@@ -19,6 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>

--- a/examples/tls/tls_client_notpm.c
+++ b/examples/tls/tls_client_notpm.c
@@ -19,6 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>

--- a/examples/tls/tls_server.c
+++ b/examples/tls/tls_server.c
@@ -19,6 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>

--- a/examples/tpm_test_keys.c
+++ b/examples/tpm_test_keys.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 /* use ANSI stdio for support of format strings, must be set before
  * including stdio.h
  */

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -19,7 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-/* This example shows using the TPM2 wrapper API's in TPM2_Wrapper_Test() below. */
+/* This example shows using the TPM2 wrapper API's in TPM2_Wrapper_Test() below.
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>

--- a/hal/tpm_io.c
+++ b/hal/tpm_io.c
@@ -31,6 +31,10 @@
  *
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_tis.h>
 #include "tpm_io.h"

--- a/hal/tpm_io_atmel.c
+++ b/hal/tpm_io_atmel.c
@@ -21,6 +21,9 @@
 
 /* This example shows IO interfaces for ATMEL microcontrollers using ASF */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_tis.h>

--- a/hal/tpm_io_barebox.c
+++ b/hal/tpm_io_barebox.c
@@ -21,6 +21,9 @@
 
 /* This example shows IO interfaces for Barebox */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_tis.h>

--- a/hal/tpm_io_infineon.c
+++ b/hal/tpm_io_infineon.c
@@ -23,6 +23,9 @@
  * - TC2XX/TC3XX using macro: `WOLFTPM_INFINEON_TRICORE`.
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_tis.h>

--- a/hal/tpm_io_linux.c
+++ b/hal/tpm_io_linux.c
@@ -23,8 +23,11 @@
  *
  * NB: To use /dev/tpm0, wolfTPM does not require an IO callback, just pass NULL
  *
- * */
+ */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_tis.h>

--- a/hal/tpm_io_microchip.c
+++ b/hal/tpm_io_microchip.c
@@ -20,8 +20,12 @@
  */
 
 /* This example shows IO interfaces for Microchip micro-controllers using
- * MPLAB X and Harmony */
+ * MPLAB X and Harmony
+ */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_tis.h>

--- a/hal/tpm_io_mmio.c
+++ b/hal/tpm_io_mmio.c
@@ -21,6 +21,9 @@
 
 /* Support for Memory Mapped I/O for accessing TPM */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_tis.h>

--- a/hal/tpm_io_qnx.c
+++ b/hal/tpm_io_qnx.c
@@ -21,6 +21,9 @@
 
 /* This example shows IO interfaces for QNX */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_tis.h>

--- a/hal/tpm_io_st.c
+++ b/hal/tpm_io_st.c
@@ -21,6 +21,9 @@
 
 /* This example shows IO interfaces for STM32 CubeMX HAL */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_tis.h>

--- a/hal/tpm_io_xilinx.c
+++ b/hal/tpm_io_xilinx.c
@@ -21,6 +21,9 @@
 
 /* This example shows IO interfaces for Xilinx */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_tis.h>

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -19,6 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_packet.h>

--- a/src/tpm2_cryptocb.c
+++ b/src/tpm2_cryptocb.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #if !defined(WOLFTPM2_NO_WRAPPER)

--- a/src/tpm2_linux.c
+++ b/src/tpm2_linux.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_types.h>
 
 #ifdef WOLFTPM_LINUX_DEV

--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -19,9 +19,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2_packet.h>
-
 
 /* Endianess Helpers */
 #ifdef LITTLE_ENDIAN_ORDER

--- a/src/tpm2_param_enc.c
+++ b/src/tpm2_param_enc.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_param_enc.h>
 #include <wolftpm/tpm2_packet.h>
 

--- a/src/tpm2_swtpm.c
+++ b/src/tpm2_swtpm.c
@@ -32,6 +32,10 @@
  * See docs/SWTPM.md
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_types.h>
 
 #ifdef WOLFTPM_SWTPM

--- a/src/tpm2_tis.c
+++ b/src/tpm2_tis.c
@@ -19,6 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2_tis.h>
 

--- a/src/tpm2_winapi.c
+++ b/src/tpm2_winapi.c
@@ -19,6 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2_types.h>
 

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 #include <wolftpm/tpm2_param_enc.h>
 

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -22,10 +22,6 @@
 #ifndef __TPM2_TYPES_H__
 #define __TPM2_TYPES_H__
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
 #include <wolftpm/visibility.h>
 #include <stdint.h>
 


### PR DESCRIPTION
Fix for config.h, which should only be included from .c files, not headers. ZD 17473