### PR TITLE
Fixes for building wolfTPM examples with `NO_FILESYSTEM`

### DIFF
--- a/examples/boot/secret_seal.c
+++ b/examples/boot/secret_seal.c
@@ -282,6 +282,7 @@ int TPM2_Boot_SecretSeal_Example(void* userCtx, int argc, char *argv[])
     printHexString((const byte*)&sealBlob.pub.publicArea, sealBlob.pub.size, 32);
     printf("Sealed keyed hash priv %d\n", sealBlob.priv.size);
     printHexString(sealBlob.priv.buffer, sealBlob.priv.size, 32);
+    (void)outFile;
 #endif
 
 exit:

--- a/examples/boot/secret_unseal.c
+++ b/examples/boot/secret_unseal.c
@@ -281,6 +281,8 @@ int TPM2_Boot_SecretUnseal_Example(void* userCtx, int argc, char *argv[])
     }
 #else
     printf("File system support not compiled in!\n");
+    (void)publicKeyFile;
+    (void)pcrSigFile;
     rc = NOT_COMPILED_IN;
 #endif
     if (rc != TPM_RC_SUCCESS) {
@@ -314,6 +316,7 @@ int TPM2_Boot_SecretUnseal_Example(void* userCtx, int argc, char *argv[])
 #ifndef NO_FILESYSTEM
     rc = readKeyBlob(sealFile, &sealBlob);
 #else
+    (void)sealFile;
     rc = NOT_COMPILED_IN;
 #endif
     if (rc != TPM_RC_SUCCESS) {

--- a/examples/keygen/keyimport.c
+++ b/examples/keygen/keyimport.c
@@ -221,6 +221,11 @@ int TPM2_Keyimport_Example(void* userCtx, int argc, char *argv[])
         }
     }
     else
+#else
+    (void)encType;
+    (void)attributes;
+    (void)bufSz;
+    (void)isPublicKey;
 #endif
     if (alg == TPM_ALG_RSA) {
         printf("Loading example RSA key (see kRsaKeyPrivQ)\n");

--- a/examples/pcr/policy_sign.c
+++ b/examples/pcr/policy_sign.c
@@ -31,7 +31,8 @@
 
 #include <stdio.h>
 
-#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT)
+#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
+    !defined(NO_FILESYSTEM)
 
 #include <hal/tpm_io.h>
 #include <examples/tpm_test.h>
@@ -66,7 +67,6 @@ static void usage(void)
     printf("./examples/pcr/policy_sign -pcr=16 -pcr=15 -pcrdigest=ba8ac02be16d9d33080d98611d70bb869aa8ac3fc684ab732b91f75f164b36bc\n");
 }
 
-#ifndef NO_FILESYSTEM
 #ifndef WC_MAX_ENCODED_DIG_ASN_SZ
 #define WC_MAX_ENCODED_DIG_ASN_SZ 9 /* enum(bit or octet) + length(4) */
 #endif
@@ -217,7 +217,6 @@ static int PolicySign(TPM_ALG_ID alg, const char* keyFile, const char* password,
     }
     return rc;
 }
-#endif /* !NO_FILESYSTEM */
 
 int TPM2_PCR_PolicySign_Example(void* userCtx, int argc, char *argv[])
 {
@@ -361,9 +360,7 @@ int TPM2_PCR_PolicySign_Example(void* userCtx, int argc, char *argv[])
         if (rc == 0) {
             printf("PCR Policy Signature (%d bytes):\n", sigSz);
             printHexString(sig, sigSz, 32);
-        #if !defined(NO_FILESYSTEM)
             rc = writeBin(outFile, sig, sigSz);
-        #endif
         }
         if (rc == 0) {
             /* Create Signing Authority Policy */
@@ -377,9 +374,7 @@ int TPM2_PCR_PolicySign_Example(void* userCtx, int argc, char *argv[])
             if (rc == 0) {
                 printf("Policy Authorize Digest (%d bytes):\n", digestSz);
                 printHexString(digest, digestSz, digestSz);
-            #if !defined(NO_FILESYSTEM)
                 rc = writeBin(outPolicyFile, digest, digestSz);
-            #endif
             }
         }
     }
