### PR TITLE
Coverity fixes for new fwtpm code

### DIFF
--- a/.github/workflows/fwtpm-test.yml
+++ b/.github/workflows/fwtpm-test.yml
@@ -210,6 +210,19 @@ jobs:
           WOLFSSL_PATH: ./wolfssl
         run: make check
 
+      - name: Print test-suite.log on failure
+        if: ${{ failure() && !matrix.build_only }}
+        run: |
+          if [ -f test-suite.log ]; then
+            echo "=== test-suite.log ==="
+            cat test-suite.log
+          fi
+          for f in tests/*.log; do
+            [ -f "$f" ] || continue
+            echo "=== $f ==="
+            cat "$f"
+          done
+
       - name: Upload failure logs
         if: ${{ failure() && !matrix.build_only }}
         uses: actions/upload-artifact@v4
@@ -217,6 +230,8 @@ jobs:
           name: fwtpm-logs-${{ matrix.name }}
           path: |
             /tmp/fwtpm_check_*.log
+            test-suite.log
+            tests/*.log
           retention-days: 5
 
   # ----------------------------------------------------------------

--- a/examples/pcr/policy.c
+++ b/examples/pcr/policy.c
@@ -61,6 +61,7 @@ int TPM2_PCR_Policy_Test(void* userCtx, int argc, char *argv[])
     TPM_ALG_ID paramEncAlg = TPM_ALG_NULL;
     WOLFTPM2_SESSION tpmSession;
     int i;
+    int hexRet;
     byte digest[32];
     word32 digestLen = 0;
     union {
@@ -108,7 +109,13 @@ int TPM2_PCR_Policy_Test(void* userCtx, int argc, char *argv[])
                 usage();
                 return 0;
             }
-            digestLen = hexToByte(digestStr, digest, digestLen / 2);
+            hexRet = hexToByte(digestStr, digest, digestLen / 2);
+            if (hexRet < 0) {
+                printf("Invalid hex digest string\n");
+                usage();
+                return 0;
+            }
+            digestLen = (word32)hexRet;
         }
         else if (argv[argc-1][0] != '-') {
             /* TODO: Allow selection of multiple PCR's SHA-1 or SHA2-256 */

