### PR TITLE
Fix possible buffer overrun issues

### DIFF
--- a/.github/workflows/make-test-swtpm.yml
+++ b/.github/workflows/make-test-swtpm.yml
@@ -139,6 +139,16 @@ jobs:
     - name: make debug io
       run: make
 
+# build with clang address sanitizer
+    - name: configure clang asan
+      run: ./configure --enable-swtpm CC=clang CFLAGS="-fsanitize=address -fno-omit-frame-pointer -g"
+    - name: make clang asan
+      run: make
+    - name: make check clang asan
+      run: |
+        make check
+        ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 WOLFSSL_PATH=./wolfssl ./examples/run_examples.sh
+
 # build pedantic
     - name: configure pedantic
       run: ./configure CFLAGS="-Wpedantic"

--- a/.github/workflows/make-test-swtpm.yml
+++ b/.github/workflows/make-test-swtpm.yml
@@ -240,6 +240,16 @@ jobs:
         make check
         WOLFSSL_PATH=./wolfssl NO_PUBASPRIV=1 ./examples/run_examples.sh
 
+# test with symmetric encryption
+    - name: configure symmetric
+      run: ./configure --enable-swtpm CFLAGS="-DWOLFTPM_USE_SYMMETRIC"
+    - name: make symmetric
+      run: make
+    - name: make check symmetric
+      run: |
+        make check
+        WOLFSSL_PATH=./wolfssl ./examples/run_examples.sh
+
 # capture logs on failure
     - name: Upload failure logs
       if: failure()

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -6328,6 +6328,9 @@ int TPM2_GetWolfRng(WC_RNG** rng)
             printf("wc_InitRng_ex failed %d: %s\n",
                 (int)rc, wc_GetErrorString(rc));
         #endif
+            if (rng) {
+                *rng = NULL;
+            }
             return rc;
         }
         ctx->rngInit = 1;

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -4364,7 +4364,7 @@ int wolfTPM2_RsaEncrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
         return rc;
     }
 
-    if (*outSz > rsaEncOut.outData.size) {
+    if (*outSz < rsaEncOut.outData.size) {
         return BUFFER_E;
     }
     *outSz = rsaEncOut.outData.size;
@@ -4419,7 +4419,7 @@ int wolfTPM2_RsaDecrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
         return rc;
     }
 
