### PR TITLE
examples: bench: Fix handle leak in bench_sym_hash

### DIFF
--- a/examples/bench/bench.c
+++ b/examples/bench/bench.c
@@ -147,6 +147,8 @@ static int bench_sym_hash(WOLFTPM2_DEV* dev, const char* desc, int algo,
     bench_stats_sym_finish(desc, count, inSz, start);
 
 exit:
+    if (rc)
+        wolfTPM2_UnloadHandle(dev, &hash.handle);
     return rc;
 }
 


### PR DESCRIPTION
If one of the TPM2 functions called from bench_sym_hash returns an error, the exit path won't unload the hash handle leaving it dangling. This could eventually lead to OOM TPM issues (like TPM2_RC_OBJECT_MEMORY).

Unload the handle on the exit path if rc is non-zero.