### PR TITLE
Fix logic for signing with input digest smaller than key size

### DIFF
--- a/IDE/VisualStudio/wolftpm.vcxproj
+++ b/IDE/VisualStudio/wolftpm.vcxproj
@@ -36,6 +36,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\tpm2.c" />
+    <ClCompile Include="..\..\src\tpm2_asn.c" />
     <ClCompile Include="..\..\src\tpm2_cryptocb.c" />
     <ClCompile Include="..\..\src\tpm2_packet.c" />
     <ClCompile Include="..\..\src\tpm2_param_enc.c" />

--- a/src/tpm2_asn.c
+++ b/src/tpm2_asn.c
@@ -27,6 +27,21 @@
 
 #ifndef WOLFTPM2_NO_ASN
 
+#if defined(HAVE_ECC) && (defined(WOLFTPM_CRYPTOCB) || \
+   (defined(HAVE_PK_CALLBACKS) && !defined(WOLFCRYPT_ONLY)))
+/* Helper to trim leading zeros when not required  */
+byte* TPM2_ASN_TrimZeros(byte* in, word32* len)
+{
+    word32 idx = 0;
+    while (idx+1 < *len && in[idx] == 0 && (in[idx+1] & 0x80) == 0) {
+        idx++;
+        in++;
+    }
+    *len -= idx;
+    return in;
+}
+#endif
+
 int TPM2_ASN_GetLength_ex(const uint8_t* input, word32* inOutIdx, int* len,
                            word32 maxIdx, int check)
 {

--- a/src/tpm2_asn.c
+++ b/src/tpm2_asn.c
@@ -27,8 +27,6 @@
 
 #ifndef WOLFTPM2_NO_ASN
 
-#if defined(HAVE_ECC) && (defined(WOLFTPM_CRYPTOCB) || \
-   (defined(HAVE_PK_CALLBACKS) && !defined(WOLFCRYPT_ONLY)))
 /* Helper to trim leading zeros when not required  */
 byte* TPM2_ASN_TrimZeros(byte* in, word32* len)
 {
@@ -40,7 +38,6 @@ byte* TPM2_ASN_TrimZeros(byte* in, word32* len)
     *len -= idx;
     return in;
 }
-#endif
 
 int TPM2_ASN_GetLength_ex(const uint8_t* input, word32* inOutIdx, int* len,
                            word32 maxIdx, int check)

--- a/src/tpm2_cryptocb.c
+++ b/src/tpm2_cryptocb.c
@@ -24,23 +24,9 @@
 #endif
 
 #include <wolftpm/tpm2_wrap.h>
+#include <wolftpm/tpm2_asn.h>
 
 #if !defined(WOLFTPM2_NO_WRAPPER)
-
-#if defined(HAVE_ECC) && (defined(WOLFTPM_CRYPTOCB) || \
-   (defined(HAVE_PK_CALLBACKS) && !defined(WOLFCRYPT_ONLY)))
-/* Helper to trim leading zeros when not required  */
-static byte* wolfTPM2_ASNTrimZeros(byte* in, word32* len)
-{
-    word32 idx = 0;
-    while (idx+1 < *len && in[idx] == 0 && (in[idx+1] & 0x80) == 0) {
-        idx++;
-        in++;
-    }
-    *len -= idx;
-    return in;
-}
-#endif
 
 #ifdef WOLFTPM_CRYPTOCB
 
@@ -272,8 +258,8 @@ int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
                 rLen = sLen = rsLen / 2;
                 r = &sigRS[0];
                 s = &sigRS[rLen];