-    if (*msgSz > rsaDecOut.message.size) {
+    if (*msgSz < rsaDecOut.message.size) {
         return BUFFER_E;
     }
     *msgSz = rsaDecOut.message.size;

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -504,9 +504,9 @@ static void test_wolfTPM2_EccSignVerifyDig(WOLFTPM2_DEV* dev,
     AssertIntEQ(rc, 0);
 
     /* combine R and S at key size (zero pad leading) */
-    XMEMCPY(&sigRs[curveSize-rLen], r, rLen);
+    XMEMMOVE(&sigRs[curveSize-rLen], r, rLen);
     XMEMSET(&sigRs[0], 0, curveSize-rLen);
-    XMEMCPY(&sigRs[curveSize + (curveSize-sLen)], s, sLen);
+    XMEMMOVE(&sigRs[curveSize + (curveSize-sLen)], s, sLen);
     XMEMSET(&sigRs[curveSize], 0, curveSize-sLen);
 
     /* Verify wolfCrypt signature with TPM */

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -72,8 +72,8 @@ typedef UINT32 TPM_GENERATED;
 #define TPM_SPEC_YEAR         2016
 #define TPM_SPEC_DAY_OF_YEAR  273
 
-#define TPM_GENERATED_VALUE   0xff544347
-
+#define TPM_GENERATED_VALUE   0xff544347U
+#define TPM_MAX_DERIVATION_BITS 8192U
 
 typedef enum {
     TPM_ALG_ERROR           = 0x0000,

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -654,39 +654,50 @@ typedef int64_t  INT64;
 #define MAX_CAP_HANDLES (MAX_CAP_DATA / sizeof(TPM_HANDLE))
 #endif
 #ifndef HASH_COUNT
-    /* Calculate hash count based on wolfCrypt enables */
-    #ifndef NO_SHA
-        #define HASH_COUNT_SHA1 1
-    #else
-        #define HASH_COUNT_SHA1 0
-    #endif
+    #ifndef WOLFTPM2_NO_WOLFCRYPT
+        /* Calculate hash count based on wolfCrypt enables */
+        #ifndef NO_SHA
+            #define HASH_COUNT_SHA1 1
+        #else
+            #define HASH_COUNT_SHA1 0
+        #endif
 
-    #ifndef NO_SHA256
-        #define HASH_COUNT_SHA256 1
-    #else
-        #define HASH_COUNT_SHA256 0
-    #endif
+        #ifndef NO_SHA256
+            #define HASH_COUNT_SHA256 1
+        #else
+            #define HASH_COUNT_SHA256 0
+        #endif
 
-    #ifdef WOLFSSL_SHA384
-        #define HASH_COUNT_SHA384 1
-    #else
-        #define HASH_COUNT_SHA384 0
-    #endif
+        #ifdef WOLFSSL_SHA384
+            #define HASH_COUNT_SHA384 1
+        #else
+            #define HASH_COUNT_SHA384 0
+        #endif
 
-    #ifdef WOLFSSL_SHA512
-        #define HASH_COUNT_SHA512 1
-    #else
-        #define HASH_COUNT_SHA512 0
-    #endif
+        #ifdef WOLFSSL_SHA512
+            #define HASH_COUNT_SHA512 1
+        #else
+            #define HASH_COUNT_SHA512 0
+        #endif
 
-    #ifdef WOLFSSL_SHA3
-        #define HASH_COUNT_SHA3 1
-    #else
-        #define HASH_COUNT_SHA3 0
-    #endif
+        #ifdef WOLFSSL_SHA3
+            #define HASH_COUNT_SHA3 1
+        #else
+            #define HASH_COUNT_SHA3 0
+        #endif
 
-    #define HASH_COUNT (HASH_COUNT_SHA1 + HASH_COUNT_SHA256 + \
-                        HASH_COUNT_SHA384 + HASH_COUNT_SHA512 + HASH_COUNT_SHA3)
+        #define HASH_COUNT (HASH_COUNT_SHA1 + HASH_COUNT_SHA256 + \
+                            HASH_COUNT_SHA384 + HASH_COUNT_SHA512 + \
+                            HASH_COUNT_SHA3)
+        /* make sure hash count is at least 2 */
+        #if HASH_COUNT < 2
+            #undef  HASH_COUNT
+            #define HASH_COUNT 2
+        #endif
+    #else
+        /* default to 2 for non-wolfCrypt builds */
+        #define HASH_COUNT 2
+    #endif
 #endif
 #ifndef MAX_CAP_ALGS
 #define MAX_CAP_ALGS (MAX_CAP_DATA / sizeof(TPMS_ALG_PROPERTY))

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -172,6 +172,7 @@ typedef int64_t  INT64;
     #define XFREE(p, h, t)    free(p)
     #endif
     #define XMEMCPY(d,s,l)    memcpy((d),(s),(l))
+    #define XMEMMOVE(d,s,l)   memmove((d),(s),(l))
     #define XMEMSET(b,c,l)    memset((b),(c),(l))
     #define XMEMCMP(s1,s2,n)  memcmp((s1),(s2),(n))
     #define XSTRLEN(s1)       strlen((s1))
@@ -428,10 +429,10 @@ typedef int64_t  INT64;
 #define MAX_SYM_BLOCK_SIZE 20
 #endif
 #ifndef MAX_SYM_KEY_BYTES
-#define MAX_SYM_KEY_BYTES 256
+#define MAX_SYM_KEY_BYTES 32
 #endif
 #ifndef LABEL_MAX_BUFFER
-#define LABEL_MAX_BUFFER 128
+#define LABEL_MAX_BUFFER 48
 #endif
 #ifndef MAX_RSA_KEY_BITS
 #define MAX_RSA_KEY_BITS 2048
@@ -444,11 +445,11 @@ typedef int64_t  INT64;
 #define MAX_ECC_KEY_BITS 521
 #endif
 #ifndef MAX_ECC_KEY_BYTES
-#define MAX_ECC_KEY_BYTES (((MAX_ECC_KEY_BITS+7)/8)*2)
+#define MAX_ECC_KEY_BYTES ((MAX_ECC_KEY_BITS+7)/8)
 #endif
 
 #ifndef MAX_AES_KEY_BITS
-#define MAX_AES_KEY_BITS 128
+#define MAX_AES_KEY_BITS 256
 #endif
 #ifndef MAX_AES_BLOCK_SIZE_BYTES
 #define MAX_AES_BLOCK_SIZE_BYTES 16

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -376,6 +376,18 @@ typedef int64_t  INT64;
     #define WOLFTPM_PERFORM_SELFTEST
 #endif
 
+/* Chip defaults */
+#if defined(WOLFTPM_SLB9672) || defined(WOLFTPM_SLB9673)
+    #ifndef MAX_RSA_KEY_BITS
+        #define MAX_RSA_KEY_BITS 4096
+    #endif
+    #ifndef MAX_ECC_KEY_BITS
+        #define MAX_ECC_KEY_BITS 384
+    #endif
+    #ifndef HASH_COUNT
+        #define HASH_COUNT 3
+    #endif
+#endif
 
 
 /* ---------------------------------------------------------------------------*/
@@ -387,10 +399,6 @@ typedef int64_t  INT64;
 #define TPM_SHA256_DIGEST_SIZE 32
 #define TPM_SHA384_DIGEST_SIZE 48
 #define TPM_SHA512_DIGEST_SIZE 64
-
-#ifndef MAX_ECC_KEY_BYTES
-#define MAX_ECC_KEY_BYTES     66
-#endif
 
 #ifndef TPM_MAX_BLOCK_SIZE
 #define TPM_MAX_BLOCK_SIZE     128
@@ -432,12 +440,15 @@ typedef int64_t  INT64;
 #define MAX_SYM_KEY_BYTES 32
 #endif
 #ifndef LABEL_MAX_BUFFER
-#define LABEL_MAX_BUFFER 48
+/* the TCG specification defines a label size not exceed 32 bytes */
+#define LABEL_MAX_BUFFER 32
 #endif
+
 #ifndef MAX_RSA_KEY_BITS
 #define MAX_RSA_KEY_BITS 2048
 #endif
 #ifndef MAX_RSA_KEY_BYTES
+/* the TCG specification defines an RSA key as two max values */
 #define MAX_RSA_KEY_BYTES (((MAX_RSA_KEY_BITS+7)/8)*2)
 #endif
 


### PR DESCRIPTION
Fix possible buffer overrun issues. Specifically issues with exporting RSA keys where the wolfCrypt max key size doesn't match what TPM supports in `wolfTPM2_RsaKey_TpmToWolf`. ZD 20237.

Fix checks around `TPM2_GetHashDigestSize`.
Fix for HASH_COUNT (make sure its at least 2 by default). 
Fix for `TPM2_GetWolfRng` to ensure NULL is set on RNG init error.
Fix some of the configurable limit defaults.

Implement an address sanitizer test.