### PR TITLE
Proper fix for the RC_WARN error codes

### DIFF
--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -5746,7 +5746,7 @@ const char* TPM2_GetRCString(int rc)
         return "Success";
     }
 
-    if ((rc & RC_WARN) && (rc & RC_FMT1) == 0 && (rc & RC_VER1) == 0) {
+    if ((rc & RC_WARN) == RC_WARN && (rc & RC_FMT1) == 0) {
         int rc_warn = rc & RC_MAX_WARN;
 
         switch (rc_warn) {


### PR DESCRIPTION
Proper fix for the RC_WARN error codes. ZD18641
Broken in commit f983525f56c245a8bc998bb20f1f6a8cc7ec748f (PR #336). 

Tested by running keygen example without unloading handles. The `TPM_RC_OBJECT_MEMORY` warning wasn't being rendered correctly.