### PR TITLE
Reset on SPDM runner test

### DIFF
--- a/.github/workflows/hw-spdm-test.yml
+++ b/.github/workflows/hw-spdm-test.yml
@@ -141,6 +141,15 @@ jobs:
                       LDFLAGS="-L${{ steps.wolfssl.outputs.prefix }}/lib"
           make -j"$(nproc)"
 
+      - name: Reset TPM before detect (shared GPIO 4 reset line)
+        if: steps.health.outcome == 'success'
+        run: |
+          # Mirror spdm_test.sh gpio_reset(): both vendors share this reset line.
+          # Without this, caps sees a chip left in SPDM-locked state or stale TIS
+          # from a prior run and returns all-zero vendor/device IDs.
+          gpioset gpiochip0 4=0 2>/dev/null && sleep 0.1 && gpioset gpiochip0 4=1 2>/dev/null || true
+          sleep 2
+
       - name: Detect ${{ matrix.vendor }} TPM on SPI CS ${{ matrix.spi_cs }}
         id: detect
         if: steps.health.outcome == 'success'
@@ -175,7 +184,7 @@ jobs:
           done
 
       - name: Post-job cleanup
-        if: always() && steps.health.outcome == 'success' && steps.detect.outputs.present == 'true'
+        if: always() && steps.health.outcome == 'success'
         env:
           LD_LIBRARY_PATH: ${{ steps.wolfssl.outputs.prefix }}/lib
         run: |
@@ -184,6 +193,7 @@ jobs:
           sleep 1
           gpioset gpiochip0 4=0 2>/dev/null && sleep 0.1 && gpioset gpiochip0 4=1 2>/dev/null || true
           sleep 2
+          # unlock/flush only meaningful if the chip was detected; ignore errors otherwise
           ./examples/spdm/spdm_ctrl --connect --unlock 2>/dev/null || true
           ./examples/management/flush 2>/dev/null || true
           echo "[cleanup] done"


### PR DESCRIPTION
Caps is failing because it may be left in bad state 
```
Run EXPECTED='NPCT75x'
TPM2 Get Capabilities
TPM2: Caps 0x00000000, Did 0x0000, Vid 0x0000, Rid 0x 0 
Failed to connect to localhost 2321
TPM2_Startup failed 257: TPM_RC_FAILURE: Commands not being accepted because of a TPM failure
wolfTPM2_Init failed
0s
Run echo "::warning::NPCT75x not detected on SPI CS 0. Skipping nuvoton SPDM tests — wire the chip and re-run, or ignore if this vendor isn't installed on this runner."
Warning: NPCT75x not detected on SPI CS 0. Skipping nuvoton SPDM tests — wire the chip and re-run, or ignore if this vendor isn't installed on this runner.
```