### PR TITLE
Draft: persistent access to /dev/tpmrmX

### DIFF
--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -645,6 +645,10 @@ TPM_RC TPM2_Init_ex(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx,
         return rc;
 #endif
 
+#ifdef WOLFTPM_LINUX_DEV
+    ctx->fd = -1;
+#endif
+
     /* Set the active TPM global */
     TPM2_SetActiveCtx(ctx);
 

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1883,6 +1883,9 @@ typedef struct TPM2_CTX {
     unsigned int rngInit:1;
     #endif
 #endif
+#ifdef WOLFTPM_LINUX_DEV
+    int fd;
+#endif
 } TPM2_CTX;
 
 


### PR DESCRIPTION
Across multiple TPM transfers, do not close-reopen TPM device