### PR TITLE
memcmp -> memcpy

### DIFF
--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -373,7 +373,7 @@ static int TPM2_ResponseProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
 
             /* Save off last known HMAC */
             session->hmac.size = authRsp.hmac.size;
-            XMEMCMP(session->hmac.buffer, authRsp.hmac.buffer,
+            XMEMCPY(session->hmac.buffer, authRsp.hmac.buffer,
                 authRsp.hmac.size);
         #else
             (void)cmdCode;


### PR DESCRIPTION
fixes this [issue](https://cloud.wolfssl-test.com/jenkins/job/wolfSSL/job/nightly-wolfTPM-examples-v2/1971/parsed_console/).

tested locally with `swtpm2` and running the examples.