### PR TITLE
Improve mutex locking protection for concurrent thread usage

### DIFF
--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -37,7 +37,14 @@
 /* --- Local Variables -- */
 /******************************************************************************/
 
+
+#ifdef WOLFTPM_NO_ACTIVE_THREAD_LS
+/* if using gHwLock and want to use a shared active TPM2_CTX between threads */
+static TPM2_CTX* gActiveTPM;
+#else
 static THREAD_LS_T TPM2_CTX* gActiveTPM;
+#endif
+
 #ifndef WOLFTPM2_NO_WOLFCRYPT
 static volatile int gWolfCryptRefCount = 0;
 #endif

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -493,8 +493,9 @@ static inline int TPM2_WolfCrypt_Init(void)
         if (rc == 0)
             rc = wc_SetSeed_Cb(wc_GenerateSeed);
     #endif
-    #ifndef WOLFSSL_MUTEX_INITIALIZER
-        wc_InitMutex(&gHwMutex);
+    #if !defined(WOLFTPM_NO_LOCK) && !defined(SINGLE_THREADED) && \
+        !defined(WOLFSSL_MUTEX_INITIALIZER)
+        wc_InitMutex(&gHwLock);
     #endif
     }
     gWolfCryptRefCount++;
@@ -693,8 +694,9 @@ TPM_RC TPM2_Cleanup(TPM2_CTX* ctx)
     if (gWolfCryptRefCount < 0)
         gWolfCryptRefCount = 0;
     if (gWolfCryptRefCount == 0) {
-    #ifndef WOLFSSL_MUTEX_INITIALIZER
-        wc_FreeMutex(&gHwMutex);
+    #if !defined(WOLFTPM_NO_LOCK) && !defined(SINGLE_THREADED) && \
+        !defined(WOLFSSL_MUTEX_INITIALIZER)
+        wc_FreeMutex(&gHwLock);
     #endif
         wolfCrypt_Cleanup();
     }

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -42,6 +42,11 @@ static THREAD_LS_T TPM2_CTX* gActiveTPM;
 static volatile int gWolfCryptRefCount = 0;
 #endif
 
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(WOLFTPM_NO_LOCK) && \
+    !defined(SINGLE_THREADED)
+static wolfSSL_Mutex gHwLock WOLFSSL_MUTEX_INITIALIZER_CLAUSE(gHwLock);
+#endif
+
 #ifdef WOLFTPM_LINUX_DEV
 #define INTERNAL_SEND_COMMAND      TPM2_LINUX_SendCommand
 #define TPM2_INTERNAL_CLEANUP(ctx)
@@ -61,43 +66,24 @@ static volatile int gWolfCryptRefCount = 0;
 /******************************************************************************/
 static TPM_RC TPM2_AcquireLock(TPM2_CTX* ctx)
 {
-#if defined(WOLFTPM2_NO_WOLFCRYPT) || defined(WOLFTPM_NO_LOCK)
-    (void)ctx;
-#else
-    int ret;
-
-    if (!ctx->hwLockInit) {
-        if (wc_InitMutex(&ctx->hwLock) != 0) {
-        #ifdef DEBUG_WOLFTPM
-            printf("TPM Mutex Init failed\n");
-        #endif
-            return TPM_RC_FAILURE;
-        }
-        ctx->hwLockInit = 1;
-        ctx->lockCount = 0;
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(WOLFTPM_NO_LOCK) && \
+    !defined(SINGLE_THREADED)
+    int ret = wc_LockMutex(&gHwLock);
+    if (ret != 0) {
+        return TPM_RC_FAILURE;
     }
-
-    if (ctx->lockCount == 0) {
-        ret = wc_LockMutex(&ctx->hwLock);
-        if (ret != 0)
-            return TPM_RC_FAILURE;
-    }
-    ctx->lockCount++;
 #endif
+    (void)ctx;
     return TPM_RC_SUCCESS;
 }
 
 static void TPM2_ReleaseLock(TPM2_CTX* ctx)
 {
-#if defined(WOLFTPM2_NO_WOLFCRYPT) || defined(WOLFTPM_NO_LOCK)
-    (void)ctx;
-#else
-    ctx->lockCount--;
-    if (ctx->lockCount == 0) {
-        wc_UnLockMutex(&ctx->hwLock);
-    }
-
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(WOLFTPM_NO_LOCK) && \
+    !defined(SINGLE_THREADED)
+    wc_UnLockMutex(&gHwLock);
 #endif
+    (void)ctx;
 }
 
 static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
@@ -507,6 +493,9 @@ static inline int TPM2_WolfCrypt_Init(void)
         if (rc == 0)
             rc = wc_SetSeed_Cb(wc_GenerateSeed);
     #endif
+    #ifndef WOLFSSL_MUTEX_INITIALIZER
+        wc_InitMutex(&gHwMutex);
+    #endif
     }
     gWolfCryptRefCount++;
 
