### PR TITLE
Various: Cleanup for public area copy and added cmake provisioning option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,15 @@ check_function_exists("gettimeofday" HAVE_GETTIMEOFDAY)
 # * wait state
 # * small stack
 
+# Provisioning
+set(WOLFTPM_PROVISIONING "yes" CACHE STRING
+    "Enable support for Provisioning Initial Device Identity (IDevID) and Attestation Identity Keys (default: enabled)")
+set_property(CACHE WOLFTPM_PROVISIONING
+    PROPERTY STRINGS "yes;no;verbose")
+if(WOLFTPM_PROVISIONING)
+    list(APPEND WOLFTPM_DEFINITIONS
+        "-DWOLFTPM_PROVISIONING")
+endif()
 
 # Enable Debugging
 set(WOLFTPM_DEBUG "no" CACHE STRING

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -1871,7 +1871,7 @@ int wolfTPM2_CreateKey(WOLFTPM2_DEV* dev, WOLFTPM2_KEYBLOB* keyBlob,
         XMEMCPY(createIn.inSensitive.sensitive.userAuth.buffer, auth,
             createIn.inSensitive.sensitive.userAuth.size);
     }
-    XMEMCPY(&createIn.inPublic.publicArea, publicTemplate, sizeof(TPMT_PUBLIC));
+    wolfTPM2_CopyPubT(&createIn.inPublic.publicArea, publicTemplate);
 
 #if 0
     /* Optional creation nonce */


### PR DESCRIPTION
Cleanup to replace memcpy with public area copy function. 
Add CMake provisioning option (`WOLFTPM_PROVISIONING`) to match configure.