### PR TITLE
Fix issue with Doxygen generation in tpm2.h due to unnamed enum

### DIFF
--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -2976,6 +2976,7 @@ int wolfTPM2_ExportPublicKeyBuffer(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
             }
         }
     #else
+        (void)out;
         rc = NOT_COMPILED_IN;
     #endif
     }
@@ -3008,6 +3009,7 @@ int wolfTPM2_ExportPublicKeyBuffer(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* tpmKey,
             }
         }
     #else
+        (void)out;
         rc = NOT_COMPILED_IN;
     #endif
     }

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -2802,7 +2802,8 @@ WOLFTPM_API TPM_RC TPM2_NV_Certify(NV_Certify_In* in, NV_Certify_Out* out);
     } SetCommandSet_In;
     WOLFTPM_API int TPM2_SetCommandSet(SetCommandSet_In* in);
 
-    enum {
+    /* Mode bit-masks for STMicro ST33 */
+    enum TPM_MODE_Vendor_Mask{
         TPMLib_2 = 0x01,
         TPMFips = 0x02,
         TPMLowPowerOff = 0x00,


### PR DESCRIPTION
Fix issue with Doxygen generation of wolfTPM due to doxybook2 crashing on unnamed enum.