@@ -398,7 +393,7 @@ exit:
 
     return rc;
 }
-#endif /* !WOLFTPM2_NO_WRAPPER && !WOLFTPM2_NO_WOLFCRYPT */
+#endif /* !WOLFTPM2_NO_WRAPPER && !WOLFTPM2_NO_WOLFCRYPT && !NO_FILESYSTEM */
 
 /******************************************************************************/
 /* --- END TPM Secure Boot Sign Policy Example -- */
@@ -409,7 +404,8 @@ int main(int argc, char *argv[])
 {
     int rc = NOT_COMPILED_IN;
 
-#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT)
+#if !defined(WOLFTPM2_NO_WRAPPER) && !defined(WOLFTPM2_NO_WOLFCRYPT) && \
+    !defined(NO_FILESYSTEM)
     rc = TPM2_PCR_PolicySign_Example(NULL, argc, argv);
 #else
     printf("Example not compiled in! Requires Wrapper and wolfCrypt\n");

--- a/examples/pkcs7/pkcs7.c
+++ b/examples/pkcs7/pkcs7.c
@@ -204,6 +204,8 @@ static int PKCS7_SignVerifyEx(WOLFTPM2_DEV* dev, int tpmDevId, WOLFTPM2_BUFFER* 
 
         XFCLOSE(pemFile);
     }
+#else
+    (void)outFile;
 #endif
 
     /* Test verify with TPM */
@@ -363,10 +365,12 @@ int TPM2_PKCS7_ExampleArgs(void* userCtx, int argc, char *argv[])
         else if (XSTRCMP(argv[argc-1], "-rsa") == 0) {
             alg = TPM_ALG_RSA;
         }
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         else if (XSTRNCMP(argv[argc-1], "-incert=",
                 XSTRLEN("-incert=")) == 0) {
             inCert = argv[argc-1] + XSTRLEN("-incert=");
         }
+    #endif
         else if (XSTRNCMP(argv[argc-1], "-out=",
                 XSTRLEN("-out=")) == 0) {
             outFile = argv[argc-1] + XSTRLEN("-out=");

--- a/examples/tls/tls_client.c
+++ b/examples/tls/tls_client.c
@@ -404,8 +404,10 @@ int TPM2_TLS_ClientArgs(void* userCtx, int argc, char *argv[])
         printf("Loading RSA certificate\n");
         #ifdef NO_FILESYSTEM
         /* Load "cert" buffer with ASN.1/DER certificate */
+        #if 0
         rc = wolfSSL_CTX_use_certificate_buffer(ctx, cert.buffer, (long)cert.size,
                                                 WOLFSSL_FILETYPE_ASN1);
+        #endif
         #else
         rc = wolfSSL_CTX_use_certificate_file(ctx, "./certs/client-rsa-cert.pem",
                                               WOLFSSL_FILETYPE_PEM);
@@ -425,8 +427,10 @@ int TPM2_TLS_ClientArgs(void* userCtx, int argc, char *argv[])
         printf("Loading ECC certificate\n");
         #ifdef NO_FILESYSTEM
         /* Load "cert" buffer with ASN.1/DER certificate */
+        #if 0
         rc = wolfSSL_CTX_use_certificate_buffer(ctx, cert.buffer, (long)cert.size,
                                                 WOLFSSL_FILETYPE_ASN1);
+        #endif
         #else
         rc = wolfSSL_CTX_use_certificate_file(ctx, "./certs/client-ecc-cert.pem",
                                               WOLFSSL_FILETYPE_PEM);

--- a/examples/tls/tls_server.c
+++ b/examples/tls/tls_server.c
@@ -383,6 +383,7 @@ int TPM2_TLS_ServerArgs(void* userCtx, int argc, char *argv[])
             goto exit;
         }
     #endif
+    (void)useSelfSign;
 #else
     {
         /* Export TPM public key as DER */


### PR DESCRIPTION
Tested with `./configure --enable-swtpm CFLAGS="-DNO_FILESYSTEM" && make`.