### PR TITLE
fix autogen.sh for WSL/Windows git hook file link attempt

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -5,12 +5,39 @@
 
 set -e
 
+# Check environment
+if [ -n "$WSL_DISTRO_NAME" ]; then
+    # we found a non-blank WSL environment distro name
+    current_path="$(pwd)"
+    pattern="/mnt/?"
+    if [ "$(echo "$current_path" | grep -E "^$pattern")" ]; then
+        # if we are in WSL and shared Windows file system, 'ln' does not work.
+        no_links=true
+    else
+        no_links=
+    fi
+fi
+
 # Git hooks should come before autoreconf.
 if test -d .git; then
-  if ! test -d .git/hooks; then
-    mkdir .git/hooks
-  fi
-  ln -s -f ../../pre-commit.sh .git/hooks/pre-commit
+    if [ -n "$no_links" ]; then
+        echo "Linux ln does not work on shared Windows file system in WSL."
+        if [ ! -e .git/hooks/pre-commit ]; then
+            echo "The pre-commit.sh file will not be copied to .git/hooks/pre-commit"
+            # shell scripts do not work on Windows; TODO create equivalent batch file
+            # cp ./pre-commit.sh .git/hooks/pre-commit || exit $?
+        fi
+        if [ ! -e .git/hooks/pre-push ]; then
+            echo "The pre-push.sh file will not be copied to .git/hooks/pre-commit"
+            # shell scripts do not work on Windows; TODO create equivalent batch file
+            # cp ./pre-push.sh .git/hooks/pre-push || exit $?
+        fi
+    else
+      if ! test -d .git/hooks; then
+        mkdir .git/hooks
+      fi
+      ln -s -f ../../pre-commit.sh .git/hooks/pre-commit
+    fi
 fi
 
 # if get an error about libtool not setup


### PR DESCRIPTION
Similar to https://github.com/wolfSSL/wolfssl/pull/6798 this PR addresses https://github.com/wolfSSL/wolfTPM/issues/346 for wolfTPM.

The `autogen.sh` is updated to check for WSL/Windows, and if detected, does not attempt to link git hook files. When running in WSL for a Windows drive, (e.g. `/mnt/c/`) new warning messages will appear regarding not attempting to link the `pre-commit` files which otherwise don't actually get linked. Rather, a zero length file is created, causing an Visual Studio.

```
gojimmypi:/mnt/c/workspace/wolfTPM-gojimmypi-pr
$ ./autogen.sh
Linux ln does not work on shared Windows file system in WSL.
The pre-commit.sh file will not be copied to .git/hooks/pre-commit
The pre-push.sh file will not be copied to .git/hooks/pre-commit
Making missing build-aux directory.
Touching missing build-aux/config.rpath file.
autoreconf: export WARNINGS=
autoreconf: Entering directory '.'
autoreconf: configure.ac: not using Gettext
[... snip / etc ...]
```

This PR addresses https://github.com/wolfSSL/wolfTPM/issues/346