### PR TITLE
Improvements in auth handling to support Policy Password and Policy Auth Value

### DIFF
--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -163,10 +163,10 @@ if [ $WOLFCRYPT_ENABLE -eq 1 ]; then
 
     ./examples/keygen/keygen ecckeyblobeh.bin -ecc -eh >> run.out 2>&1
     RESULT=$?
-    [ $RESULT -ne 0 ] && echo -e "keygen endorsement rsa failed! $RESULT" && exit 1
+    [ $RESULT -ne 0 ] && echo -e "keygen endorsement ecc failed! $RESULT" && exit 1
     ./examples/keygen/keyload ecckeyblobeh.bin -ecc -eh >> run.out 2>&1
     RESULT=$?
-    [ $RESULT -ne 0 ] && echo -e "keygen endorsement rsa failed! $RESULT" && exit 1
+    [ $RESULT -ne 0 ] && echo -e "keyload endorsement ecc failed! $RESULT" && exit 1
 fi
 
 

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -275,6 +275,8 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
 #endif
 
     (void)cmdCode;
+    (void)i;
+
     return rc;
 }
 

--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -391,7 +391,7 @@ TPM_ST TPM2_Packet_AppendAuth(TPM2_Packet* packet, TPM2_CTX* ctx, CmdInfo_t* inf
             }
         }
         /* based on position difference places calculated size at marked U32 above */
-        i = TPM2_Packet_PlaceU32(packet, authTotalSzPos);
+        (void)TPM2_Packet_PlaceU32(packet, authTotalSzPos);
         st = TPM_ST_SESSIONS;
     }
     return st;

