### PR TITLE
Helper to get wolfCrypt hash type

### DIFF
--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -5525,6 +5525,26 @@ int TPM2_GetHashDigestSize(TPMI_ALG_HASH hashAlg)
     return 0;
 }
 
+TPMI_ALG_HASH TPM2_GetTpmHashType(int hashType)
+{
+#ifndef WOLFTPM2_NO_WOLFCRYPT
+    switch (hashType) {
+        case (int)WC_HASH_TYPE_SHA:
+            return TPM_ALG_SHA1;
+        case (int)WC_HASH_TYPE_SHA256:
+            return TPM_ALG_SHA256;
+        case (int)WC_HASH_TYPE_SHA384:
+            return TPM_ALG_SHA384;
+        case (int)WC_HASH_TYPE_SHA512:
+            return TPM_ALG_SHA512;
+        default:
+            break;
+    }
+#endif
+    (void)hashType;
+    return TPM_ALG_ERROR;
+}
+
 int TPM2_GetHashType(TPMI_ALG_HASH hashAlg)
 {
 #ifndef WOLFTPM2_NO_WOLFCRYPT

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -3396,6 +3396,28 @@ WOLFTPM_API int TPM2_GetHashType(TPMI_ALG_HASH hashAlg);
 
 /*!
     \ingroup TPM2_Proprietary
+    \brief Translate a wolfCrypt hash type to TPM2 hash type
+
+    \return a TPM2 hash type (TPM_ALG_*)
+    \return TPM_ALG_ERROR when wolfCrypt hash type is invalid or not found
+
+    \param hashType a wolfCrypt hash type
+
+    _Example_
+    \code
+    int wc_hashType = WC_HASH_TYPE_SHA256;
+    TPMI_ALG_HASH hashAlg;
+
+    hashAlg = TPM2_GetHashDigestSize(wc_hashType);
+    if (hashAlg != TPM_ALG_ERROR) {
+        //hashAlg contains a valid TPM2 hash type
+    }
+    \endcode
+*/
+WOLFTPM_API TPMI_ALG_HASH TPM2_GetTpmHashType(int hashType);
+
+/*!
+    \ingroup TPM2_Proprietary
     \brief Generate a fresh nonce of random numbers
     \note Can use the TPM random number generator if WOLFTPM2_USE_HW_RNG is defined
 


### PR DESCRIPTION
Helper to get wolfCrypt hash type. `TPMI_ALG_HASH TPM2_GetTpmHashType(int hashType)`.