### PR TITLE
Fix for crypto callback unavailable and ECDSA hash type

### DIFF
--- a/src/tpm2_cryptocb.c
+++ b/src/tpm2_cryptocb.c
@@ -182,20 +182,15 @@ int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
             int curve_id;
             WOLFTPM2_KEY* key;
 
-        #ifdef WOLFTPM2_USE_SW_ECDHE
-            if (tlsCtx->ecdhKey == NULL) {
-                return exit_rc;
-            }
-        #endif
-
             if (   tlsCtx->eccKey   == NULL
                 && tlsCtx->ecdsaKey == NULL
                 && tlsCtx->ecdhKey  == NULL
             ) {
             #ifdef DEBUG_WOLFTPM
-                printf("No crypto callback key pointer set!\n");
+                printf("No crypto callback TPM key set, "
+                       "fallback to software crypto\n");
             #endif
-                return BAD_FUNC_ARG;
+                return exit_rc;
             }
 
             /* Make sure an ECDH key has been set and curve is supported */
@@ -205,6 +200,7 @@ int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
             }
             rc = TPM2_GetTpmCurve(curve_id);
             if (rc < 0) {
+                /* curve not available, so fallback to sw crypto */
                 return exit_rc;
             }
             curve_id = rc;
@@ -215,9 +211,14 @@ int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
             if (tlsCtx->ecdhKey == NULL)
         #endif
             {
-                /* Create an ECC key for ECDSA - if one isn't already created */
                 key = (tlsCtx->ecdsaKey != NULL) ?
                     (WOLFTPM2_KEY*)tlsCtx->ecdsaKey : tlsCtx->eccKey;
+                if (key == NULL) {
+                    /* fallback to software crypto */
+                    return exit_rc;
+                }
+
+                /* Create an ECC key for ECDSA - if one isn't already created */
                 if (key->handle.hndl == 0 ||
                     key->handle.hndl == TPM_RH_NULL
                 ) {
@@ -261,8 +262,13 @@ int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
             }
         #ifndef WOLFTPM2_USE_SW_ECDHE
             else {
-                /* Generate ephemeral key - if one isn't already created */
                 key = tlsCtx->ecdhKey;
+                if (key == NULL) {
+                    /* fallback to software crypto */
+                    return exit_rc;
+                }
+
+                /* Generate ephemeral key - if one isn't already created */
                 if (key->handle.hndl == 0 ||
                     key->handle.hndl == TPM_RH_NULL) {
                     rc = wolfTPM2_ECDHGenKey(tlsCtx->dev, tlsCtx->ecdhKey,

--- a/src/tpm2_cryptocb.c
+++ b/src/tpm2_cryptocb.c
@@ -182,6 +182,12 @@ int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
             int curve_id;
             WOLFTPM2_KEY* key;
 
+        #ifdef WOLFTPM2_USE_SW_ECDHE
+            if (tlsCtx->ecdhKey == NULL) {
+                return exit_rc;
+            }
+        #endif
+
             if (   tlsCtx->eccKey   == NULL
                 && tlsCtx->ecdsaKey == NULL
                 && tlsCtx->ecdhKey  == NULL
@@ -262,13 +268,8 @@ int wolfTPM2_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
             }
         #ifndef WOLFTPM2_USE_SW_ECDHE
             else {
-                key = tlsCtx->ecdhKey;
-                if (key == NULL) {
-                    /* fallback to software crypto */
-                    return exit_rc;
-                }
-
                 /* Generate ephemeral key - if one isn't already created */
+                key = tlsCtx->ecdhKey;
                 if (key->handle.hndl == 0 ||
                     key->handle.hndl == TPM_RH_NULL) {
                     rc = wolfTPM2_ECDHGenKey(tlsCtx->dev, tlsCtx->ecdhKey,

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -4132,7 +4132,7 @@ int wolfTPM2_SignHash(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
             sigAlg = TPM_ALG_ECDSA;
         }
         if (hashAlg == 0 || hashAlg == TPM_ALG_NULL) {
-            /* determine hash type based on cuve */
+            /* determine hash type based on curve */
             int curve_id = pub->parameters.eccDetail.curveID;
             if (curve_id == TPM_ECC_NIST_P521)
                 hashAlg = TPM_ALG_SHA512;

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -4132,11 +4132,13 @@ int wolfTPM2_SignHash(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
             sigAlg = TPM_ALG_ECDSA;
         }
         if (hashAlg == 0 || hashAlg == TPM_ALG_NULL) {
-            if (digestSz == 64)
+            /* determine hash type based on cuve */
+            int curve_id = pub->parameters.eccDetail.curveID;
+            if (curve_id == TPM_ECC_NIST_P521)
                 hashAlg = TPM_ALG_SHA512;
-            else if (digestSz == 48)
+            else if (curve_id == TPM_ECC_NIST_P384)
                 hashAlg = TPM_ALG_SHA384;
-            else if (digestSz == 32)
+            else
                 hashAlg = TPM_ALG_SHA256;
         }
     }
@@ -4273,12 +4275,16 @@ int wolfTPM2_VerifyHash_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 int wolfTPM2_VerifyHash(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     const byte* sig, int sigSz, const byte* digest, int digestSz)
 {
+    int curve_id = 0;
     int hashAlg = TPM_ALG_NULL;
 
-    /* detect hash algorithm based on digest size */
-    if (digestSz >= TPM_SHA512_DIGEST_SIZE)
+    /* detect hash algorithm based on key curve */
+    if (key != NULL) {
+        curve_id = key->pub.publicArea.parameters.eccDetail.curveID;
+    }
+    if (curve_id == TPM_ECC_NIST_P521)
         hashAlg = TPM_ALG_SHA512;
-    else if (digestSz >= TPM_SHA384_DIGEST_SIZE)
+    else if (curve_id == TPM_ECC_NIST_P384)
         hashAlg = TPM_ALG_SHA384;
     else
         hashAlg = TPM_ALG_SHA256;


### PR DESCRIPTION
* Fix for crypto callback to return CRYPTOCB_UNAVAILABLE when a TPM key is not set. (ZD 19829)
* Fix to use curve type to determine hash type not digest size. (ZD 20296) - fixes wolfPKCS11 TPM test. Broken in #432