### PR TITLE
Various improvements for `/dev/tpm0`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ ek.pem
 
 # Generated Documentation
 docs/html
+docs/xml
 
 # Wrapper
 wrapper/CSharp/obj

--- a/IDE/Espressif/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/components/wolfssl/include/user_settings.h
@@ -394,7 +394,7 @@
     /***** END CONFIG_IDF_TARGET_ESP8684 *****/
 
 #else
-    /* Anything else encountered, disable HW accleration */
+    /* Anything else encountered, disable HW acceleration */
     #warning "Unexpected CONFIG_IDF_TARGET_NN value"
     #define NO_ESP32_CRYPT
     #define NO_WOLFSSL_ESP32_CRYPT_HASH
@@ -662,7 +662,7 @@ Turn on timer debugging (used when CPU cycles not available)
  * Do not exceed a value of 400000 */
 /* #define I2C_MASTER_FREQ_HZ 100000 */
 
-/* Examples may have a main() function, we'll have oour own: */
+/* Examples may have a main() function, we'll have our own: */
 #define NO_MAIN_DRIVER
 
 /* I2C GPIO settings are defined in idf.py menuconfig

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ cd wolfTPM
 make
 ```
 
+The default is SLB9672/SLB9673 (if I2C). To specify SLB9670 use `--enable-infineon=slb9670`.
+
 ### Building ST ST33
 
 Build wolfTPM:
@@ -268,9 +270,9 @@ idf.py build
 
 ### Building for "/dev/tpmX"
 
-This build option allows you to talk to any TPM vendor supported by the Linux TIS kernel driver
+The `--enable-devtpm` or `WOLFTPM_LINUX_DEV` build option allows you to use the Linux supplied TPM (TIS) driver.
 
-Build wolfTPM:
+To specify a different `/dev/tpmX` device use `CFLAGS="-DTPM2_LINUX_DEV=/dev/tpm1"`
 
 ```bash
 ./autogen.sh
@@ -278,11 +280,30 @@ Build wolfTPM:
 make
 ```
 
-Note: When using a TPM device through the Linux kernel driver make sure sufficient permissions are given to the application that uses wolfTPM, because the "/dev/tpmX" typically has read-write permissions only for the "tss" user group. Either run wolfTPM examples and your application using sudo or add your user to the "tss" group like this:
+The `TPM2_Init` or `wolfTPM2_Init` calls should use NULL for the HAL IO callback argument. The default HAL IO `TPM2_IoCb` maps to a macro specifying NULL (`#define TPM2_IoCb NULL`) in tpm_io.h for the devtpm option.
+
+By default the `/dev/tpmX` requires sudo permissions to use it. If using the tpm2-tss it will install a "tss" group that you can add permissions to `sudo adduser [username] tss`.
+
+To add your own custom wolfTPM rule for /dev/tpm0 do the following:
+
+1) Create new group and add your user to it (replace "[username]" with yours):
 
 ```bash
-sudo adduser yourusername tss
+sudo addgroup wolftpm
+sudo adduser [username] wolftpm
+sudo chgrp wolftpm /dev/tpm0
 ```
+
+2) Create new rule file: `sudo vim /etc/udev/rules.d/wolftpm-udev.rules`
+
+3) Add the following replacing "yourusername" with actual user or group.
+
+```
+KERNEL=="tpm[0-9]*", TAG+="systemd", MODE="0660", GROUP="wolftpm"
+```
+
+4) Reboot or reload rules: `sudo udevadm control -R`
+
 
 ### Building for SWTPM
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ sudo chgrp wolftpm /dev/tpm0
 
 2) Create new rule file: `sudo vim /etc/udev/rules.d/wolftpm-udev.rules`
 
-3) Add the following replacing "yourusername" with actual user or group.
+3) Add the following rule to file:
 
 ```
 KERNEL=="tpm[0-9]*", TAG+="systemd", MODE="0660", GROUP="wolftpm"

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -870,6 +870,7 @@ INPUT                  = ./docs/README.md \
                          ./examples/pcr/README.md \
                          ./examples/attestation/README.md \
                          ./examples/boot/README.md \
+                         ./hal/README.md \
                          ./wolftpm/tpm2.h \
                          ./wolftpm/tpm2_wrap.h \
                          ./hal/tpm_io.h

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,6 +98,8 @@ Every example application that is included with wolfTPM includes the `tpm_io.h` 
 
 The `tpm_io.c` file sets up the example HAL IO callback necessary for testing and running the example applications with a Linux Kernel, STM32 CubeMX HAL or Atmel/Microchip ASF. The reference is easily modified, such that custom IO callbacks or different callbacks may be added or removed as desired.
 
+See [hal/README.md](/hal/README.md) for HAL IO callback details.
+
 ## API Reference
 
 See [https://www.wolfssl.com/docs/wolftpm-manual/](https://www.wolfssl.com/docs/wolftpm-manual/).

--- a/examples/pcr/README.md
+++ b/examples/pcr/README.md
@@ -1,6 +1,6 @@
 # Quote & Attestation Demo
 
-This folder contains examples for performing local attestation. You will learn how to measure a system file using wolfTPM and then generate a TPM 2.0 Quote as proof for that measurement. See [Technology Introduction](## Technology introduction) below.
+This folder contains examples for performing local attestation. You will learn how to measure a system file using wolfTPM and then generate a TPM 2.0 Quote as proof for that measurement. See [Technology Introduction](/examples/pcr/README.md#technology-introduction) below.
 
 ## List of examples
 
@@ -18,7 +18,7 @@ Scripts:
 * `./examples/pcr/demo-quote-zip.sh` - script demonstrating how using the tools above a system file can be measured and a TPM-signed proof with that measurement generated
 
 
-## Technology introduction
+## Technology Introduction
 
 ### Platform Configuration Registers (PCR)
 

--- a/src/tpm2_linux.c
+++ b/src/tpm2_linux.c
@@ -69,7 +69,7 @@ int TPM2_LINUX_SendCommand(TPM2_CTX* ctx, TPM2_Packet* packet)
 #endif
 
     fd = open(TPM2_LINUX_DEV, O_RDWR | O_NONBLOCK);
-    if (fd > 0) {
+    if (fd >= 0) {
         /* Send the TPM command */
         if (write(fd, packet->buf, packet->pos) == packet->pos) {
             fds.fd = fd;

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -39,7 +39,7 @@
  * * Windows systems
  * * Hybrid SoC
  * * Linux using /dev/tpm0
- * * Linux using devspi
+ * * Linux using spidev driver
  * * Linux using i2c driver
  *
  * Typically, a wolfTPM developer would use the wolfTPM2 wrappers for quicker development.


### PR DESCRIPTION
* Fix for /dev/tpm0 file descriptor check (fixes #365). 
* Added documentation for /dev/tpm0 permissions (fixes #358). 
* Various spelling and documentation cleanups.