--- a/src/tpm2_param_enc.c
+++ b/src/tpm2_param_enc.c
@@ -383,18 +383,42 @@ int TPM2_CalcCpHash(TPMI_ALG_HASH authHash, TPM_CC cmdCode,
         /* Hash Command Code */
         UINT32 ccSwap = TPM2_Packet_SwapU32(cmdCode);
         rc = wc_HashUpdate(&hash_ctx, hashType, (byte*)&ccSwap, sizeof(ccSwap));
+    #ifdef WOLFTPM_DEBUG_VERBOSE
+        printf("cpHash: cmdcode size %d\n", (int)sizeof(TPM_CC));
+        TPM2_PrintBin((unsigned char*)&cmdCode, sizeof(TPM_CC));
+    #endif
 
         /* For Command's only hash each session name */
-        if (rc == 0 && name1 && name1->size > 0)
+        if (rc == 0 && name1 && name1->size > 0) {
+        #ifdef WOLFTPM_DEBUG_VERBOSE
+            printf("Name 0: %d\n", name1->size);
+    		TPM2_PrintBin(name1->name, name1->size);
+        #endif
             rc = wc_HashUpdate(&hash_ctx, hashType, name1->name, name1->size);
-        if (rc == 0 && name2 && name2->size > 0)
+        }
+        if (rc == 0 && name2 && name2->size > 0) {
+        #ifdef WOLFTPM_DEBUG_VERBOSE
+            printf("Name 1: %d\n", name2->size);
+    		TPM2_PrintBin(name2->name, name2->size);
+        #endif
             rc = wc_HashUpdate(&hash_ctx, hashType, name2->name, name2->size);
-        if (rc == 0 && name3 && name3->size > 0)
+        }
+        if (rc == 0 && name3 && name3->size > 0) {
+        #ifdef WOLFTPM_DEBUG_VERBOSE
+            printf("Name 2: %d\n", name3->size);
+    		TPM2_PrintBin(name3->name, name3->size);
+        #endif
             rc = wc_HashUpdate(&hash_ctx, hashType, name3->name, name3->size);
+        }
 
         /* Hash Remainder of parameters - after handles and auth */
-        if (rc == 0)
+        if (rc == 0) {
+        #ifdef WOLFTPM_DEBUG_VERBOSE
+            printf("cpHash: params size %d\n", paramSz);
+            TPM2_PrintBin(param, paramSz);
+        #endif
             rc = wc_HashUpdate(&hash_ctx, hashType, param, paramSz);
+        }
 
         if (rc == 0)
             rc = wc_HashFinal(&hash_ctx, hashType, hash->buffer);

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -903,6 +903,23 @@ int wolfTPM2_SetAuth(WOLFTPM2_DEV* dev, int index,
     }
 
     session = &dev->session[index];
+
+  #ifdef WOLFTPM_DEBUG_VERBOSE
+    printf("Session %d: Edit\n", index);
+    printf("\tHandle 0x%x -> 0x%x\n", session->sessionHandle, sessionHandle);
+    printf("\tAttributes 0x%x -> 0x%x\n", session->sessionAttributes, sessionAttributes);
+    if (auth) {
+        printf("\tAuth Sz %d -> %d\n", session->auth.size, auth->size);
+        TPM2_PrintBin(session->auth.buffer, session->auth.size);
+        TPM2_PrintBin(auth->buffer, auth->size);
+    }
+    if (name) {
+        printf("\tName Sz %d -> %d\n", session->name.size, name->size);
+        TPM2_PrintBin(session->name.name, session->name.size);
+        TPM2_PrintBin(name->name, name->size);
+    }
+#endif
+
     XMEMSET(session, 0, sizeof(TPM2_AUTH_SESSION));
     session->sessionHandle = sessionHandle;
     session->sessionAttributes = sessionAttributes;
@@ -936,10 +953,24 @@ int wolfTPM2_SetAuthHandle(WOLFTPM2_DEV* dev, int index,
     }
 
     if (handle) {
-        TPM2_AUTH_SESSION* session = &dev->session[index];
-        session->policyAuth = handle->policyAuth;
         /* don't set auth for policy session, just name */
         if (handle->policyAuth) {
+            TPM2_AUTH_SESSION* session = &dev->session[index];
+            int authDigestSz = TPM2_GetHashDigestSize(session->authHash);
+        #ifdef WOLFTPM_DEBUG_VERBOSE
+            printf("Session %d: Edit (PolicyAuth)\n", index);
+            printf("\tHandle 0x%x (not touching)\n", session->sessionHandle);
+            printf("\tPolicyAuth %d->%d\n", session->policyAuth, handle->policyAuth);
+            printf("\tAuth Sz %d -> %d\n", session->auth.size, authDigestSz + handle->auth.size);
+            TPM2_PrintBin(session->auth.buffer, session->auth.size);
+            TPM2_PrintBin(handle->auth.buffer, handle->auth.size);
+            printf("\tName Sz %d -> %d\n", session->name.size, handle->name.size);
+            TPM2_PrintBin(session->name.name, session->name.size);
+            TPM2_PrintBin(handle->name.name, handle->name.size);
+        #endif
+            session->policyAuth = handle->policyAuth;
+            session->auth.size = authDigestSz + handle->auth.size;
+            XMEMCPY(&session->auth.buffer[authDigestSz], handle->auth.buffer, handle->auth.size);
             session->name.size = handle->name.size;
             XMEMCPY(session->name.name, handle->name.name, handle->name.size);
             return TPM_RC_SUCCESS;
@@ -963,9 +994,27 @@ int wolfTPM2_SetAuthHandleName(WOLFTPM2_DEV* dev, int index,
     name = &handle->name;
     session = &dev->session[index];
 
-    if (session->sessionHandle == TPM_RS_PW && handle->auth.size > 0) {
-        session->auth.size = handle->auth.size;
-        XMEMCPY(session->auth.buffer, handle->auth.buffer, handle->auth.size);
+    if (handle->auth.size > 0) {
+        if (session->sessionHandle == TPM_RS_PW) {
+            /* password based authentication */
+            session->auth.size = handle->auth.size;
+            XMEMCPY(session->auth.buffer, handle->auth.buffer, handle->auth.size);
+        }
+        else {
+            if (handle->policyPass) {
+                /* use policy password directly */
+                session->auth.size = handle->auth.size;
+                XMEMCPY(session->auth.buffer, handle->auth.buffer, handle->auth.size);
+                session->policyPass = handle->policyPass;
+            }
+            else if (handle->policyAuth) {
+                /* HMAC + policy auth value */
+                int authDigestSz = TPM2_GetHashDigestSize(session->authHash);
+                session->auth.size = authDigestSz + handle->auth.size;
+                XMEMCPY(&session->auth.buffer[authDigestSz], handle->auth.buffer, handle->auth.size);
+                session->policyAuth = handle->policyAuth;
+            }
+        }
     }
     session->name.size = name->size;
     XMEMCPY(session->name.name, name->name, session->name.size);
@@ -995,6 +1044,10 @@ int wolfTPM2_SetAuthSession(WOLFTPM2_DEV* dev, int index,
 
         /* save off session attributes */
         tpmSession->sessionAttributes = sessionAttributes;
+
+        /* Capture auth type */
+        session->policyAuth = tpmSession->handle.policyAuth;
+        session->policyPass = tpmSession->handle.policyPass;
 
         /* define the symmetric algorithm */
         session->authHash = tpmSession->authHash;
@@ -7120,7 +7173,118 @@ int wolfTPM2_PolicyAuthorizeMake(TPM_ALG_ID pcrAlg,
 /* --- END Policy Support -- */
 /******************************************************************************/
 
+/******************************************************************************/
+/* Additional Functions to support policy authorizations - START  */
+/******************************************************************************/
 
+
+int wolfTPM2_SetSessionHandle(WOLFTPM2_DEV* dev, int index, WOLFTPM2_SESSION* tpmSession)
+{
+    TPM2_AUTH_SESSION* session;
+
+    if (dev == NULL || index >= MAX_SESSION_NUM || index < 0) {
+        return BAD_FUNC_ARG;
+    }
+
+    session = &dev->session[index];
+    session->sessionHandle = TPM_RS_PW;
+
+    /* Set password handle unless TPM session is available */
+    if (tpmSession) {
+        session->sessionHandle = tpmSession->handle.hndl;
+
+        session->auth.size = tpmSession->handle.auth.size;
+        XMEMCPY(session->auth.buffer, tpmSession->handle.auth.buffer, tpmSession->handle.auth.size);
+
+        session->name.size = tpmSession->handle.name.size;
+        XMEMCPY(session->name.name, tpmSession->handle.name.name, tpmSession->handle.name.size);
+
+        session->policyAuth = tpmSession->handle.policyAuth;
+        session->policyPass = tpmSession->handle.policyPass;
+    }
+
+    TPM2_SetSessionAuth(dev->session);
+
+    return TPM_RC_SUCCESS;
+}
+
+/* Use this password (in clear) for the policy session instead of the HMAC */
+int wolfTPM2_PolicyPassword(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* tpmSession,
+    const byte* auth, int authSz)
+{
+    PolicyPassword_In policyPasswordIn;
+
+    if (dev == NULL || tpmSession == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (auth != NULL && authSz >= 0) {
+        tpmSession->handle.auth.size = authSz;
+        tpmSession->handle.policyPass = 1;
+        XMEMCPY(tpmSession->handle.auth.buffer, auth, authSz);
+    }
+
+    XMEMSET(&policyPasswordIn, 0, sizeof(policyPasswordIn));
+    policyPasswordIn.policySession = tpmSession->handle.hndl;
+
+    return TPM2_PolicyPassword(&policyPasswordIn);
+}
+
+/* Use this auth with HMAC key on HMAC computation */
+int wolfTPM2_PolicyAuthValue(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* tpmSession,
+    const byte* auth, int authSz)
+{
+    PolicyAuthValue_In policyAuthValueIn;
+
+    if (dev == NULL || tpmSession == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (auth != NULL && authSz >= 0) {
+        int authDigestSz = TPM2_GetHashDigestSize(tpmSession->authHash);
+        tpmSession->handle.auth.size = authDigestSz + authSz;
+        /* leave room for the computed HMAC key */
+        XMEMCPY(&tpmSession->handle.auth.buffer[authDigestSz], auth, authSz);
+        tpmSession->handle.policyAuth = 1;
+    }
+
+    XMEMSET(&policyAuthValueIn, 0, sizeof(policyAuthValueIn));
+    policyAuthValueIn.policySession = tpmSession->handle.hndl;
+
+    return TPM2_PolicyAuthValue(&policyAuthValueIn);
+}
+
+int wolfTPM2_GetKeyTemplate_RSA_policySRK(TPMT_PUBLIC* publicTemplate)
+{
+    TPMA_OBJECT objectAttributes = (
+        TPMA_OBJECT_fixedTPM | TPMA_OBJECT_fixedParent |
+        TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_adminWithPolicy |
+        TPMA_OBJECT_restricted | TPMA_OBJECT_decrypt | TPMA_OBJECT_noDA);
+
+    return GetKeyTemplateRSA(publicTemplate, TPM_ALG_SHA256,
+        objectAttributes, 2048, 0, TPM_ALG_NULL, TPM_ALG_NULL);
+}
+
+int wolfTPM2_GetKeyTemplate_policyKeySeal(TPMT_PUBLIC* publicTemplate, TPM_ALG_ID nameAlg)
+{
+    if (publicTemplate == NULL)
+        return BAD_FUNC_ARG;
+    /* Seal Object can be only of type KEYEDHASH and can not be used for
+     * signing or encryption. Hash algorithm can be chosen by the developer.
+     */
+    XMEMSET(publicTemplate, 0, sizeof(TPMT_PUBLIC));
+    publicTemplate->type = TPM_ALG_KEYEDHASH;
+    publicTemplate->nameAlg = nameAlg;
+    publicTemplate->objectAttributes = (
+        TPMA_OBJECT_fixedTPM | TPMA_OBJECT_fixedParent |
+        TPMA_OBJECT_adminWithPolicy | TPMA_OBJECT_noDA);
+    publicTemplate->parameters.keyedHashDetail.scheme.scheme = TPM_ALG_NULL;
+    return TPM_RC_SUCCESS;
+}
+
+/******************************************************************************/
+/* Additional Functions to support policy authorizations - END  */
+/******************************************************************************/
 
 /******************************************************************************/
 /* --- BEGIN Provisioned TPM Support -- */

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1621,19 +1621,19 @@ typedef struct TPMS_AUTH_RESPONSE {
 
 /* Implementation specific authorization session information */
 typedef struct TPM2_AUTH_SESSION {
-    /* BEGIN */
-    /* This section should match TPMS_AUTH_COMMAND */
+    /* this section is used for TPMS_AUTH_COMMAND */
     TPMI_SH_AUTH_SESSION sessionHandle;
     TPM2B_NONCE nonceCaller;
     TPMA_SESSION sessionAttributes;
     TPM2B_AUTH auth;
-    /* END */
 
     /* additional auth data required for implementation */
     TPM2B_NONCE nonceTPM;
     TPMT_SYM_DEF symmetric;
     TPMI_ALG_HASH authHash;
     TPM2B_NAME name;
+
+    unsigned int policyAuth : 1; /* if policy auth should be used */
 } TPM2_AUTH_SESSION;
 
 /* Macros to determine TPM 2.0 Session type */

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1625,15 +1625,17 @@ typedef struct TPM2_AUTH_SESSION {
     TPMI_SH_AUTH_SESSION sessionHandle;
     TPM2B_NONCE nonceCaller;
     TPMA_SESSION sessionAttributes;
-    TPM2B_AUTH auth;
+    TPM2B_AUTH hmac;
 
     /* additional auth data required for implementation */
     TPM2B_NONCE nonceTPM;
     TPMT_SYM_DEF symmetric;
     TPMI_ALG_HASH authHash;
     TPM2B_NAME name;
+    TPM2B_AUTH auth;
 
     unsigned int policyAuth : 1; /* if policy auth should be used */
+    unsigned int policyPass : 1;
 } TPM2_AUTH_SESSION;
 
 /* Macros to determine TPM 2.0 Session type */

--- a/wolftpm/tpm2_packet.h
+++ b/wolftpm/tpm2_packet.h
@@ -111,7 +111,7 @@ WOLFTPM_LOCAL void TPM2_Packet_ParseBytes(TPM2_Packet* packet, byte* buf, int si
 WOLFTPM_LOCAL void TPM2_Packet_MarkU16(TPM2_Packet* packet, int* markSz);
 WOLFTPM_LOCAL int  TPM2_Packet_PlaceU16(TPM2_Packet* packet, int markSz);
 WOLFTPM_LOCAL void TPM2_Packet_MarkU32(TPM2_Packet* packet, int* markSz);
-WOLFTPM_LOCAL void TPM2_Packet_PlaceU32(TPM2_Packet* packet, int markSz);
+WOLFTPM_LOCAL int  TPM2_Packet_PlaceU32(TPM2_Packet* packet, int markSz);
 WOLFTPM_LOCAL TPM_ST TPM2_Packet_AppendAuth(TPM2_Packet* packet, TPM2_CTX* ctx, CmdInfo_t* info);
 WOLFTPM_LOCAL void TPM2_Packet_AppendAuthCmd(TPM2_Packet* packet, TPMS_AUTH_COMMAND* authCmd);
 WOLFTPM_LOCAL void TPM2_Packet_ParseAuth(TPM2_Packet* packet, TPMS_AUTH_RESPONSE* auth);

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -494,15 +494,36 @@ WOLFTPM_API int wolfTPM2_SetAuthHandle(WOLFTPM2_DEV* dev, int index, const WOLFT
 
     \param dev pointer to a TPM2_DEV struct
     \param index integer value, specifying the TPM Authorization slot, between zero and three
-    \param tpmSession sessionHandle integer value of TPM_HANDLE type
+    \param tpmSession pointer to a WOLFTPM2_SESSION struct used with wolfTPM2_StartSession and wolfTPM2_SetAuthSession
     \param sessionAttributes integer value of type TPMA_SESSION, selecting one or more attributes for the Session
 
     \sa wolfTPM2_SetAuth
     \sa wolfTPM2_SetAuthPassword
     \sa wolfTPM2_SetAuthHandle
+    \sa wolfTPM2_SetSessionHandle
 */
 WOLFTPM_API int wolfTPM2_SetAuthSession(WOLFTPM2_DEV* dev, int index,
     WOLFTPM2_SESSION* tpmSession, TPMA_SESSION sessionAttributes);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Sets a TPM Authorization slot using the provided wolfTPM2 session object
+    \note This wrapper is useful for configuring TPM sessions, e.g. session for parameter encryption
+
+    \return TPM_RC_SUCCESS: successful
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a TPM2_DEV struct
+    \param index integer value, specifying the TPM Authorization slot, between zero and three
+    \param tpmSession pointer to a WOLFTPM2_SESSION struct used with wolfTPM2_StartSession and wolfTPM2_SetAuthSession
+
+    \sa wolfTPM2_SetAuth
+    \sa wolfTPM2_SetAuthPassword
+    \sa wolfTPM2_SetAuthHandle
+    \sa wolfTPM2_SetAuthSession
+*/
+WOLFTPM_API int wolfTPM2_SetSessionHandle(WOLFTPM2_DEV* dev, int index,
+    WOLFTPM2_SESSION* tpmSession);
 
 /*!
     \ingroup wolfTPM2_Wrappers
@@ -1924,10 +1945,36 @@ WOLFTPM_API int wolfTPM2_NVCreateAuthPolicy(WOLFTPM2_DEV* dev, WOLFTPM2_HANDLE* 
     \sa wolfTPM2_NVReadAuth
     \sa wolfTPM2_NVCreateAuth
     \sa wolfTPM2_NVDeleteAuth
+    \sa wolfTPM2_NVWriteAuthPolicy
 */
 WOLFTPM_API int wolfTPM2_NVWriteAuth(WOLFTPM2_DEV* dev, WOLFTPM2_NV* nv,
     word32 nvIndex, byte* dataBuf, word32 dataSz, word32 offset);
 
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Stores user data to a NV Index, at a given offset. Allows using a policy session and PCR's for authentication.
+    \note User data size should be less or equal to the NV Index maxSize specified using wolfTPM2_CreateAuth
+
+    \return TPM_RC_SUCCESS: successful
+    \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a TPM2_DEV struct
+    \param tpmSession pointer to a WOLFTPM2_SESSION struct used with wolfTPM2_StartSession and wolfTPM2_SetAuthSession
+    \param pcrAlg the hash algorithm to use with PCR policy
+    \param pcrArray array of PCR Indexes to use when creating the policy
+    \param pcrArraySz the number of PCR Indexes in the pcrArray
+    \param nv pointer to a populated structure of WOLFTPM2_NV type
+    \param nvIndex integer value, holding an existing NV Index Handle value
+    \param dataBuf pointer to a byte buffer, containing the user data to be written to the TPM's NVRAM
+    \param dataSz integer value, specifying the size of the user data buffer, in bytes
+    \param offset integer value of word32 type, specifying the offset from the NV Index memory start, can be zero
+
+    \sa wolfTPM2_NVReadAuth
+    \sa wolfTPM2_NVCreateAuth
+    \sa wolfTPM2_NVDeleteAuth
+    \sa wolfTPM2_NVWriteAuth
+*/
 WOLFTPM_API int wolfTPM2_NVWriteAuthPolicy(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* tpmSession,
     TPM_ALG_ID pcrAlg, byte* pcrArray, word32 pcrArraySz, WOLFTPM2_NV* nv,
     word32 nvIndex, byte* dataBuf, word32 dataSz, word32 offset);
@@ -1951,14 +1998,57 @@ WOLFTPM_API int wolfTPM2_NVWriteAuthPolicy(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* 
     \sa wolfTPM2_NVWriteAuth
     \sa wolfTPM2_NVCreateAuth
     \sa wolfTPM2_NVDeleteAuth
+    \sa wolfTPM2_NVReadAuthPolicy
 */
 WOLFTPM_API int wolfTPM2_NVReadAuth(WOLFTPM2_DEV* dev, WOLFTPM2_NV* nv,
     word32 nvIndex, byte* dataBuf, word32* pDataSz, word32 offset);
 
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Reads user data from a NV Index, starting at the given offset. Allows using a policy session and PCR's for authentication.
+    \note User data size should be less or equal to the NV Index maxSize specified using wolfTPM2_CreateAuth
+
+    \return TPM_RC_SUCCESS: successful
+    \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a TPM2_DEV struct
+    \param tpmSession pointer to a WOLFTPM2_SESSION struct used with wolfTPM2_StartSession and wolfTPM2_SetAuthSession
+    \param pcrAlg the hash algorithm to use with PCR policy
+    \param pcrArray array of PCR Indexes to use when creating the policy
+    \param pcrArraySz the number of PCR Indexes in the pcrArray
+    \param nv pointer to a populated structure of WOLFTPM2_NV type
+    \param nvIndex integer value, holding an existing NV Index Handle value
+    \param dataBuf pointer to an empty byte buffer, used to store the read data from the TPM's NVRAM
+    \param pDataSz pointer to an integer variable, used to store the size of the data read from NVRAM, in bytes
+    \param offset integer value of word32 type, specifying the offset from the NV Index memory start, can be zero
+
+    \sa wolfTPM2_NVWriteAuth
+    \sa wolfTPM2_NVCreateAuth
+    \sa wolfTPM2_NVDeleteAuth
+    \sa wolfTPM2_NVReadAuth
+*/
 WOLFTPM_API int wolfTPM2_NVReadAuthPolicy(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* tpmSession,
     TPM_ALG_ID pcrAlg, byte* pcrArray, word32 pcrArraySz, WOLFTPM2_NV* nv,
     word32 nvIndex, byte* dataBuf, word32* pDataSz, word32 offset);
 
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Helper to get size of NV and read buffer without authentication. Typically used for reading a certificate from an NV.
+
+    \return TPM_RC_SUCCESS: successful
+    \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a TPM2_DEV struct
+    \param handle integer value, holding an existing NV Index Handle value
+    \param buffer pointer to an empty byte buffer, used to store the read data from the TPM's NVRAM
+    \param len pointer to an integer variable, used to store the size of the data read from NVRAM, in bytes
+
+    \sa wolfTPM2_NVWriteAuth
+    \sa wolfTPM2_NVCreateAuth
+    \sa wolfTPM2_NVDeleteAuth
+*/
 WOLFTPM_API int wolfTPM2_NVReadCert(WOLFTPM2_DEV* dev, TPM_HANDLE handle,
     uint8_t* buffer, uint32_t* len);
 
@@ -3589,6 +3679,46 @@ WOLFTPM_API int wolfTPM2_PolicyAuthorizeMake(TPM_ALG_ID pcrAlg,
     const TPM2B_PUBLIC* pub, byte* digest, word32* digestSz,
     const byte* policyRef, word32 policyRefSz);
 
+/*!
+    \ingroup wolfTPM2_Wrappers
+
+    \brief Wrapper for setting a policy password and calling TPM2_PolicyPassword.
+    This will set a password (in clear) for the policy session instead of HMAC.
+
+    \return TPM_RC_SUCCESS: successful
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a TPM2_DEV struct
+    \param sessionHandle the handle of the current policy session, a session is required to use policy PCR
+    \param tpmSession pointer to a WOLFTPM2_SESSION struct used with wolfTPM2_StartSession and wolfTPM2_SetAuthSession
+    \param auth pointer to a string constant, specifying the password authorization for the policy session
+    \param authSz integer value, specifying the size of the password authorization, in bytes
+
+    \sa wolfTPM2_PolicyAuthValue
+*/
+WOLFTPM_API int wolfTPM2_PolicyPassword(WOLFTPM2_DEV* dev,
+    WOLFTPM2_SESSION* tpmSession, const byte* auth, int authSz);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+
+    \brief Wrapper for setting a policy auth value that is added to the HMAC key for a policy session.
+
+    \return TPM_RC_SUCCESS: successful
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a TPM2_DEV struct
+    \param sessionHandle the handle of the current policy session, a session is required to use policy PCR
+    \param tpmSession pointer to a WOLFTPM2_SESSION struct used with wolfTPM2_StartSession and wolfTPM2_SetAuthSession
+    \param auth pointer to a string constant, specifying the password authorization for the policy session
+    \param authSz integer value, specifying the size of the password authorization, in bytes
+
+    \sa wolfTPM2_PolicyPassword
+*/
+WOLFTPM_API int wolfTPM2_PolicyAuthValue(WOLFTPM2_DEV* dev,
+    WOLFTPM2_SESSION* tpmSession, const byte* auth, int authSz);
+
+
 
 /* pre-provisioned IAK and IDevID key/cert from TPM vendor */
 #ifdef WOLFTPM_MFG_IDENTITY
@@ -3634,14 +3764,6 @@ WOLFTPM_API int wolfTPM2_FirmwareUpgradeRecover(WOLFTPM2_DEV* dev,
 WOLFTPM_API int wolfTPM2_FirmwareUpgradeCancel(WOLFTPM2_DEV* dev);
 
 #endif /* WOLFTPM_FIRMWARE_UPGRADE */
-
-
-WOLFTPM_API int wolfTPM2_SetSessionHandle(WOLFTPM2_DEV* dev, int index, WOLFTPM2_SESSION* tpmSession);
-/* Use this password (in clear) for the policy session instead of the HMAC */
-WOLFTPM_API int wolfTPM2_PolicyPassword(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* tpmSession, const byte* auth, int authSz);
-WOLFTPM_API int wolfTPM2_PolicyAuthValue(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* tpmSession, const byte* auth, int authSz);
-WOLFTPM_API int wolfTPM2_GetKeyTemplate_RSA_policySRK(TPMT_PUBLIC* publicTemplate);
-WOLFTPM_API int wolfTPM2_GetKeyTemplate_policyKeySeal(TPMT_PUBLIC* publicTemplate, TPM_ALG_ID nameAlg);
 
 
 #ifdef __cplusplus

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -3689,7 +3689,6 @@ WOLFTPM_API int wolfTPM2_PolicyAuthorizeMake(TPM_ALG_ID pcrAlg,
     \return BAD_FUNC_ARG: check the provided arguments
 
     \param dev pointer to a TPM2_DEV struct
-    \param sessionHandle the handle of the current policy session, a session is required to use policy PCR
     \param tpmSession pointer to a WOLFTPM2_SESSION struct used with wolfTPM2_StartSession and wolfTPM2_SetAuthSession
     \param auth pointer to a string constant, specifying the password authorization for the policy session
     \param authSz integer value, specifying the size of the password authorization, in bytes
@@ -3708,7 +3707,6 @@ WOLFTPM_API int wolfTPM2_PolicyPassword(WOLFTPM2_DEV* dev,
     \return BAD_FUNC_ARG: check the provided arguments
 
     \param dev pointer to a TPM2_DEV struct
-    \param sessionHandle the handle of the current policy session, a session is required to use policy PCR
     \param tpmSession pointer to a WOLFTPM2_SESSION struct used with wolfTPM2_StartSession and wolfTPM2_SetAuthSession
     \param auth pointer to a string constant, specifying the password authorization for the policy session
     \param authSz integer value, specifying the size of the password authorization, in bytes

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -31,10 +31,12 @@
 
 typedef struct WOLFTPM2_HANDLE {
     TPM_HANDLE      hndl;
-    TPM2B_AUTH      auth;       /* Used if policyAuth is not set */
+    TPM2B_AUTH      auth;
     TPMT_SYM_DEF    symmetric;
     TPM2B_NAME      name;
-    int             policyAuth; /* Handle requires Policy, not password Auth */
+
+    /* bit-fields */
+    unsigned int    policyAuth : 1; /* Handle requires policy auth */
     unsigned int    nameLoaded : 1; /* flag to indicate if "name" was loaded and computed */
 } WOLFTPM2_HANDLE;
 

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -36,6 +36,7 @@ typedef struct WOLFTPM2_HANDLE {
     TPM2B_NAME      name;
 
     /* bit-fields */
+    unsigned int    policyPass : 1;
     unsigned int    policyAuth : 1; /* Handle requires policy auth */
     unsigned int    nameLoaded : 1; /* flag to indicate if "name" was loaded and computed */
 } WOLFTPM2_HANDLE;
@@ -3625,6 +3626,15 @@ WOLFTPM_API int wolfTPM2_FirmwareUpgradeRecover(WOLFTPM2_DEV* dev,
 WOLFTPM_API int wolfTPM2_FirmwareUpgradeCancel(WOLFTPM2_DEV* dev);
 
 #endif /* WOLFTPM_FIRMWARE_UPGRADE */
+
+
+WOLFTPM_API int wolfTPM2_SetSessionHandle(WOLFTPM2_DEV* dev, int index, WOLFTPM2_SESSION* tpmSession);
+/* Use this password (in clear) for the policy session instead of the HMAC */
+WOLFTPM_API int wolfTPM2_PolicyPassword(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* tpmSession, const byte* auth, int authSz);
+WOLFTPM_API int wolfTPM2_PolicyAuthValue(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* tpmSession, const byte* auth, int authSz);
+WOLFTPM_API int wolfTPM2_GetKeyTemplate_RSA_policySRK(TPMT_PUBLIC* publicTemplate);
+WOLFTPM_API int wolfTPM2_GetKeyTemplate_policyKeySeal(TPMT_PUBLIC* publicTemplate, TPM_ALG_ID nameAlg);
+
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -1928,6 +1928,10 @@ WOLFTPM_API int wolfTPM2_NVCreateAuthPolicy(WOLFTPM2_DEV* dev, WOLFTPM2_HANDLE* 
 WOLFTPM_API int wolfTPM2_NVWriteAuth(WOLFTPM2_DEV* dev, WOLFTPM2_NV* nv,
     word32 nvIndex, byte* dataBuf, word32 dataSz, word32 offset);
 
+WOLFTPM_API int wolfTPM2_NVWriteAuthPolicy(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* tpmSession,
+    TPM_ALG_ID pcrAlg, byte* pcrArray, word32 pcrArraySz, WOLFTPM2_NV* nv,
+    word32 nvIndex, byte* dataBuf, word32 dataSz, word32 offset);
+
 /*!
     \ingroup wolfTPM2_Wrappers
     \brief Reads user data from a NV Index, starting at the given offset
@@ -1949,6 +1953,10 @@ WOLFTPM_API int wolfTPM2_NVWriteAuth(WOLFTPM2_DEV* dev, WOLFTPM2_NV* nv,
     \sa wolfTPM2_NVDeleteAuth
 */
 WOLFTPM_API int wolfTPM2_NVReadAuth(WOLFTPM2_DEV* dev, WOLFTPM2_NV* nv,
+    word32 nvIndex, byte* dataBuf, word32* pDataSz, word32 offset);
+
+WOLFTPM_API int wolfTPM2_NVReadAuthPolicy(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* tpmSession,
+    TPM_ALG_ID pcrAlg, byte* pcrArray, word32 pcrArraySz, WOLFTPM2_NV* nv,
     word32 nvIndex, byte* dataBuf, word32* pDataSz, word32 offset);
 
 WOLFTPM_API int wolfTPM2_NVReadCert(WOLFTPM2_DEV* dev, TPM_HANDLE handle,


### PR DESCRIPTION
* Refactor to eliminate confusing cast between TPMS_AUTH_COMMAND and TPM2_AUTH_SESSION.
* Adds support for `TPM2_PolicyAuthValue` and `TPM2_PolicyPassword`.
* Adds NV policy read/write API's: `wolfTPM2_NVReadAuthPolicy` and `wolfTPM2_NVWriteAuthPolicy`.
ZD 17739
