### PR TITLE
Fixing PKCS7 Type delclaration in example

### DIFF
--- a/examples/pkcs7/pkcs7.c
+++ b/examples/pkcs7/pkcs7.c
@@ -97,7 +97,7 @@ static int PKCS7_SignVerifyEx(WOLFTPM2_DEV* dev, int tpmDevId,
     int alg, enum wc_HashType hashType, const char* outFile)
 {
     int rc;
-    PKCS7 pkcs7;
+    wc_PKCS7 pkcs7;
     wc_HashAlg       hash;
     byte             hashBuf[TPM_MAX_DIGEST_SIZE];
     word32           hashSz;
@@ -247,7 +247,7 @@ static int PKCS7_SignVerify(WOLFTPM2_DEV* dev, int tpmDevId,
     int alg, enum wc_HashType hashType, const char* outFile)
 {
     int rc;
-    PKCS7 pkcs7;
+    wc_PKCS7 pkcs7;
     byte  data[] = "My encoded DER cert.";
     byte output[MAX_PKCS7_SIZE];
     int outputSz;


### PR DESCRIPTION
When compiling wolfSSL master against wolfTPM master these examples will fail to compile.

Errors:
```
| ../git/examples/pkcs7/pkcs7.c: In function 'PKCS7_SignVerifyEx':
| ../git/examples/pkcs7/pkcs7.c:100:5: error: unknown type name 'PKCS7'; did you mean 'wc_PKCS7'?
|   100 |     PKCS7 pkcs7;
|       |     ^~~~~
|       |     wc_PKCS7
```



This was found via yocto kirkstone.
Yocto configure with these flags in local.conf:
```
IMAGE_INSTALL:append = "wolfssl wolfssh wolftpm wolfmqtt wolfprovider wolfprovidertest openssl openssl-bin"
```
then set wolfSSL and wolfTPM to their respective master branches via yocto to reproduce the error



wolfssl configured vias yocto with with:
```
./configure flags: --build=x86_64-linux --host=x86_64-poky-linux --target=x86_64-poky-linux --prefix=/usr --exec_prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --libexecdir=/usr/libexec --datadir=/usr/share --sysconfdir=/etc --sharedstatedir=/com --localstatedir=/var --libdir=/usr/lib --includedir=/usr/include --oldincludedir=/usr/include --infodir=/usr/share/info --mandir=/usr/share/man --disable-silent-rules --disable-dependency-tracking --with-libtool-sysroot=/home/msi-debian/WolfWork/yocto/kirkstone/poky/build/tmp/work/core2-64-poky-linux/wolfssl/5.7.4-r0/recipe-sysroot --enable-reproducible-build --enable-ssh --enable-certreq --enable-certext --enable-pkcs7 --enable-cryptocb --enable-opensslcoexist --enable-cmac --enable-keygen --enable-sha --enable-des3 --enable-aesctr --enable-aesccm --enable-x963kdf --enable-compkey --enable-certgen --enable-aeskeywrap --enable-enckeys --enable-base16 --disable-static build_alias=x86_64-linux host_alias=x86_64-poky-linux target_alias=x86_64-poky-linux 'CC=x86_64-poky-linux-gcc  -m64 -march=core2 -mtune=core2 -msse3 -mfpmath=sse -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/home/msi-debian/WolfWork/yocto/kirkstone/poky/build/tmp/work/core2-64-poky-linux/wolfssl/5.7.4-r0/recipe-sysroot' 'CFLAGS= -O2 -pipe -g -feliminate-unused-debug-types -fmacro-prefix-map=/home/msi-debian/WolfWork/yocto/kirkstone/poky/build/tmp/work/core2-64-poky-linux/wolfssl/5.7.4-r0=/usr/src/debug/wolfssl/5.7.4-r0                      -fdebug-prefix-map=/home/msi-debian/WolfWork/yocto/kirkstone/poky/build/tmp/work/core2-64-poky-linux/wolfssl/5.7.4-r0=/usr/src/debug/wolfssl/5.7.4-r0                      -fdebug-prefix-map=/home/msi-debian/WolfWork/yocto/kirkstone/poky/build/tmp/work/core2-64-poky-linux/wolfssl/5.7.4-r0/recipe-sysroot=                      -fdebug-prefix-map=/home/msi-debian/WolfWork/yocto/kirkstone/poky/build/tmp/work/core2-64-poky-linux/wolfssl/5.7.4-r0/recipe-sysroot-native= ' 'LDFLAGS=-Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -fmacro-prefix-map=/home/msi-debian/WolfWork/yocto/kirkstone/poky/build/tmp/work/core2-64-poky-linux/wolfssl/5.7.4-r0=/usr/src/debug/wolfssl/5.7.4-r0                      -fdebug-prefix-map=/home/msi-debian/WolfWork/yocto/kirkstone/poky/build/tmp/work/core2-64-poky-linux/wolfssl/5.7.4-r0=/usr/src/debug/wolfssl/5.7.4-r0                      -fdebug-prefix-map=/home/msi-debian/WolfWork/yocto/kirkstone/poky/build/tmp/work/core2-64-poky-linux/wolfssl/5.7.4-r0/recipe-sysroot=                      -fdebug-prefix-map=/home/msi-debian/WolfWork/yocto/kirkstone/poky/build/tmp/work/core2-64-poky-linux/wolfssl/5.7.4-r0/recipe-sysroot-native=  -Wl,-z,relro,-z,now' 'CPPFLAGS=  -DHAVE_AES_ECB -DWOLFSSL_AES_DIRECT -DWC_RSA_NO_PADDING -DWOLFSSL_PUBLIC_MP -DECC_MIN_KEY_SZ=192 -DHAVE_PUBLIC_FFDHE -DWOLFSSL_DH_EXTRA -DRSA_MIN_SIZE=1024  -DWOLFSSL_PSS_LONG_SALT -DWOLFSSL_PSS_SALT_LEN_DISCOVER' 'CPP=x86_64-poky-linux-gcc -E --sysroot=/home/msi-debian/WolfWork/yocto/kirkstone/poky/build/tmp/work/core2-64-poky-linux/wolfssl/5.7.4-r0/recipe-sysroot  -m64 -march=core2 -mtune=core2 -msse3 -mfpmath=sse -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security'
```

When patch of PR is applied to wolfTPM in yocto, it will compile.
