### PR TITLE
Fix for `wolfTPM2_SetKeyAuthPassword` that was truncating password to 2 bytes

### DIFF
--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -528,8 +528,8 @@ int wolfTPM2_SetKeyAuthPassword(WOLFTPM2_KEY *key, const byte* auth,
     }
 
     /* specify auth password for storage key */
-    if (authSz > (int)sizeof(key->handle.auth.size)) {
-        authSz = (int)sizeof(key->handle.auth.size); /* truncate */
+    if (authSz > (int)sizeof(key->handle.auth.buffer)) {
+        authSz = (int)sizeof(key->handle.auth.buffer); /* truncate */
     }
     key->handle.auth.size = (UINT16)authSz;
     if (auth != NULL) {

--- a/wrapper/CSharp/wolfTPM.cs
+++ b/wrapper/CSharp/wolfTPM.cs
@@ -903,8 +903,13 @@ namespace wolfTPM
 
         const string DLLNAME = "wolftpm";
 
-        public const int MAX_KEYBLOB_BYTES = 1024;
+        /* These "max" buffer sizes are used for testing only and may be larger
+         * depending on actual platform. */
+        /* Temporary buffer large enough for key blob public+private parts */
+        public const int MAX_KEYBLOB_BYTES = 2048; /* MAX_CONTEXT_SIZE */
+        /* Temporary buffer large enough for test CSR's */
         public const int MAX_TPM_BUFFER = 2048;
+
         public const int INVALID_DEVID = -2;
         private IntPtr device = IntPtr.Zero;
 


### PR DESCRIPTION
Fix for `wolfTPM2_SetKeyAuthPassword` that was truncating password to 2 chars. Bug introduced in PR #427 and release v3.9.2.
Added test to catch this edge case in C# wrapper tests.
Increased MAX_KEYBLOB_BYTES because some platforms require larger value. Added inline code documentation about use of these (testing only).
Reviewed all code to make sure no other issues like this were introduced.
ZD 20841