### PR TITLE
Fix issue with license header matching.

### DIFF
--- a/IDE/Espressif/main/main.c
+++ b/IDE/Espressif/main/main.c
@@ -1,4 +1,6 @@
-/* wolftpm test main.c
+/* main.c
+ *
+ * Copyright (C) 2006-2024 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *


### PR DESCRIPTION
Resolves:

```
Running grep on input directory for 'General Public' mentions:
[SKIPPING: *.m4, build-aux, configure, *.json]
/Users/davidgarske/Projects/WolfSSL/TPM/wolftpm-3.4.0-commercial/IDE/Espressif/main/main.c:6: * it under the terms of the GNU General Public License as published by
/Users/davidgarske/Projects/WolfSSL/TPM/wolftpm-3.4.0-commercial/IDE/Espressif/main/main.c:13: * GNU General Public License for more details.
/Users/davidgarske/Projects/WolfSSL/TPM/wolftpm-3.4.0-commercial/IDE/Espressif/main/main.c:15: * You should have received a copy of the GNU General Public License
```