### PR TITLE
Fix for TPM2_VerifySignature not using the correct hash algorithm

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -264,12 +264,13 @@ fi
 
 
 # STM ST33 Support
-AC_ARG_ENABLE([st33],,
+AC_ARG_ENABLE([st33],
+    [AS_HELP_STRING([--enable-st33],[Enable ST ST33 TPM Support (default: disabled)])],
     [ ENABLED_ST33=$enableval ],
     [ ENABLED_ST33=no ]
     )
 AC_ARG_ENABLE([st],
-    [AS_HELP_STRING([--enable-st],[Enable ST ST33 TPM Support (default: disabled)])],
+    [AS_HELP_STRING([--enable-st],[Enable ST TPM Support (default: disabled)])],
     [ ENABLED_ST=$enableval ],
     [ ENABLED_ST=no ]
     )
@@ -307,7 +308,7 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_NUVOTON"
 fi
 
-# Infineon SLB9670/SLB9672
+# Infineon SLB9670/SLB9672/SLB9673
 AC_ARG_ENABLE([infineon],
     [AS_HELP_STRING([--enable-infineon],[Enable Infineon SLB9670/SLB9672 TPM Support (default: disabled)])],
     [ ENABLED_INFINEON=$enableval ],
@@ -319,7 +320,13 @@ then
     then
         AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_SLB9670"
     else
-        AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_SLB9672"
+        if test "x$ENABLED_INFINEON" = "xslb9673"
+        then
+            enable_i2c=yes
+            AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_SLB9673"
+        else
+            AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_SLB9672"
+        fi
     fi
 fi
 
@@ -375,7 +382,8 @@ AC_ARG_ENABLE([autodetect],
 if test "x$ENABLED_AUTODETECT" = "xtest"
 then
     # If a module hasn't been selected then enable auto-detection
-    if test "x$ENABLED_INFINEON" = "xno" && test "x$ENABLED_MCHP" = "xno" && test "x$ENABLED_ST33" = "xno" && test "x$ENABLED_NUVOTON" = "xno"
+    if test "x$ENABLED_INFINEON" = "xno" && test "x$ENABLED_MCHP" = "xno" && test "x$ENABLED_MICROCHIP" = "xno" && \
+       test "x$ENABLED_ST" = "xno" && test "x$ENABLED_ST33" = "xno" && test "x$ENABLED_NUVOTON" = "xno"
     then
         ENABLED_AUTODETECT=yes
     fi

--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -422,7 +422,7 @@ run_tpm_tls_client() { # Usage: run_tpm_tls_client [ecc/rsa] [tpmargs] [tlsversi
     [ $RESULT -ne 0 ] && echo -e "tpm tls client $1 $2 failed! $RESULT" && exit 1
 }
 
-run_tpm_tls_server() { # Usage: run_tpm_tls_server [ecc/rsa] [tpmargs] [tlsversion]
+run_tpm_tls_server() { # Usage: run_tpm_tls_server [ecc/rsa] [tpmargs] [tlsversion] [extraargs]
     echo -e "TLS test (TPM as server) $1 $2 $3"
     generate_port
 
@@ -433,8 +433,8 @@ run_tpm_tls_server() { # Usage: run_tpm_tls_server [ecc/rsa] [tpmargs] [tlsversi
     pushd $WOLFSSL_PATH >> $TPMPWD/run.out 2>&1
     sleep 0.1
 
-    echo -e "./examples/client/client -v $3 -p $port -w -g -A ./certs/tpm-ca-$1-cert.pem"
-    ./examples/client/client -p $port -w -g -A ./certs/tpm-ca-$1-cert.pem >> $TPMPWD/run.out 2>&1
+    echo -e "./examples/client/client -v $3 -p $port -w -g -A ./certs/tpm-ca-$1-cert.pem $4"
+    ./examples/client/client -p $port -w -g -A ./certs/tpm-ca-$1-cert.pem $4 >> $TPMPWD/run.out 2>&1
     RESULT=$?
     [ $RESULT -ne 0 ] && echo -e "tls client $1 $2 failed! $RESULT" && exit 1
     popd >> $TPMPWD/run.out 2>&1
@@ -480,6 +480,8 @@ if [ $WOLFCRYPT_ENABLE -eq 1 ] && [ $WOLFCRYPT_DEFAULT -eq 0 ] && [ $NO_FILESYST
             run_tpm_tls_server "ecc" "-aes" "3"
             run_tpm_tls_server "ecc" "" "4"
             run_tpm_tls_server "ecc" "-aes" "4"
+            run_tpm_tls_server "ecc" "" "4" "./certs/client-ecc384-key.pem -c ./certs/client-ecc384-cert.pem"
+            run_tpm_tls_server "ecc" "-aes" "4" "./certs/client-ecc384-key.pem -c ./certs/client-ecc384-cert.pem"
         fi
 
         # TLS client/server ECC TLS v1.2 and v1.3 PK callbacks
@@ -493,6 +495,8 @@ if [ $WOLFCRYPT_ENABLE -eq 1 ] && [ $WOLFCRYPT_DEFAULT -eq 0 ] && [ $NO_FILESYST
             run_tpm_tls_server "ecc" "-pk -aes" "3"
             run_tpm_tls_server "ecc" "-pk" "4"
             run_tpm_tls_server "ecc" "-pk -aes" "4"
+            run_tpm_tls_server "ecc" "-pk" "4" "./certs/client-ecc384-key.pem -c ./certs/client-ecc384-cert.pem"
+            run_tpm_tls_server "ecc" "-pk -aes" "4" "./certs/client-ecc384-key.pem -c ./certs/client-ecc384-cert.pem"
         fi
     fi
 fi

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -4275,7 +4275,7 @@ int wolfTPM2_VerifyHash(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 {
     int hashAlg = TPM_ALG_NULL;
 
-    /* detect hash algithm based on digest size*/
+    /* detect hash algorithm based on digest size */
     if (digestSz >= TPM_SHA512_DIGEST_SIZE)
         hashAlg = TPM_ALG_SHA512;
     else if (digestSz >= TPM_SHA384_DIGEST_SIZE)

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -4273,8 +4273,18 @@ int wolfTPM2_VerifyHash_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 int wolfTPM2_VerifyHash(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const byte* sig, int sigSz, const byte* digest, int digestSz)
 {
+    int hashAlg = TPM_ALG_NULL;
+
+    /* detect hash algithm based on digest size*/
+    if (digestSz >= TPM_SHA512_DIGEST_SIZE)
+        hashAlg = TPM_ALG_SHA512;
+    else if (digestSz >= TPM_SHA384_DIGEST_SIZE)
+        hashAlg = TPM_ALG_SHA384;
+    else
+        hashAlg = TPM_ALG_SHA256;
+
     return wolfTPM2_VerifyHashTicket(dev, key, sig, sigSz, digest, digestSz,
-        TPM_ALG_NULL, WOLFTPM2_WRAP_DIGEST, NULL);
+        TPM_ALG_NULL, hashAlg, NULL);
 }
 
 /* Generate ECC key-pair with NULL hierarchy and load (populates handle) */


### PR DESCRIPTION
Fix for TPM2_VerifySignature not using the correct hash algorithm (ZD 20296)

Issue can be reproduced using the TLS v1.3 example with P384 client mutual auth.

```
./examples/tls/tls_server -ecc
./examples/client/client -v 4 -g -k ./certs/client-ecc384-key.pem -c ./certs/client-ecc384-cert.pem -d
```