### PR TITLE
Fix for two missed files for config.h

### DIFF
--- a/examples/pcr/reset.c
+++ b/examples/pcr/reset.c
@@ -21,6 +21,10 @@
 
 /* This is a helper tool for reseting the value of a TPM2.0 PCR */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <wolftpm/tpm2_wrap.h>
 
 #ifndef WOLFTPM2_NO_WRAPPER

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -21,6 +21,9 @@
 
 /* wolfTPM 2.0 unit tests */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolftpm/tpm2.h>
 #include <wolftpm/tpm2_wrap.h>


### PR DESCRIPTION
Fix for two missed files for config.h. Found using `git grep -L "HAVE_CONFIG_H" -- **/*.c`.