--- a/src/fwtpm/fwtpm_command.c
+++ b/src/fwtpm/fwtpm_command.c
@@ -3587,7 +3587,7 @@ static TPM_RC FwCmd_Create(FWTPM_CTX* ctx, TPM2_Packet* cmd,
 
                 if (rc == 0 && sensDataSize > 0) {
                     /* Use caller-supplied key material */
-                    if (sensDataSize > (UINT16)FWTPM_MAX_PRIVKEY_DER) {
+                    if (sensDataSize > (UINT16)FWTPM_MAX_DATA_BUF) {
                         rc = TPM_RC_SIZE;
                     }
                     if (rc == 0) {
@@ -4090,7 +4090,7 @@ static TPM_RC FwCmd_LoadExternal(FWTPM_CTX* ctx, TPM2_Packet* cmd,
     if (rc == 0 && inPrivSize > 0 && sensitiveType == TPM_ALG_SYMCIPHER &&
             qSz > 0) {
         /* For SYMCIPHER, qBuf contains the raw AES key bytes */
-        if (qSz > (UINT16)FWTPM_MAX_PRIVKEY_DER) {
+        if (qSz > (UINT16)FWTPM_MAX_DER_SIG_BUF) {
             rc = TPM_RC_SIZE;
         }
         if (rc == 0) {
@@ -5459,7 +5459,7 @@ static TPM_RC FwCmd_CreateLoaded(FWTPM_CTX* ctx, TPM2_Packet* cmd,
                 }
 
                 if (rc == 0 && sensDataSize > 0) {
-                    if (sensDataSize > (UINT16)FWTPM_MAX_PRIVKEY_DER) {
+                    if (sensDataSize > (UINT16)FWTPM_MAX_DATA_BUF) {
                         rc = TPM_RC_SIZE;
                     }
                     if (rc == 0) {
@@ -5496,7 +5496,7 @@ static TPM_RC FwCmd_CreateLoaded(FWTPM_CTX* ctx, TPM2_Packet* cmd,
                 }
 
                 if (rc == 0 && sensDataSize > 0) {
-                    if (sensDataSize > (UINT16)FWTPM_MAX_PRIVKEY_DER) {
+                    if (sensDataSize > (UINT16)FWTPM_MAX_DATA_BUF) {
                         rc = TPM_RC_SIZE;
                     }
                     if (rc == 0) {
@@ -7339,7 +7339,10 @@ static TPM_RC FwCmd_StartAuthSession(FWTPM_CTX* ctx, TPM2_Packet* cmd,
                     XMEMCPY(&bindAuth, &bindObj->authValue, sizeof(TPM2B_AUTH));
                 }
             }
-            if (bindAuth.size > 0) {
+            if (bindAuth.size > sizeof(bindAuth.buffer)) {
+                rc = TPM_RC_FAILURE;
+            }
+            if (rc == 0 && bindAuth.size > 0) {
                 if (keyInSz + bindAuth.size <= (int)sizeof(keyIn)) {
                     XMEMCPY(keyIn + keyInSz, bindAuth.buffer, bindAuth.size);
                     keyInSz += bindAuth.size;
@@ -11108,31 +11111,46 @@ static TPM_RC FwCmd_Quote(FWTPM_CTX* ctx, TPM2_Packet* cmd,
         wcH = FwGetWcHashType(pcrHashAlg);
         dSz = TPM2_GetHashDigestSize(pcrHashAlg);
         if (wcH != WC_HASH_TYPE_NONE && dSz > 0) {
-            wc_HashInit(hashCtx, wcH);
-            for (s = 0; s < numSel; s++) {
-                int bank = FwGetPcrBankIndex(selections[s].hashAlg);
-                int bankDSz = TPM2_GetHashDigestSize(
-                    selections[s].hashAlg);
-                UINT32 j;
-                if (bank < 0 || bankDSz == 0)
-                    continue;
-                for (j = 0; j < selections[s].sizeOfSelect; j++) {
-                    int pcr;
-                    for (pcr = 0; pcr < 8; pcr++) {
-                        if (selections[s].pcrSelect[j] & (1 << pcr)) {
-                            int pcrIdx = j * 8 + pcr;
-                            if (pcrIdx < IMPLEMENTATION_PCR) {
-                                wc_HashUpdate(hashCtx, wcH,
-                                    ctx->pcrDigest[pcrIdx][bank],
-                                    bankDSz);
+            if (wc_HashInit(hashCtx, wcH) != 0) {
+                rc = TPM_RC_FAILURE;
+            }
+            if (rc == 0) {
+                for (s = 0; s < numSel && rc == 0; s++) {
+                    int bank = FwGetPcrBankIndex(selections[s].hashAlg);
+                    int bankDSz = TPM2_GetHashDigestSize(
+                        selections[s].hashAlg);
+                    UINT32 j;
+                    if (bank < 0 || bankDSz == 0)
+                        continue;
+                    for (j = 0; j < selections[s].sizeOfSelect &&
+                            rc == 0; j++) {
+                        int pcr;
+                        for (pcr = 0; pcr < 8; pcr++) {
+                            if (selections[s].pcrSelect[j] & (1 << pcr)) {
+                                int pcrIdx = j * 8 + pcr;
+                                if (pcrIdx < IMPLEMENTATION_PCR) {
+                                    if (wc_HashUpdate(hashCtx, wcH,
+                                            ctx->pcrDigest[pcrIdx][bank],
+                                            bankDSz) != 0) {
+                                        rc = TPM_RC_FAILURE;
+                                        break;
+                                    }
+                                }
                             }
                         }
                     }
                 }
+                if (rc == 0) {
+                    if (wc_HashFinal(hashCtx, wcH,
+                            pcrDigestBuf) != 0) {
+                        rc = TPM_RC_FAILURE;
+                    }
+                    else {
+                        pcrDigestSz = dSz;
+                    }
+                }
+                wc_HashFree(hashCtx, wcH);
             }
-            wc_HashFinal(hashCtx, wcH, pcrDigestBuf);
-            wc_HashFree(hashCtx, wcH);
-            pcrDigestSz = dSz;
         }
         TPM2_Packet_AppendU16(&attestPkt, (UINT16)pcrDigestSz);
         TPM2_Packet_AppendBytes(&attestPkt, pcrDigestBuf, pcrDigestSz);
@@ -11547,8 +11565,13 @@ static TPM_RC FwCmd_NV_Certify(FWTPM_CTX* ctx, TPM2_Packet* cmd,
         dSz = TPM2_GetHashDigestSize(nv->nvPublic.nameAlg);
         if (wcH != WC_HASH_TYPE_NONE && dSz > 0) {
             FwStoreU16BE(nvName.name, nv->nvPublic.nameAlg);
-            wc_Hash(wcH, nvPubBuf, tmpPkt.pos, nvName.name + 2, dSz);
-            nvName.size = (UINT16)(2 + dSz);
+            if (wc_Hash(wcH, nvPubBuf, tmpPkt.pos,
+                    nvName.name + 2, dSz) == 0) {
+                nvName.size = (UINT16)(2 + dSz);
+            }
+            else {
+                rc = TPM_RC_FAILURE;
+            }
         }
     }
 
@@ -11738,7 +11761,7 @@ static TPM_RC FwCmd_MakeCredential(FWTPM_CTX* ctx, TPM2_Packet* cmd,
         /* patch blob size */
         blobSz = rsp->pos - blobStart;
         if (blobSz < 0 || blobSz > 0xFFFF ||
-            encSeedSz < 0 || encSeedSz > 0xFFFF) {
+            encSeedSz < 0 || encSeedSz > (int)FWTPM_MAX_PUB_BUF) {
             rc = TPM_RC_SIZE;
         }
         if (rc == 0) {
@@ -11913,6 +11936,9 @@ static TPM_RC FwCmd_ActivateCredential(FWTPM_CTX* ctx, TPM2_Packet* cmd,
             blobBuf, blobSz,
             objName->name, objName->size,
             credOut, (int)sizeof(credOut), &credSz);
+    }
+    if (rc == 0 && credSz > (UINT16)sizeof(credOut)) {
+        rc = TPM_RC_SIZE;
     }
 
     /* Build response: TPM2B_DIGEST */
@@ -12849,7 +12875,6 @@ int FWTPM_ProcessCommand(FWTPM_CTX* ctx,
                     cmdAuthCnt++;
                 }
 
-                cmdPkt.pos = authEnd;
                 cpStart = authEnd; /* cpBuffer starts after auth area */
             }
         }

--- a/src/fwtpm/fwtpm_main.c
+++ b/src/fwtpm/fwtpm_main.c
@@ -108,7 +108,7 @@ int main(int argc, char* argv[])
     /* Delete NV state file if --clear was requested */
     if (clearNv) {
         printf("Clearing NV state file: %s\n", FWTPM_NV_FILE);
-        remove(FWTPM_NV_FILE);
+        (void)remove(FWTPM_NV_FILE);
     }
 
     /* Initialize fwTPM */

--- a/tests/fwtpm_check.sh
+++ b/tests/fwtpm_check.sh
@@ -429,9 +429,11 @@ elif [ -x "$TPM2_TOOLS_SCRIPT" ]; then
             sleep 0.3
         fi
         rm -f "$BUILD_DIR/fwtpm_nv.bin"
+        echo "--- fwtpm_server restart for tpm2-tools ---" \
+            >> /tmp/fwtpm_check_$$.log
         "$FWTPM_SERVER" --port "$FWTPM_PORT" \
             --platform-port "$FWTPM_PLAT_PORT" \
-            > /tmp/fwtpm_check_$$.log 2>&1 &
+            >> /tmp/fwtpm_check_$$.log 2>&1 &
         echo $! > "$PID_FILE"
         if ! wait_for_port "$FWTPM_PORT" 500; then
             echo "FAIL: fwtpm_server restart failed before tpm2-tools tests"

--- a/tests/fwtpm_unit_tests.c
+++ b/tests/fwtpm_unit_tests.c
@@ -2095,7 +2095,7 @@ int fwtpm_unit_tests(int argc, char *argv[])
     printf("fwTPM Unit Tests\n");
 
     /* Remove stale NV state to ensure clean test runs */
-    remove(FWTPM_NV_FILE);
+    (void)remove(FWTPM_NV_FILE);
 
     /* Lifecycle */
     test_fwtpm_init_cleanup();
@@ -2142,7 +2142,7 @@ int fwtpm_unit_tests(int argc, char *argv[])
      * state, so remove FWTPM_NV_FILE afterwards. */
     test_fwtpm_clock_sethal();
     test_fwtpm_nv_sethal_mock();
-    remove(FWTPM_NV_FILE);
+    (void)remove(FWTPM_NV_FILE);
 
     /* Key operations */
 #if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)


### PR DESCRIPTION
## Coverity Fixes (CID 909296–909315)

Address 18 Coverity findings: 4 bug fixes, 2 dead code cleanups, 5 defense-in-depth improvements, and 7 reviewed-no-action.

### Bug Fixes

| CID | File | Description |
|-----|------|-------------|
| 909299, 909313 | `src/fwtpm/fwtpm_command.c` | **OVERRUN:** `sensData` buffer size check used the wrong constant (`FWTPM_MAX_PRIVKEY_DER` = 1280 vs. actual buffer size `FWTPM_MAX_DATA_BUF` = 1024). Corrected in `FwCmd_Create` and `FwCmd_CreateLoaded` (3 locations). Defense-in-depth — upstream parser already bounds the size. |
| 909307 | `src/fwtpm/fwtpm_command.c` | **CHECKED_RETURN:** Added error check for `wc_Hash()` in `FwCmd_NV_Certify`. |
| 909302 | `src/fwtpm/fwtpm_command.c` | **CHECKED_RETURN:** Added error check for `wc_HashInit()` in `FwCmd_Quote` and guarded subsequent hash operations. |
| 909314 | `examples/pcr/policy.c` | **NEGATIVE_RETURNS:** `hexToByte()` returns `int` (may be -1) was assigned directly to `word32`. Added error check with early return. |

### Dead Code Cleanup

| CID | File | Description |
|-----|------|-------------|
| 909312 | `src/fwtpm/fwtpm_command.c` | **UNUSED_VALUE:** Removed dead `cmdPkt.pos` assignment in `FWTPM_ProcessCommand` (overwritten before use). |
| 909303 | `src/fwtpm/fwtpm_command.c` | **DEADCODE:** Corrected bound in `FwCmd_LoadExternal` SYMCIPHER path to match the actual `qSz` constraint (`FWTPM_MAX_DER_SIG_BUF`). |

### Defense-in-Depth

| CID | File | Description |
|-----|------|-------------|
| 909315, 909310 | `src/fwtpm/fwtpm_main.c`, `tests/fwtpm_unit_tests.c` | **CHECKED_RETURN:** Cast `remove()` to `(void)` — failure is intentional (file may not exist). |
| 909306 | `src/fwtpm/fwtpm_command.c` | **OVERRUN:** Tightened size validation in `FwCmd_MakeCredential` to use the actual buffer size (`FWTPM_MAX_PUB_BUF`). |
| 909305 | `src/fwtpm/fwtpm_command.c` | **TAINTED_SCALAR:** Added explicit bounds check on `credSz` after `FwCredentialUnwrap()` in `FwCmd_ActivateCredential`. |
| 909301 | `src/fwtpm/fwtpm_command.c` | **OVERRUN:** Added explicit `bindAuth.size` clamp in `FwCmd_StartAuthSession`. |

### Reviewed – No Action Required

7 additional findings (CID 909296, 909297, 909298, 909300, 909308, 909309, 909311) were reviewed and determined to be false positives or by-design behavior; no code changes required.
