### PR TITLE
Fix TLS examples to not use openssl compatibility macros

### DIFF
--- a/examples/tls/tls_client.c
+++ b/examples/tls/tls_client.c
@@ -594,7 +594,7 @@ exit:
     }
 
     /* Bidirectional shutdown */
-    while (wolfSSL_shutdown(ssl) == SSL_SHUTDOWN_NOT_DONE) {
+    while (wolfSSL_shutdown(ssl) == WOLFSSL_SHUTDOWN_NOT_DONE) {
         printf("Shutdown not complete\n");
     }
 

--- a/examples/tls/tls_server.c
+++ b/examples/tls/tls_server.c
@@ -564,7 +564,7 @@ int TPM2_TLS_ServerArgs(void* userCtx, int argc, char *argv[])
         }
 
         /* Bidirectional shutdown */
-        while (wolfSSL_shutdown(ssl) == SSL_SHUTDOWN_NOT_DONE) {
+        while (wolfSSL_shutdown(ssl) == WOLFSSL_SHUTDOWN_NOT_DONE) {
             printf("Shutdown not complete\n");
         }
 
@@ -583,7 +583,7 @@ exit:
 
     if (ssl != NULL) {
         /* Bidirectional shutdown */
-        while (wolfSSL_shutdown(ssl) == SSL_SHUTDOWN_NOT_DONE) {
+        while (wolfSSL_shutdown(ssl) == WOLFSSL_SHUTDOWN_NOT_DONE) {
             printf("Shutdown not complete\n");
         }
 


### PR DESCRIPTION
Fixes issues building wolfSSL with provider or engine enabled.