### PR TITLE
Fix for st33KTPM support pr deadcode

### DIFF
--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -311,12 +311,9 @@ static void test_wolfTPM2_ST33_FirmwareUpgrade(void)
     }
 #endif /* !WOLFTPM2_NO_WOLFCRYPT */
 
-    rc = 0;
-
     wolfTPM2_Cleanup(&dev);
 
-    printf("Test ST33 Firmware Upgrade:\tAPI Availability:\t%s\n",
-        rc == 0 ? "Passed" : "Failed");
+    printf("Test ST33 Firmware Upgrade:\tAPI Availability:\tPassed\n");
 }
 #endif /* WOLFTPM_ST33 || WOLFTPM_AUTODETECT */
 #endif /* WOLFTPM_FIRMWARE_UPGRADE */


### PR DESCRIPTION
Fixed deadcode here

```
** CID 899688:       Control flow issues  (DEADCODE)
/tests/unit_tests.c: 318           in test_wolfTPM2_ST33_FirmwareUpgrade()


_____________________________________________________________________________________________
*** CID 899688:         Control flow issues  (DEADCODE)
/tests/unit_tests.c: 318             in test_wolfTPM2_ST33_FirmwareUpgrade()
312     #endif /* !WOLFTPM2_NO_WOLFCRYPT */
313     
314         rc = 0;
315     
316         wolfTPM2_Cleanup(&dev);
317     
>>>     CID 899688:         Control flow issues  (DEADCODE)
>>>     Execution cannot reach the expression ""Failed"" inside this statement: "printf("Test ST33 Firmware ...".
318         printf("Test ST33 Firmware Upgrade:\tAPI Availability:\t%s\n",
319             rc == 0 ? "Passed" : "Failed");
320     }
321     #endif /* WOLFTPM_ST33 || WOLFTPM_AUTODETECT */
322     #endif /* WOLFTPM_FIRMWARE_UPGRADE */
```