### PR TITLE
Added ST33 support for pre-provisioned device identity key and certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Tested with:
 
 * Infineon OPTIGA (TM) Trusted Platform Module 2.0 SLB9670, SLB9672 and SLB9673 (I2C).
     - LetsTrust: Vendor for TPM development boards [http://letstrust.de](http://letstrust.de).
-* STMicro STSAFE-TPM, ST33TPHF2XSPI/2XI2C and ST33KTPM2X
+* STMicro STSAFE-TPM, ST33TPHF2XSPI/2XI2C and ST33KTPM2X (SPI and I2C)
 * Microchip ATTPM20 module
 * Nuvoton NPCT65X or NPCT75x TPM2.0 module
 * Nations Technologies Z32H330 TPM 2.0 module
@@ -104,6 +104,10 @@ Mfg IFX (1), Vendor SLB9672, Fw 16.10 (0x4068), FIPS 140-2 1, CC-EAL4 1
 Infineon SLB9673:
 TPM2: Caps 0x1ae00082, Did 0x001c, Vid 0x15d1, Rid 0x16
 Mfg IFX (1), Vendor SLB9673, Fw 26.13 (0x456a), FIPS 140-2 1, CC-EAL4 1
+
+STMicro ST33KTPM2XI2C
+TPM2: Caps 0x30000415, Did 0x0003, Vid 0x104a, Rid 0x 0
+Mfg STM  (2), Vendor ST33KTPM2XI2C, Fw 9.256 (0x0), FIPS 140-2 1, CC-EAL4 0
 
 STMicro ST33TPHF2XSPI
 TPM2: Caps 0x1a7e2882, Did 0x0000, Vid 0x104a, Rid 0x4e
@@ -477,6 +481,40 @@ ECC      256 key gen        4 ops took 1.244 sec, avg 311.031 ms, 3.215 ops/sec
 ECDSA    256 sign          14 ops took 1.009 sec, avg 72.057 ms, 13.878 ops/sec
 ECDSA    256 verify        18 ops took 1.043 sec, avg 57.921 ms, 17.265 ops/sec
 ECDHE    256 agree          9 ops took 1.025 sec, avg 113.888 ms, 8.781 ops/sec
+```
+
+Run on STMicro ST33KTPM2XI2C at 33MHz:
+
+```
+./examples/bench/bench
+TPM2 Benchmark using Wrapper API's
+	Use Parameter Encryption: NULL
+Loading SRK: Storage 0x81000200 (282 bytes)
+RNG                 24 KB took 1.042 seconds,   23.028 KB/s
+AES-128-CBC-enc     52 KB took 1.018 seconds,   51.077 KB/s
+AES-128-CBC-dec     52 KB took 1.027 seconds,   50.644 KB/s
+AES-256-CBC-enc     46 KB took 1.012 seconds,   45.446 KB/s
+AES-256-CBC-dec     46 KB took 1.021 seconds,   45.072 KB/s
+AES-128-CTR-enc     44 KB took 1.025 seconds,   42.927 KB/s
+AES-128-CTR-dec     44 KB took 1.024 seconds,   42.955 KB/s
+AES-256-CTR-enc     40 KB took 1.025 seconds,   39.016 KB/s
+AES-256-CTR-dec     40 KB took 1.026 seconds,   38.992 KB/s
+AES-128-CFB-enc     52 KB took 1.026 seconds,   50.674 KB/s
+AES-128-CFB-dec     46 KB took 1.023 seconds,   44.986 KB/s
+AES-256-CFB-enc     46 KB took 1.021 seconds,   45.047 KB/s
+AES-256-CFB-dec     42 KB took 1.033 seconds,   40.665 KB/s
+SHA1               138 KB took 1.009 seconds,  136.727 KB/s
+SHA256             128 KB took 1.010 seconds,  126.723 KB/s
+SHA384             116 KB took 1.001 seconds,  115.833 KB/s
+RSA     2048 key gen        9 ops took 17.497 sec, avg 1944.057 ms, 0.514 ops/sec
+RSA     2048 Public       155 ops took 1.003 sec, avg 6.468 ms, 154.601 ops/sec
+RSA     2048 Private       12 ops took 1.090 sec, avg 90.806 ms, 11.013 ops/sec
+RSA     2048 Pub  OAEP    122 ops took 1.004 sec, avg 8.230 ms, 121.501 ops/sec
+RSA     2048 Priv OAEP     11 ops took 1.023 sec, avg 92.964 ms, 10.757 ops/sec
+ECC      256 key gen       12 ops took 1.070 sec, avg 89.172 ms, 11.214 ops/sec
+ECDSA    256 sign          40 ops took 1.010 sec, avg 25.251 ms, 39.602 ops/sec
+ECDSA    256 verify        28 ops took 1.023 sec, avg 36.543 ms, 27.365 ops/sec
+ECDHE    256 agree         16 ops took 1.062 sec, avg 66.391 ms, 15.062 ops/sec
 ```
 
 Run on STMicro ST33TPHF2XSPI at 33MHz:

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ Infineon SLB9673:
 TPM2: Caps 0x1ae00082, Did 0x001c, Vid 0x15d1, Rid 0x16
 Mfg IFX (1), Vendor SLB9673, Fw 26.13 (0x456a), FIPS 140-2 1, CC-EAL4 1
 
-STMicro ST33KTPM2XI2C
+STMicro ST33KTPM2XSPI
 TPM2: Caps 0x30000415, Did 0x0003, Vid 0x104a, Rid 0x 0
-Mfg STM  (2), Vendor ST33KTPM2XI2C, Fw 9.256 (0x0), FIPS 140-2 1, CC-EAL4 0
+Mfg STM  (2), Vendor ST33KTPM2XSPI, Fw 9.256 (0x0), FIPS 140-2 1, CC-EAL4 0
 
 STMicro ST33TPHF2XSPI
 TPM2: Caps 0x1a7e2882, Did 0x0000, Vid 0x104a, Rid 0x4e
@@ -483,7 +483,7 @@ ECDSA    256 verify        18 ops took 1.043 sec, avg 57.921 ms, 17.265 ops/sec
 ECDHE    256 agree          9 ops took 1.025 sec, avg 113.888 ms, 8.781 ops/sec
 ```
 
-Run on STMicro ST33KTPM2XI2C at 33MHz:
+Run on STMicro ST33KTPM2XSPI at 33MHz:
 
 ```
 ./examples/bench/bench

--- a/certs/wolf-ca-ecc-cert.pem
+++ b/certs/wolf-ca-ecc-cert.pem
@@ -2,12 +2,12 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            65:67:42:4c:06:e7:e4:c3:68:01:a9:94:a9:07:e6:fe:bd:2c:d6:3d
+            0f:17:46:70:fd:c2:70:d1:f9:42:49:9c:1a:c3:5d:dd:30:c8:5f:85
         Signature Algorithm: ecdsa-with-SHA256
         Issuer: C = US, ST = Washington, L = Seattle, O = wolfSSL, OU = Development, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
         Validity
-            Not Before: Dec 16 21:17:49 2022 GMT
-            Not After : Sep 11 21:17:49 2025 GMT
+            Not Before: Dec 13 22:19:28 2023 GMT
+            Not After : Sep  8 22:19:28 2026 GMT
         Subject: C = US, ST = Washington, L = Seattle, O = wolfSSL, OU = Development, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: id-ecPublicKey
@@ -31,16 +31,16 @@ Certificate:
             X509v3 Key Usage: critical
                 Digital Signature, Certificate Sign, CRL Sign
     Signature Algorithm: ecdsa-with-SHA256
-         30:46:02:21:00:b0:12:16:03:26:79:d4:6b:94:d9:7e:ca:e1:
-         2d:24:64:ef:11:6e:f2:12:81:e4:ce:1d:77:7d:ca:5c:47:50:
-         62:02:21:00:80:bf:46:3c:5d:d8:e5:ab:47:ce:a2:19:bd:21:
-         de:85:6f:ab:c9:8f:01:f3:ab:1b:b9:e1:53:d6:24:77:a6:4d
+         30:45:02:21:00:c8:64:7f:ee:4b:be:83:48:13:ea:92:f8:1a:
+         82:1e:85:b1:5a:a4:1c:e3:e8:ea:25:44:6f:e7:70:fd:eb:f3:
+         76:02:20:44:02:a2:ec:c5:a1:ae:e2:a4:8a:d9:13:95:2b:a6:
+         5b:09:57:86:61:42:96:97:f0:95:62:0c:03:e6:53:04:25
 -----BEGIN CERTIFICATE-----
-MIICljCCAjugAwIBAgIUZWdCTAbn5MNoAamUqQfm/r0s1j0wCgYIKoZIzj0EAwIw
+MIIClTCCAjugAwIBAgIUDxdGcP3CcNH5QkmcGsNd3TDIX4UwCgYIKoZIzj0EAwIw
 gZcxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdT
 ZWF0dGxlMRAwDgYDVQQKDAd3b2xmU1NMMRQwEgYDVQQLDAtEZXZlbG9wbWVudDEY
 MBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdv
-bGZzc2wuY29tMB4XDTIyMTIxNjIxMTc0OVoXDTI1MDkxMTIxMTc0OVowgZcxCzAJ
+bGZzc2wuY29tMB4XDTIzMTIxMzIyMTkyOFoXDTI2MDkwODIyMTkyOFowgZcxCzAJ
 BgNVBAYTAlVTMRMwEQYDVQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdTZWF0dGxl
 MRAwDgYDVQQKDAd3b2xmU1NMMRQwEgYDVQQLDAtEZXZlbG9wbWVudDEYMBYGA1UE
 AwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wu
@@ -48,6 +48,6 @@ Y29tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAtPZbtYBjkXIuZAx5cBM456t
 KTiYuhDW6QkqgKkuFyq5ir8zg0bjlQvkd0C1O0NFMw9hU3w3RMHL/IDK6EPqp6Nj
 MGEwHQYDVR0OBBYEFFaOmsPwQt4YuUVVbvmTz+rD86UhMB8GA1UdIwQYMBaAFFaO
 msPwQt4YuUVVbvmTz+rD86UhMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQD
-AgGGMAoGCCqGSM49BAMCA0kAMEYCIQCwEhYDJnnUa5TZfsrhLSRk7xFu8hKB5M4d
-d33KXEdQYgIhAIC/Rjxd2OWrR86iGb0h3oVvq8mPAfOrG7nhU9Ykd6ZN
+AgGGMAoGCCqGSM49BAMCA0gAMEUCIQDIZH/uS76DSBPqkvgagh6FsVqkHOPo6iVE
+b+dw/evzdgIgRAKi7MWhruKkitkTlSumWwlXhmFClpfwlWIMA+ZTBCU=
 -----END CERTIFICATE-----

--- a/certs/wolf-ca-rsa-cert.pem
+++ b/certs/wolf-ca-rsa-cert.pem
@@ -2,12 +2,12 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            2c:80:ce:db:47:9d:07:66:92:3d:68:d7:ca:ac:90:4f:ca:69:41:4b
+            33:44:1a:a8:6c:01:ec:f6:60:f2:70:51:0a:4c:d1:14:fa:bc:e9:44
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: C = US, ST = Montana, L = Bozeman, O = Sawtooth, OU = Consulting, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
         Validity
-            Not Before: Dec 16 21:17:49 2022 GMT
-            Not After : Sep 11 21:17:49 2025 GMT
+            Not Before: Dec 13 22:19:28 2023 GMT
+            Not After : Sep  8 22:19:28 2026 GMT
         Subject: C = US, ST = Montana, L = Bozeman, O = Sawtooth, OU = Consulting, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
@@ -38,7 +38,7 @@ Certificate:
             X509v3 Authority Key Identifier: 
                 keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
                 DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:2C:80:CE:DB:47:9D:07:66:92:3D:68:D7:CA:AC:90:4F:CA:69:41:4B
+                serial:33:44:1A:A8:6C:01:EC:F6:60:F2:70:51:0A:4C:D1:14:FA:BC:E9:44
 
             X509v3 Basic Constraints: 
                 CA:TRUE
@@ -47,27 +47,27 @@ Certificate:
             X509v3 Extended Key Usage: 
                 TLS Web Server Authentication, TLS Web Client Authentication
     Signature Algorithm: sha256WithRSAEncryption
-         ae:b0:a4:35:8e:8a:1b:a6:eb:b3:a2:57:cf:3a:1f:dc:6e:bc:
-         d2:d0:a6:4a:8f:88:0a:6e:74:d5:d1:7c:d1:44:b1:d4:3b:17:
-         03:09:5a:46:ed:08:08:cf:f1:fd:20:07:67:c0:97:ec:35:f3:
-         75:ca:20:61:98:3e:f5:4d:be:e6:9d:75:1e:e4:03:ad:8c:a6:
-         1e:3d:ec:e4:1a:92:5b:f9:a3:ad:83:ca:4f:cd:aa:38:bb:6e:
-         ae:ad:fa:a7:46:f1:8b:73:ec:09:23:bc:f2:18:e5:b7:92:86:
-         3e:a4:75:60:c7:3d:0f:3f:83:00:c3:06:08:9c:d1:54:d6:ba:
-         6d:95:3d:34:a1:be:24:91:cc:20:03:11:5b:72:1c:d4:65:d0:
-         11:88:75:26:04:26:ef:66:70:e6:3b:38:87:9c:53:71:1b:09:
-         51:70:50:99:4c:31:0c:62:44:57:30:60:04:fc:12:2c:a3:24:
-         b4:f7:11:d5:0e:b5:21:0b:ed:86:11:67:4d:36:fa:57:a0:59:
-         55:21:b3:6d:e4:77:5e:ec:7e:f0:09:13:8e:99:98:b2:e1:82:
-         b6:4b:3e:0f:41:a6:0c:cd:49:99:7e:e4:8a:cb:37:ed:53:cf:
-         86:5d:a9:26:a8:e5:01:25:5a:b4:bc:25:35:f1:fa:5a:5c:ce:
-         d4:b8:9a:2c
+         2d:fc:f9:32:5a:be:d6:9d:42:8b:86:4e:67:22:c3:50:2d:cb:
+         14:27:1d:94:f3:cd:88:42:da:41:1c:39:24:67:a7:92:4d:27:
+         ea:56:82:19:bf:11:b2:43:a4:8d:5d:87:b2:27:64:66:82:81:
+         df:c4:fd:5b:62:b0:c2:4d:9d:29:f2:41:32:cc:2e:b5:da:38:
+         06:1b:e8:7f:8c:6e:3d:80:1e:00:56:49:bf:39:e0:da:68:2f:
+         c4:fd:00:e6:d1:81:1a:d1:4a:bb:76:52:ce:4d:24:9d:c4:a3:
+         a7:f1:65:14:2f:1f:a8:2d:c6:cb:ce:b1:a7:89:74:26:27:c3:
+         f3:a3:84:4c:34:01:14:03:7d:16:3a:c8:8b:25:2e:7b:90:cc:
+         46:b1:52:34:ba:93:6e:ef:fe:43:a3:ad:c6:6f:51:fb:ba:ea:
+         38:e3:6f:d6:ee:63:62:36:ea:5e:08:b4:e2:2a:46:89:e3:ae:
+         b3:b4:06:ef:63:7a:6e:5d:dd:c9:ec:02:4f:f7:64:c0:27:07:
+         b4:6f:4a:18:72:5b:34:74:7c:d0:a9:04:8f:40:8b:6a:39:d2:
+         6b:1a:01:f2:01:a8:81:34:3a:e5:b0:55:d1:3c:95:ca:b0:82:
+         d6:ed:98:28:15:59:7e:95:a7:69:c7:b5:7b:ec:01:a7:4d:e6:
+         b9:a2:fe:35
 -----BEGIN CERTIFICATE-----
-MIIE/zCCA+egAwIBAgIULIDO20edB2aSPWjXyqyQT8ppQUswDQYJKoZIhvcNAQEL
+MIIE/zCCA+egAwIBAgIUM0QaqGwB7PZg8nBRCkzRFPq86UQwDQYJKoZIhvcNAQEL
 BQAwgZQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdC
 b3plbWFuMREwDwYDVQQKDAhTYXd0b290aDETMBEGA1UECwwKQ29uc3VsdGluZzEY
 MBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdv
-bGZzc2wuY29tMB4XDTIyMTIxNjIxMTc0OVoXDTI1MDkxMTIxMTc0OVowgZQxCzAJ
+bGZzc2wuY29tMB4XDTIzMTIxMzIyMTkyOFoXDTI2MDkwODIyMTkyOFowgZQxCzAJ
 BgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREw
 DwYDVQQKDAhTYXd0b290aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwP
 d3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29t
@@ -82,12 +82,12 @@ BgNVHSMEgcwwgcmAFCeOZxF0wyYdP+0zY7Ok2B0w5ejVoYGapIGXMIGUMQswCQYD
 VQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8G
 A1UECgwIU2F3dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3
 dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIU
-LIDO20edB2aSPWjXyqyQT8ppQUswDAYDVR0TBAUwAwEB/zAcBgNVHREEFTATggtl
+M0QaqGwB7PZg8nBRCkzRFPq86UQwDAYDVR0TBAUwAwEB/zAcBgNVHREEFTATggtl
 eGFtcGxlLmNvbYcEfwAAATAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw
-DQYJKoZIhvcNAQELBQADggEBAK6wpDWOihum67OiV886H9xuvNLQpkqPiApudNXR
-fNFEsdQ7FwMJWkbtCAjP8f0gB2fAl+w183XKIGGYPvVNvuaddR7kA62Mph497OQa
-klv5o62Dyk/Nqji7bq6t+qdG8Ytz7AkjvPIY5beShj6kdWDHPQ8/gwDDBgic0VTW
-um2VPTShviSRzCADEVtyHNRl0BGIdSYEJu9mcOY7OIecU3EbCVFwUJlMMQxiRFcw
-YAT8EiyjJLT3EdUOtSEL7YYRZ002+legWVUhs23kd17sfvAJE46ZmLLhgrZLPg9B
-pgzNSZl+5IrLN+1Tz4ZdqSao5QElWrS8JTXx+lpcztS4miw=
+DQYJKoZIhvcNAQELBQADggEBAC38+TJavtadQouGTmciw1AtyxQnHZTzzYhC2kEc
+OSRnp5JNJ+pWghm/EbJDpI1dh7InZGaCgd/E/VtisMJNnSnyQTLMLrXaOAYb6H+M
+bj2AHgBWSb854NpoL8T9AObRgRrRSrt2Us5NJJ3Eo6fxZRQvH6gtxsvOsaeJdCYn
+w/OjhEw0ARQDfRY6yIslLnuQzEaxUjS6k27v/kOjrcZvUfu66jjjb9buY2I26l4I
+tOIqRonjrrO0Bu9jem5d3cnsAk/3ZMAnB7RvShhyWzR0fNCpBI9Ai2o50msaAfIB
+qIE0OuWwVdE8lcqwgtbtmCgVWX6Vp2nHtXvsAadN5rmi/jU=
 -----END CERTIFICATE-----

--- a/examples/native/native_test.c
+++ b/examples/native/native_test.c
@@ -331,7 +331,7 @@ int TPM2_Native_TestArgs(void* userCtx, int argc, char *argv[])
 #if defined(WOLFTPM_ST33) || defined(WOLFTPM_AUTODETECT)
     if (TPM2_GetVendorID() == TPM_VENDOR_STM) {
         XMEMSET(&cmdIn.getRand, 0, sizeof(cmdIn.getRand));
-        i = (int)sizeof(cmdOut.getRand2.randomBytes);
+        i = (int)sizeof(cmdOut.getRand2.randomBytes.buffer);
         if (i > (MAX_RESPONSE_SIZE-(int)sizeof(UINT16))) {
             i = (MAX_RESPONSE_SIZE-(int)sizeof(UINT16));
         }
@@ -361,7 +361,7 @@ int TPM2_Native_TestArgs(void* userCtx, int argc, char *argv[])
     /* the getRand and getRand2 have same return size header in cmdOut union */
     if (cmdOut.getRand.randomBytes.size != i) {
         printf("TPM2_GetRandom length mismatch %d != %d\n",
-            cmdOut.getRand.randomBytes.size, MAX_RNG_REQ_SIZE);
+            cmdOut.getRand.randomBytes.size, i);
         goto exit;
     }
     printf("TPM2_GetRandom: Got %d bytes\n", cmdOut.getRand.randomBytes.size);
@@ -371,7 +371,7 @@ int TPM2_Native_TestArgs(void* userCtx, int argc, char *argv[])
 
     /* Stir Random */
     XMEMSET(&cmdIn.stirRand, 0, sizeof(cmdIn.stirRand));
-    cmdIn.stirRand.inData.size = cmdOut.getRand.randomBytes.size;
+    cmdIn.stirRand.inData.size = MAX_RNG_REQ_SIZE;
     XMEMCPY(cmdIn.stirRand.inData.buffer,
         cmdOut.getRand.randomBytes.buffer, cmdIn.stirRand.inData.size);
     rc = TPM2_StirRandom(&cmdIn.stirRand);

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -5256,6 +5256,23 @@ TPM_RC TPM2_GetRandom2(GetRandom2_In* in, GetRandom2_Out* out)
     }
     return rc;
 }
+
+TPM_RC TPM2_GetProductInfo(uint8_t* info, uint16_t size)
+{
+    TPM_RC rc;
+    TPM2_CTX* ctx = TPM2_GetActiveCtx();
+    
+    TPM2_Packet packet;
+    TPM2_Packet_Init(ctx, &packet);
+    TPM2_Packet_AppendU32(&packet, 0x100);
+    TPM2_Packet_AppendU32(&packet, 3);
+    TPM2_Packet_AppendU32(&packet, 1);
+    TPM2_Packet_Finalize(&packet, TPM_ST_NO_SESSIONS, TPM_CC_GetCapability);
+    
+    rc = TPM2_SendCommand(ctx, &packet);
+    if (rc == TPM_RC_SUCCESS) memcpy(info, &packet.buf[25], size);
+    return rc;
+}
 #endif /* WOLFTPM_ST33 || WOLFTPM_AUTODETECT */
 
 /* GPIO Vendor Specific API's */

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -5261,16 +5261,38 @@ TPM_RC TPM2_GetProductInfo(uint8_t* info, uint16_t size)
 {
     TPM_RC rc;
     TPM2_CTX* ctx = TPM2_GetActiveCtx();
-    
-    TPM2_Packet packet;
-    TPM2_Packet_Init(ctx, &packet);
-    TPM2_Packet_AppendU32(&packet, 0x100);
-    TPM2_Packet_AppendU32(&packet, 3);
-    TPM2_Packet_AppendU32(&packet, 1);
-    TPM2_Packet_Finalize(&packet, TPM_ST_NO_SESSIONS, TPM_CC_GetCapability);
-    
-    rc = TPM2_SendCommand(ctx, &packet);
-    if (rc == TPM_RC_SUCCESS) memcpy(info, &packet.buf[25], size);
+
+    if (ctx == NULL || info == NULL)
+        return BAD_FUNC_ARG;
+
+    rc = TPM2_AcquireLock(ctx);
+    if (rc == TPM_RC_SUCCESS) {
+        TPM2_Packet packet;
+        TPM2_Packet_Init(ctx, &packet);
+        TPM2_Packet_AppendU32(&packet, TPM_CAP_VENDOR_PROPERTY);
+        TPM2_Packet_AppendU32(&packet, 3); /* cTPM_SUBCAP_VENDOR_GET_PRODUCT_INFO */
+        TPM2_Packet_AppendU32(&packet, 1); /* only 1 property */
+        TPM2_Packet_Finalize(&packet, TPM_ST_NO_SESSIONS, TPM_CC_GetCapability);
+
+        /* send command */
+        rc = TPM2_SendCommand(ctx, &packet);
+        if (rc == TPM_RC_SUCCESS) {
+            /* Product info is:
+             * Serial Number (7 bytes)
+             * Pad (1 byte)
+             * Product ID (PIN) (2 bytes)
+             * Master Product ID (MPIN) (2 bytes)
+             * Product Internal Revision (1 byte)
+             * Pad (3 bytes)
+             * Firmware kernel version (4 bytes)
+             */
+
+            /* start of product info starts at byte 26 */
+            if (size > packet.size - 26)
+                size = packet.size - 26;
+            XMEMCPY(info, &packet.buf[25], size);
+        }
+    }
     return rc;
 }
 #endif /* WOLFTPM_ST33 || WOLFTPM_AUTODETECT */

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -5177,6 +5177,7 @@ int TPM2_SetCommandSet(SetCommandSet_In* in)
         TPM2_Packet packet;
         CmdInfo_t info = {0,0,0,0};
         info.inHandleCnt = 1;
+        info.flags = (CMD_FLAG_AUTH_USER1);
 
         TPM2_Packet_Init(ctx, &packet);
 
@@ -5209,6 +5210,7 @@ int TPM2_SetMode(SetMode_In* in)
         TPM2_Packet packet;
         CmdInfo_t info = {0,0,0,0};
         info.inHandleCnt = 1;
+        info.flags = (CMD_FLAG_AUTH_USER1);
 
         TPM2_Packet_Init(ctx, &packet);
 
@@ -5625,7 +5627,7 @@ const char* TPM2_GetRCString(int rc)
         return "Success";
     }
 
-    if ((rc & RC_WARN) && (rc & RC_FMT1) == 0) {
+    if ((rc & RC_WARN) && (rc & RC_FMT1) == 0 && (rc & RC_VER1) == 0) {
         int rc_warn = rc & RC_MAX_WARN;
 
         switch (rc_warn) {

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -4435,13 +4435,14 @@ int wolfTPM2_NVReadCert(WOLFTPM2_DEV* dev, TPM_HANDLE handle,
     rc = wolfTPM2_NVReadPublic(dev, handle, &nvPublic);
     if (rc == 0) {
         if (buffer == NULL) {
-            /* just return size */
+            /* just set size and return success */
             *len = nvPublic.dataSize;
             return 0;
         }
         if (nvPublic.dataSize > *len) {
             return BUFFER_E;
         }
+        *len = nvPublic.dataSize;
     }
     else {
     #ifdef DEBUG_WOLFTPM

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -7056,7 +7056,7 @@ int wolfTPM2_PolicyAuthorizeMake(TPM_ALG_ID pcrAlg,
 #ifdef WOLFTPM_MFG_IDENTITY
 
 #ifdef TEST_SAMPLE
-static const uint8_t* TPM2_IAK_SAMPLE_MASTER_PASSWORD = {
+static const uint8_t TPM2_IAK_SAMPLE_MASTER_PASSWORD[] = {
     0xFE, 0xEF, 0x8C, 0xDF, 0x1B, 0x77, 0xBD, 0x00,
     0x30, 0x58, 0x5E, 0x47, 0xB8, 0x21, 0x46, 0x0B
 };
@@ -7085,17 +7085,18 @@ int wolfTPM2_SetIdentityAuth(WOLFTPM2_DEV* dev, WOLFTPM2_HANDLE* handle,
     rc = wc_HashInit(&hash_ctx, hashType);
     if (rc == 0) {
         rc = wc_HashUpdate(&hash_ctx, hashType, serialNum, sizeof(serialNum));
-        if (rc == 0)
+        if (rc == 0) {
         #ifdef TEST_SAMPLE
             rc = wc_HashUpdate(&hash_ctx, hashType,
                 TPM2_IAK_SAMPLE_MASTER_PASSWORD,
                 sizeof(TPM2_IAK_SAMPLE_MASTER_PASSWORD));
             (void)masterPassword;
-            (void)masterPasswordSs;
+            (void)masterPasswordSz;
         #else
             rc = wc_HashUpdate(&hash_ctx, hashType,
                 masterPassword, masterPasswordSz);
         #endif
+        }
         if (rc == 0) {
             rc = wc_HashFinal(&hash_ctx, hashType, digest);
         }

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -5089,6 +5089,9 @@ int wolfTPM2_EncryptDecryptBlock(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
         /* try to enable support */
         rc = wolfTPM2_SetCommand(dev, TPM_CC_EncryptDecrypt2, YES);
         if (rc == TPM_RC_SUCCESS) {
+            /* reset session auth for key */
+            wolfTPM2_SetAuthHandle(dev, 0, &key->handle);
+
             /* try command again */
             rc = TPM2_EncryptDecrypt2(&encDecIn, &encDecOut);
         }
@@ -5152,6 +5155,9 @@ int wolfTPM2_SetCommand(WOLFTPM2_DEV* dev, TPM_CC commandCode, int enableFlag)
 #if defined(WOLFTPM_ST33) || defined(WOLFTPM_AUTODETECT)
     if (TPM2_GetVendorID() == TPM_VENDOR_STM) {
         SetCommandSet_In in;
+
+        /* set blank platform auth */
+        wolfTPM2_SetAuthPassword(dev, 0, NULL);
 
         /* Enable commands (like TPM2_EncryptDecrypt2) */
         XMEMSET(&in, 0, sizeof(in));

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -2821,6 +2821,8 @@ WOLFTPM_API TPM_RC TPM2_NV_Certify(NV_Certify_In* in, NV_Certify_Out* out);
      * error is returned, but the TPM returns as much data as a TPM2B_DATA
      * buffer can contain. */
     WOLFTPM_API TPM_RC TPM2_GetRandom2(GetRandom2_In* in, GetRandom2_Out* out);
+
+    WOLFTPM_API TPM_RC TPM2_GetProductInfo(uint8_t* info, uint16_t size);
 #endif
 
 /* Vendor Specific GPIO */

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -1911,6 +1911,9 @@ WOLFTPM_API int wolfTPM2_NVWriteAuth(WOLFTPM2_DEV* dev, WOLFTPM2_NV* nv,
 WOLFTPM_API int wolfTPM2_NVReadAuth(WOLFTPM2_DEV* dev, WOLFTPM2_NV* nv,
     word32 nvIndex, byte* dataBuf, word32* pDataSz, word32 offset);
 
+WOLFTPM_API int wolfTPM2_NVReadCert(WOLFTPM2_DEV* dev, TPM_HANDLE handle,
+    uint8_t* buffer, uint32_t* len);
+
 /*!
     \ingroup wolfTPM2_Wrappers
     \brief Increments an NV one-way counter
@@ -3537,6 +3540,23 @@ WOLFTPM_API int wolfTPM2_PolicyPCRMake(TPM_ALG_ID pcrAlg,
 WOLFTPM_API int wolfTPM2_PolicyAuthorizeMake(TPM_ALG_ID pcrAlg,
     const TPM2B_PUBLIC* pub, byte* digest, word32* digestSz,
     const byte* policyRef, word32 policyRefSz);
+
+
+/* pre-provisioned IAK and IDevID key/cert from TPM vendor */
+#ifdef WOLFTPM_MFG_IDENTITY
+
+/* Initial attestation key (IAK) and an initial device ID (IDevID) */
+/* Default is: ECDSA SECP384P1, SHA2-384 */
+#define TPM2_IAK_KEY_HANDLE     0x81080000
+#define TPM2_IAK_CERT_HANDLE    0x1C20100
+
+#define TPM2_IDEVID_KEY_HANDLE  0x81080001
+#define TPM2_IDEVID_CERT_HANDLE 0x1C20101
+
+WOLFTPM_API int wolfTPM2_SetIdentityAuth(WOLFTPM2_DEV* dev, WOLFTPM2_HANDLE* handle,
+    uint8_t* masterPassword, uint16_t masterPasswordSz);
+
+#endif /* WOLFTPM_MFG_IDENTITY */
 
 
 /* Internal API's */


### PR DESCRIPTION
* Add example for using TPM pre-provisioned device identity to TLS client example.
* Add support for pre-provisioned TPM using the "TPM 2.0 Keys for Device Identity and Attestation" specification. Build macro: `WOLFTPM_MFG_IDENTITY`.
* Added ST33 command for getting product info (serial number)
* Added benchmarks for new ST33KTPM2XI2C. 
* Fixed ST33 vendor command to enable command codes (`TPM2_SetCommandSet`). It requires platform auth to be set. 
* Fixed `0x1XX` error code parsing.