### PR TITLE
Fix for netdb.h

### DIFF
--- a/examples/tls/tls_common.h
+++ b/examples/tls/tls_common.h
@@ -95,6 +95,9 @@ typedef struct SockIoCbCtx {
 
 #ifndef WOLFSSL_USER_IO
 /* socket includes */
+#ifdef HAVE_NETDB_H
+#include <netdb.h>
+#endif
 
 static inline int SockIORecv(WOLFSSL* ssl, char* buff, int sz, void* ctx)
 {

--- a/src/tpm2_swtpm.c
+++ b/src/tpm2_swtpm.c
@@ -47,6 +47,9 @@
 #include <errno.h>
 #include <string.h>
 #include <stdio.h>
+#ifdef HAVE_NETDB_H
+#include <netdb.h>
+#endif
 
 #include <wolftpm/tpm2_socket.h>
 

--- a/wolftpm/tpm2_socket.h
+++ b/wolftpm/tpm2_socket.h
@@ -39,7 +39,6 @@
 #else
     #include <sys/types.h>
     #include <sys/socket.h>
-    #include <netdb.h>
 
     #define SOCKET_T int
 #endif


### PR DESCRIPTION
Don't rely on wolfSSL for inclusion of the netdb.h header.