@@ -697,19 +686,16 @@ TPM_RC TPM2_Cleanup(TPM2_CTX* ctx)
         wc_FreeRng(&ctx->rng);
     }
     #endif
-    #ifndef WOLFTPM_NO_LOCK
-    if (ctx->hwLockInit) {
-        ctx->hwLockInit = 0;
-        wc_FreeMutex(&ctx->hwLock);
-    }
-    #endif
 
     /* track wolf initialize reference count in wolfTPM. wolfCrypt does not
-        properly track reference count in v4.1 or older releases */
+     * properly track reference count in v4.1 or older releases */
     gWolfCryptRefCount--;
     if (gWolfCryptRefCount < 0)
         gWolfCryptRefCount = 0;
     if (gWolfCryptRefCount == 0) {
+    #ifndef WOLFSSL_MUTEX_INITIALIZER
+        wc_FreeMutex(&gHwMutex);
+    #endif
         wolfCrypt_Cleanup();
     }
 #endif /* !WOLFTPM2_NO_WOLFCRYPT */

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1855,10 +1855,6 @@ typedef struct TPM2_CTX {
     struct wolfTPM_winContext winCtx;
 #endif
 #ifndef WOLFTPM2_NO_WOLFCRYPT
-#ifndef WOLFTPM_NO_LOCK
-    wolfSSL_Mutex hwLock;
-    int lockCount;
-#endif
     #ifdef WOLFTPM2_USE_WOLF_RNG
     WC_RNG rng;
     #endif
@@ -1878,9 +1874,6 @@ typedef struct TPM2_CTX {
     byte rid;
     /* Informational Bits - use unsigned int for best compiler compatibility */
 #ifndef WOLFTPM2_NO_WOLFCRYPT
-    #ifndef WOLFTPM_NO_LOCK
-    unsigned int hwLockInit:1;
-    #endif
     #ifndef WC_NO_RNG
     unsigned int rngInit:1;
     #endif

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -234,6 +234,20 @@ typedef int64_t  INT64;
     #endif
 #endif
 
+/* if using older wolfSSL that does not have the pthread mutex initializer */
+#ifndef WOLFSSL_MUTEX_INITIALIZER
+    #if defined(WOLFSSL_PTHREADS)
+        #define WOLFSSL_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
+    #endif
+#endif
+#ifndef WOLFSSL_MUTEX_INITIALIZER_CLAUSE
+    #ifdef WOLFSSL_MUTEX_INITIALIZER
+        #define WOLFSSL_MUTEX_INITIALIZER_CLAUSE(lockname) = WOLFSSL_MUTEX_INITIALIZER
+    #else
+        #define WOLFSSL_MUTEX_INITIALIZER_CLAUSE(lockname) /* null expansion */
+    #endif
+#endif
+
 #ifndef WOLFTPM_CUSTOM_TYPES
     #include <stdlib.h>
 


### PR DESCRIPTION
Use a global mutex instead of one that is part of TPM2_CTX. ZD 19771
Add build option `WOLFTPM_NO_ACTIVE_THREAD_LS` to support no thread local on `gActiveTPM`.