### PR TITLE
Revise I2C HAL gating logic in tpm_to_infineon

### DIFF
--- a/hal/tpm_io_infineon.c
+++ b/hal/tpm_io_infineon.c
@@ -43,6 +43,7 @@
        defined(WOLFTPM_SWTPM) ||     \
        defined(WOLFTPM_WINAPI) )
 
+#if defined(WOLFTPM_INFINEON_TRICORE) || defined(CY_USING_HAL)
 #ifdef WOLFTPM_I2C
     #ifndef TPM_I2C_TRIES
         #define TPM_I2C_TRIES 10
@@ -148,7 +149,7 @@
 
     #else
         #error Infineon I2C support on this platform not supported yet
-    #endif /* CY_USING_HAL or WOLFTPM_INFINEON_TRICORE */
+    #endif /* CY_USING_HAL */
 
 #else /* SPI */
 
@@ -211,6 +212,8 @@
         #error Infineon I2C support on this platform not supported yet
     #endif /* CY_USING_HAL or WOLFTPM_INFINEON_TRICORE */
 #endif /* SPI or I2C */
+#endif /* WOLFTPM_INFINEON_TRICORE || CY_USING_HAL */
+
 
 #endif /* !(WOLFTPM_LINUX_DEV || WOLFTPM_SWTPM || WOLFTPM_WINAPI) */
 #endif /* WOLFTPM_INCLUDE_IO_FILE */


### PR DESCRIPTION
This PR updates the gating logic in the `hal/tpm_io_infineon.c` to be more consistent with other target platforms.

For example, note how the `tpm_io_microchip.c` is wrapped with `WOLFTPM_MICROCHIP_HARMONY`, disabling the entire file otherwise:

![image](https://github.com/wolfSSL/wolfTPM/assets/13059545/f64e4857-9772-4d24-8070-87d5e1a0818d)

Without this modification, enabling `WOLFTPM_INCLUDE_IO_FILE` and `WOLFTPM_I2C` causes a compile-time error as the only gate is `WOLFTPM_I2C`. In my case, I'm using the Espressf I2C library, not the [cyhal](https://infineon.github.io/psoc6hal/html/index.html) here:

![image](https://github.com/wolfSSL/wolfTPM/assets/13059545/3aa1beba-eace-4a92-ac9d-b452cd692dc7)

Here's the content of my wolfTPM `options.h`:

```
#define WOLFTPM_ADV_IO
#define WOLFTPM_I2C
#define WOLFTPM_EXAMPLE_HAL
#define WOLFSSL_ESPIDF
#define WOLFTPM_INCLUDE_IO_FILE
```

## Testing

I have *not* tested this, as I don't have the target library that is being changed.