-                r = wolfTPM2_ASNTrimZeros(r, &rLen);
-                s = wolfTPM2_ASNTrimZeros(s, &sLen);
+                r = TPM2_ASN_TrimZeros(r, &rLen);
+                s = TPM2_ASN_TrimZeros(s, &sLen);
 
                 /* Encode ECDSA Header */
                 rc = wc_ecc_rs_raw_to_sig(r, rLen, s, sLen,
@@ -1134,8 +1120,8 @@ int wolfTPM2_PK_EccSign(WOLFSSL* ssl,
                 rLen = sLen = rsLen / 2;
                 r = &sigRS[0];
                 s = &sigRS[rLen];
-                r = wolfTPM2_ASNTrimZeros(r, &rLen);
-                s = wolfTPM2_ASNTrimZeros(s, &sLen);
+                r = TPM2_ASN_TrimZeros(r, &rLen);
+                s = TPM2_ASN_TrimZeros(s, &sLen);
 
                 /* Encode ECDSA Header */
                 ret = wc_ecc_rs_raw_to_sig(r, rLen, s, sLen, out, outSz);

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -3932,8 +3932,6 @@ int wolfTPM2_VerifyHashTicket(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 
     XMEMSET(&verifySigIn, 0, sizeof(verifySigIn));
     verifySigIn.keyHandle = key->handle.hndl;
-
-
     verifySigIn.digest.size = TPM2_GetHashDigestSize(hashAlg);
     if (verifySigIn.digest.size <= 0) {
         return BAD_FUNC_ARG;

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -3756,7 +3756,7 @@ int wolfTPM2_SignHashScheme(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     int sigOutSz = 0;
 
     if (dev == NULL || key == NULL || digest == NULL || sig == NULL ||
-                                                            sigSz == NULL) {
+                                                                sigSz == NULL) {
         return BAD_FUNC_ARG;
     }
 
@@ -3772,18 +3772,18 @@ int wolfTPM2_SignHashScheme(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     /* set session auth for key */
     wolfTPM2_SetAuthHandle(dev, 0, &key->handle);
 
+    /* verify input cannot exceed buffer */
+    if (digestSz > (int)sizeof(signIn.digest.buffer))
+        digestSz = (int)sizeof(signIn.digest.buffer);
+
     XMEMSET(&signIn, 0, sizeof(signIn));
     signIn.keyHandle = key->handle.hndl;
     signIn.digest.size = TPM2_GetHashDigestSize(hashAlg);
     if (signIn.digest.size <= 0) {
         return BAD_FUNC_ARG;
     }
-    /* truncate if too large */
-    if (signIn.digest.size > curveSize) {
-        signIn.digest.size = curveSize;
-    }
     /* if digest provided is smaller than key size then zero pad leading */
-    if (signIn.digest.size > digestSz) {
+    if (digestSz < signIn.digest.size) {
         XMEMCPY(&signIn.digest.buffer[signIn.digest.size - digestSz], digest,
             digestSz);
     }
@@ -3932,8 +3932,20 @@ int wolfTPM2_VerifyHashTicket(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 
     XMEMSET(&verifySigIn, 0, sizeof(verifySigIn));
     verifySigIn.keyHandle = key->handle.hndl;
-    verifySigIn.digest.size = digestSz;
-    XMEMCPY(verifySigIn.digest.buffer, digest, digestSz);
+
+
+    verifySigIn.digest.size = TPM2_GetHashDigestSize(hashAlg);
+    if (verifySigIn.digest.size <= 0) {
+        return BAD_FUNC_ARG;
+    }
+    /* if digest provided is smaller than key size then zero pad leading */
+    if (digestSz < verifySigIn.digest.size) {
+        XMEMCPY(&verifySigIn.digest.buffer[verifySigIn.digest.size - digestSz],
+            digest, digestSz);
+    }
+    else {
+        XMEMCPY(verifySigIn.digest.buffer, digest, digestSz);
+    }
     verifySigIn.signature.sigAlg = sigAlg;
     verifySigIn.signature.signature.any.hashAlg = hashAlg;
     if (key->pub.publicArea.type == TPM_ALG_ECC) {

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -429,6 +429,10 @@ static void test_wolfTPM2_EccSignVerifyDig(WOLFTPM2_DEV* dev,
     AssertIntEQ(rc, 0);
     rc = wolfTPM2_CreateAndLoadKey(dev, &eccKey, &storageKey->handle,
         &publicTemplate, (byte*)gKeyAuth, sizeof(gKeyAuth)-1);
+    if ((rc & TPM_RC_HASH) == TPM_RC_HASH) {
+        printf("Hash type not supported... Skipping\n");
+        return;
+    }
     AssertIntEQ(rc, 0);
 
     /* Sign with TPM */

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -397,7 +397,8 @@ static void test_wolfTPM2_CSR(void)
 #endif
 }
 
-#if !defined(WOLFTPM2_NO_WOLFCRYPT) && defined(HAVE_ECC)
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && defined(HAVE_ECC) && \
+    !defined(WOLFTPM2_NO_ASN)
 static void test_wolfTPM2_EccSignVerifyDig(const byte* digest, int digestSz,
     TPM_ECC_CURVE curve, TPMI_ALG_HASH hashAlg)
 {
@@ -829,7 +830,8 @@ int unit_tests(int argc, char *argv[])
     test_wolfTPM2_KeyBlob(TPM_ALG_ECC);
     test_wolfTPM2_Cleanup();
     test_wolfTPM2_thread_local_storage();
-    #if !defined(WOLFTPM2_NO_WOLFCRYPT) && defined(HAVE_ECC)
+    #if !defined(WOLFTPM2_NO_WOLFCRYPT) && defined(HAVE_ECC) && \
+        !defined(WOLFTPM2_NO_ASN)
     test_wolfTPM2_EccSignVerify();
     #endif
 #endif /* !WOLFTPM2_NO_WRAPPER */

--- a/wolftpm/tpm2_asn.h
+++ b/wolftpm/tpm2_asn.h
@@ -139,6 +139,10 @@ WOLFTPM_API int TPM2_ASN_DecodeRsaPubKey(uint8_t* input, int inputSz, TPM2B_PUBL
 */
 WOLFTPM_API int TPM2_ASN_RsaUnpadPkcsv15(uint8_t** pSig, int* sigSz);
 
+
+WOLFTPM_LOCAL byte* TPM2_ASN_TrimZeros(byte* in, word32* len);
+
+
 #ifdef __cplusplus
     }  /* extern "C" */
 #endif

--- a/wolftpm/tpm2_asn.h
+++ b/wolftpm/tpm2_asn.h
@@ -80,8 +80,9 @@ typedef struct DecodedX509 {
     \param maxIdx Maximum allowed index in buffer
     \return Length on success, TPM_RC_INSUFFICIENT on buffer error
 */
-WOLFTPM_API int TPM2_ASN_GetLength(const uint8_t* input, word32* inOutIdx, int* len,
-                           word32 maxIdx);
+WOLFTPM_API int TPM2_ASN_GetLength(const uint8_t* input, word32* inOutIdx,
+    int* len, word32 maxIdx);
+
 /*!
     \ingroup ASN
     \brief Decodes ASN.1 length with optional length checking
@@ -92,8 +93,9 @@ WOLFTPM_API int TPM2_ASN_GetLength(const uint8_t* input, word32* inOutIdx, int* 
     \param check Flag to enable length validation
     \return Length on success, TPM_RC_INSUFFICIENT on buffer error
 */
-WOLFTPM_API int TPM2_ASN_GetLength_ex(const uint8_t* input, word32* inOutIdx, int* len,
-                           word32 maxIdx, int check);
+WOLFTPM_API int TPM2_ASN_GetLength_ex(const uint8_t* input, word32* inOutIdx,
+    int* len, word32 maxIdx, int check);
+
 /*!
     \ingroup ASN
     \brief Decodes ASN.1 tag and validates length
@@ -104,15 +106,19 @@ WOLFTPM_API int TPM2_ASN_GetLength_ex(const uint8_t* input, word32* inOutIdx, in
     \param tag Expected ASN.1 tag value
     \return 0 on success, TPM_RC_INSUFFICIENT on buffer error, TPM_RC_VALUE on tag mismatch
 */
-WOLFTPM_API int TPM2_ASN_DecodeTag(const uint8_t* input, int inputSz, int* inOutIdx, int* tag_len, uint8_t tag);
+WOLFTPM_API int TPM2_ASN_DecodeTag(const uint8_t* input, int inputSz,
+    int* inOutIdx, int* tag_len, uint8_t tag);
+
 /*!
     \ingroup ASN
     \brief Decodes RSA signature from ASN.1 format
     \param pInput Pointer to buffer containing ASN.1 encoded RSA signature
     \param inputSz Size of input buffer
-    \return Size of decoded signature on success, TPM_RC_VALUE on invalid input, TPM_RC_INSUFFICIENT on buffer error
+    \return Size of decoded signature on success, TPM_RC_VALUE on invalid input,
+            TPM_RC_INSUFFICIENT on buffer error
 */
 WOLFTPM_API int TPM2_ASN_RsaDecodeSignature(uint8_t** pInput, int inputSz);
+
 /*!
     \brief Decodes an X.509 certificate
     \param input Buffer containing ASN.1 encoded X.509 certificate
@@ -120,28 +126,39 @@ WOLFTPM_API int TPM2_ASN_RsaDecodeSignature(uint8_t** pInput, int inputSz);
     \param x509 Structure to store decoded certificate data
     \return 0 on success, TPM_RC_VALUE on invalid input, TPM_RC_INSUFFICIENT on buffer error
 */
-WOLFTPM_API int TPM2_ASN_DecodeX509Cert(uint8_t* input, int inputSz, DecodedX509* x509);
+WOLFTPM_API int TPM2_ASN_DecodeX509Cert(uint8_t* input, int inputSz,
+    DecodedX509* x509);
+
 /*!
     \ingroup ASN
     \brief Decodes RSA public key from ASN.1 format into TPM2B_PUBLIC structure
     \param input Buffer containing ASN.1 encoded RSA public key
     \param inputSz Size of input buffer
     \param pub TPM2B_PUBLIC structure to store decoded key
-    \return 0 on success, TPM_RC_VALUE on invalid input, TPM_RC_INSUFFICIENT on buffer error
+    \return 0 on success, TPM_RC_VALUE on invalid input,
+        TPM_RC_INSUFFICIENT on buffer error
 */
-WOLFTPM_API int TPM2_ASN_DecodeRsaPubKey(uint8_t* input, int inputSz, TPM2B_PUBLIC* pub);
+WOLFTPM_API int TPM2_ASN_DecodeRsaPubKey(uint8_t* input, int inputSz,
+    TPM2B_PUBLIC* pub);
+
 /*!
     \ingroup ASN
     \brief Removes PKCS#1 v1.5 padding from RSA signature
-    \param pSig Pointer to buffer containing padded signature, updated to point to unpadded data
+    \param pSig Pointer to buffer containing padded signature, updated to point
+        to unpadded data
     \param sigSz Size of signature buffer, updated with unpadded size
     \return 0 on success, TPM_RC_VALUE on invalid padding
 */
 WOLFTPM_API int TPM2_ASN_RsaUnpadPkcsv15(uint8_t** pSig, int* sigSz);
 
-
-WOLFTPM_LOCAL byte* TPM2_ASN_TrimZeros(byte* in, word32* len);
-
+/*!
+    \ingroup ASN
+    \brief Removes leading zero bytes from a buffer
+    \param in Pointer to input buffer containing data to trim
+    \param len Pointer to length of input buffer, updated with new length after trimming
+    \return Pointer to the trimmed buffer (may be same as input if no trimming needed)
+*/
+WOLFTPM_API byte* TPM2_ASN_TrimZeros(byte* in, word32* len);
 
 #ifdef __cplusplus
     }  /* extern "C" */


### PR DESCRIPTION
* Fixed logic for signing with input digest smaller than key size. ZD 19869
* Improved input digest size logic for TPM2_Sign and TPM2_Verify. 
* Added test case for ECC sign/verify with various digest input sizes.
* Exposed `TPM2_ASN_TrimZeros`.
* Fixed `test_TPM2_PCRSel` test.