### PR TITLE
Fixes for PCR selection and keygen with `-sym=` option

### DIFF
--- a/examples/gpio/gpio_config.c
+++ b/examples/gpio/gpio_config.c
@@ -363,7 +363,7 @@ int TPM2_GPIO_Config_Example(void* userCtx, int argc, char *argv[])
 #endif
 
     /* Prepare GPIO configuration according to Nuvoton requirements */
-    if(gpioMode == TPM_GPIO_MODE_PUSHPULL) {
+    if (gpioMode == TPM_GPIO_MODE_PUSHPULL) {
         /* For NUVOTON_GPIO_MODE_PUSHPULL */
         newConfig.GpioPushPull |= (1 << gpioNum);
     }

--- a/examples/gpio/gpio_read.c
+++ b/examples/gpio/gpio_read.c
@@ -69,7 +69,7 @@ int TPM2_GPIO_Read_Example(void* userCtx, int argc, char *argv[])
             return 0;
         }
         pin = XATOI(argv[1]);
-        if(pin < TPM_GPIO_NUM_MIN || pin > TPM_GPIO_NUM_MAX) {
+        if (pin < TPM_GPIO_NUM_MIN || pin > TPM_GPIO_NUM_MAX) {
             usage();
             return 0;
         }

--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -166,13 +166,30 @@ if [ $WOLFCRYPT_ENABLE -eq 1 ]; then
 fi
 rm -f ececcblob.bin
 
-./examples/keygen/keygen symkeyblob.bin -sym=aescfb128 >> run.out 2>&1
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "keygen sym aes failed! $RESULT" && exit 1
-./examples/keygen/keyload symkeyblob.bin >> run.out 2>&1
-RESULT=$?
-rm -f symkeyblob.bin
-[ $RESULT -ne 0 ] && echo -e "keygen sym aes load failed! $RESULT" && exit 1
+
+# KeyGen AES Tests
+run_keygen_aes_test() { # Usage: run_keygen_aes_test [aescfb128]
+    echo -e "KeyGen test: $1"
+    ./examples/keygen/keygen symkeyblob.bin -sym=$1 >> run.out 2>&1
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "keygen sym $1 failed! $RESULT" && exit 1
+    ./examples/keygen/keyload symkeyblob.bin >> run.out 2>&1
+    RESULT=$?
+    rm -f symkeyblob.bin
+    [ $RESULT -ne 0 ] && echo -e "keygen sym $1 load failed! $RESULT" && exit 1
+}
+
+run_keygen_aes_test "aescfb128"
+run_keygen_aes_test "aescfb256"
+run_keygen_aes_test "aesctr128"
+run_keygen_aes_test "aesctr256"
+run_keygen_aes_test "aescbc128"
+run_keygen_aes_test "aescbc256"
+
+# AES 192-bit not supported with SWTPM
+#run_keygen_aes_test "aescfb192"
+#run_keygen_aes_test "aesctr192"
+#run_keygen_aes_test "aescbc192"
 
 ./examples/keygen/keygen keyedhashblob.bin -keyedhash >> run.out 2>&1
 RESULT=$?

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -289,7 +289,9 @@ static void test_TPM2_PCRSel(void)
     TPM2_SetupPCRSelArray(&pcr, TPM_ALG_SHA256, pcrArray, 1);
     pcrArray[0] = 3;
     TPM2_SetupPCRSelArray(&pcr, TPM_ALG_SHA384, pcrArray, 1);
-    if (pcr.count != 2) {
+    pcrArray[0] = 4;
+    TPM2_SetupPCRSelArray(&pcr, TPM_ALG_SHA512, pcrArray, 1);
+    if (pcr.count != HASH_COUNT) {
         rc = BAD_FUNC_ARG;
     }
 

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -3363,7 +3363,7 @@ WOLFTPM_API int TPM2_GetNonce(byte* nonceBuf, int nonceSz);
     \brief Helper function to prepare a correct PCR selection
             For example, when preparing to create a TPM2_Quote
 
-    \param pcr pointer to a structure of type TPML_PCR_SELECTION
+    \param pcr pointer to a structure of type TPML_PCR_SELECTION. Note: Caller must zeroize/memset(0)
     \param alg value of type TPM_ALG_ID specifying the type of hash algorithm used
     \param pcrIndex value between 0 and 23 specifying the PCR register for use
 
@@ -3371,7 +3371,7 @@ WOLFTPM_API int TPM2_GetNonce(byte* nonceBuf, int nonceSz);
     \code
     int pcrIndex = 16; // This is a PCR register for DEBUG & testing purposes
     PCR_Read_In pcrRead;
-
+    XMEMSET(&pcrRead, 0, sizeof(pcrRead));
     TPM2_SetupPCRSel(&pcrRead.pcrSelectionIn, TPM_ALG_SHA256, pcrIndex);
     \endcode
 
@@ -3388,17 +3388,22 @@ WOLFTPM_API void TPM2_SetupPCRSel(TPML_PCR_SELECTION* pcr, TPM_ALG_ID alg,
     \brief Helper function to prepare a correct PCR selection with multiple indices
             For example, when preparing to create a TPM2_Quote
 
-    \param pcr pointer to a structure of type TPML_PCR_SELECTION
+    \param pcr pointer to a structure of type TPML_PCR_SELECTION. Note: Caller must zeroize/memset(0)
     \param alg value of type TPM_ALG_ID specifying the type of hash algorithm used
     \param pcrArray array of values between 0 and 23 specifying the PCR register for use
-    \param pcrArrayLen length of the pcrArray
+    \param pcrArraySz length of the pcrArray
 
     _Example_
     \code
-    int pcrIndex = 16; // This is a PCR register for DEBUG & testing purposes
     PCR_Read_In pcrRead;
+    byte   pcrArray[PCR_SELECT_MAX];
+    word32 pcrArraySz = 0;
 
-    TPM2_SetupPCRSel(&pcrRead.pcrSelectionIn, TPM_ALG_SHA256, pcrIndex);
+    XMEMSET(&pcrRead, 0, sizeof(pcrRead));
+    XMEMSET(pcrArray, 0, sizeof(pcrArray));
+    pcrArray[pcrArraySz++] = 16; // This is a PCR register for DEBUG & testing purposes
+
+    TPM2_SetupPCRSelArray(&pcrRead.pcrSelectionIn, TPM_ALG_SHA256, pcrArray, pcrArraySz);
     \endcode
 
     \sa TPM2_PCR_Read
@@ -3407,7 +3412,7 @@ WOLFTPM_API void TPM2_SetupPCRSel(TPML_PCR_SELECTION* pcr, TPM_ALG_ID alg,
     \sa TPM2_Quote
 */
 WOLFTPM_API void TPM2_SetupPCRSelArray(TPML_PCR_SELECTION* pcr, TPM_ALG_ID alg,
-    byte* pcrArray, word32 pcrArrayLen);
+    byte* pcrArray, word32 pcrArraySz);
 
 /*!
     \ingroup TPM2_Proprietary


### PR DESCRIPTION
* Fixes for keygen with `-sym=`.
* Fixes for `TPM2_SetupPCRSel`. 
* Added test cases. 

Fixes ZD 18492