### PR TITLE
Minor fixes for release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Portable TPM 2.0 project designed for embedded use.
 
 * This implementation provides all TPM 2.0 API's in compliance with the specification.
 * Wrappers provided to simplify Key Generation/Loading, RSA encrypt/decrypt, ECC sign/verify, ECDH, NV, Hashing/HACM, AES, Sealing/Unsealing, Attestation, PCR Extend/Quote and Secure Root of Trust.
-* Testing done using TPM 2.0 modules from STMicro ST33 (SPI/I2C), Infineon OPTIGA SLB9670/SLB9672, Microchip ATTPM20, Nations Tech Z32H330TC/NS350 and Nuvoton NPCT650/NPCT750.
+* Testing done using TPM 2.0 modules from STMicro ST33 (SPI/I2C), Infineon OPTIGA SLB9670/SLB9672/SLB9673, Microchip ATTPM20, Nations Tech Z32H330TC/NS350 and Nuvoton NPCT650/NPCT750.
 * wolfTPM uses the TPM Interface Specification (TIS) to communicate either over SPI, or using a memory mapped I/O range.
 * wolfTPM can also use the Linux TPM kernel interface (`/dev/tpmX`) to talk with any physical TPM on SPI, I2C and even LPC bus.
 * Platform support for Raspberry Pi (Linux), MMIO, STM32 with CubeMX, Atmel ASF, Xilinx, QNX Infineon TriCore and Barebox.
@@ -31,7 +31,7 @@ Portable TPM 2.0 project designed for embedded use.
     * Time signed or set
     * PCR read/reset
     * GPIO configure, read and write.
-    * Endrosement Key/Cert retreival and validation.
+    * Endorsement Key/Cert retrieval and validation.
 * Parameter encryption support using AES-CFB or XOR.
 * Support for salted unbound authenticated sessions.
 * Support for HMAC Sessions.

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -4564,13 +4564,6 @@ static int wolfTPM2_NVWriteData(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* tpmSession,
             XMEMCPY(in.write.data.buffer, &dataBuf[pos], towrite);
         if (!extend) {
             in.write.offset = offset+pos;
-            rc = TPM2_NV_Write(&in.write);
-        }
-        else {
-            rc = TPM2_NV_Extend(&in.extend);
-        }
-        if (rc != TPM_RC_SUCCESS) {
-            break;
         }
 
     #ifdef DEBUG_WOLFTPM
@@ -4579,6 +4572,16 @@ static int wolfTPM2_NVWriteData(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* tpmSession,
             (word32)in.write.authHandle, (word32)in.write.nvIndex,
             in.write.offset, in.write.data.size, extend);
     #endif
+
+        if (!extend) {
+            rc = TPM2_NV_Write(&in.write);
+        }
+        else {
+            rc = TPM2_NV_Extend(&in.extend);
+        }
+        if (rc != TPM_RC_SUCCESS) {
+            break;
+        }
 
         pos += towrite;
         dataSz -= towrite;

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -2822,8 +2822,10 @@ int wolfTPM2_DecodeRsaDer(const byte* der, word32 derSz,
     rc = wc_InitRsaKey(key, NULL);
     if (rc == 0) {
         idx = 0;
+    #ifdef HAVE_PKCS8
         /* skip PKCS8 header */
         (void)wc_GetPkcs8TraditionalOffset((byte*)der, &idx, derSz);
+    #endif
         rc = wc_RsaPrivateKeyDecode(der, &idx, key, derSz);
         if (rc == 0) {
             isPrivateKey = 1;


### PR DESCRIPTION
Fix spelling and update list of supported TPM's.
Improve TPM NV write debug logging (show before).
Fix for possible missing `wc_GetPkcs8TraditionalOffset`.