### PR TITLE
Fix SPI and I2C behavior with SWTPM or FWTPM

### DIFF
--- a/.github/workflows/hw-spdm-test.yml
+++ b/.github/workflows/hw-spdm-test.yml
@@ -152,11 +152,14 @@ jobs:
           # spdm_test.sh handles vendor-specific reset (gpio_reset for nuvoton,
           # no-reset for nations) and SPDM-lock state internally. No pre-detect
           # needed: each runner is dedicated to a single known chip.
-          set -e
+          # pipefail so `spdm_test.sh | tee` propagates spdm_test.sh's non-zero
+          # exit — without it, tee always returns 0 and internal test failures
+          # silently pass CI.
+          set -eo pipefail
           for mode in ${{ matrix.modes }}; do
             echo "=== spdm_test.sh mode=$mode ==="
-            ./examples/spdm/spdm_test.sh ./examples/spdm/spdm_ctrl "$mode" \
-              2>&1 | tee "spdm-${{ matrix.vendor }}-${mode}.log"
+            ./examples/spdm/spdm_test.sh ./examples/spdm/spdm_ctrl "$mode" 2>&1 \
+              | tee "spdm-${{ matrix.vendor }}-${mode}.log"
           done
 
       - name: Post-job cleanup

--- a/.github/workflows/make-test-swtpm.yml
+++ b/.github/workflows/make-test-swtpm.yml
@@ -112,6 +112,92 @@ jobs:
           - name: nuvoton
             wolftpm_config: --enable-nuvoton --disable-fwtpm
 
+          # --- Auto-disable-on-HW tests: verify that hardware-path flags
+          # (vendor/bus/autodetect) disable the swtpm + fwtpm defaults on
+          # Linux aarch64/x86_64 without the user needing --disable-swtpm
+          # or --disable-fwtpm. See configure.ac WOLFTPM_HW_SELECTED. ---
+
+          # Vendor flag alone — no --disable-fwtpm / --disable-swtpm needed.
+          - name: nuvoton-autodisable
+            wolftpm_config: --enable-nuvoton
+            needs_swtpm: false
+          - name: nations-autodisable
+            wolftpm_config: --enable-nations
+            needs_swtpm: false
+
+          # New --enable-spi intent flag.
+          - name: spi
+            wolftpm_config: --enable-spi
+            needs_swtpm: false
+
+          # Explicit --enable-swtpm wins over the vendor auto-disable.
+          - name: nuvoton-explicit-swtpm
+            wolftpm_config: --enable-swtpm --enable-nuvoton --disable-fwtpm
+
+          # SPDM + vendor without any --disable flags (CI-path mirror of
+          # the hw-spdm-test.yml build line).
+          - name: spdm-nuvoton-autodisable
+            wolfssl_config: --enable-wolftpm --enable-ecc --enable-sha384 --enable-aesgcm --enable-hkdf --enable-sp
+            wolftpm_config: --enable-spdm --enable-nuvoton --enable-debug
+            needs_swtpm: false
+          - name: spdm-nations-autodisable
+            wolfssl_config: --enable-wolftpm --enable-ecc --enable-sha384 --enable-aesgcm --enable-hkdf --enable-sp
+            wolftpm_config: --enable-spdm --enable-nations --enable-debug
+            needs_swtpm: false
+
+          # Explicit --enable-fwtpm wins over the vendor auto-disable.
+          - name: nuvoton-explicit-fwtpm
+            wolftpm_config: --enable-nuvoton --enable-fwtpm
+            needs_swtpm: false
+
+          # --enable-spi + explicit --enable-swtpm (explicit sw wins).
+          - name: spi-explicit-swtpm
+            wolftpm_config: --enable-spi --enable-swtpm --disable-fwtpm
+
+          # MMIO (no existing matrix entry covered this).
+          - name: mmio
+            wolftpm_config: --enable-mmio --disable-fwtpm
+            needs_swtpm: false
+
+          # Linux kernel TPM driver (build-only; CI runner has no /dev/tpm*).
+          - name: devtpm
+            wolftpm_config: --enable-devtpm
+            needs_swtpm: false
+            test_command: "true"
+
+          # Negative tests: configure must error on conflicting flag combos,
+          # and we verify the SPECIFIC error message (not just a non-zero
+          # exit). wolfSSL is installed by the earlier `Setup wolfSSL` step,
+          # so configure gets past its wolfSSL check and hits the real
+          # conflict detection.
+          - name: config-conflicts
+            wolftpm_config: --disable-fwtpm
+            needs_swtpm: false
+            test_command: |-
+              set -e
+              check_conflict() {
+                local flags="$1" expected_err="$2"
+                echo "=== expect failure: ./configure $flags ==="
+                echo "    expected error substring: '$expected_err'"
+                make distclean >/dev/null 2>&1 || true
+                ./autogen.sh >/dev/null 2>&1
+                local out
+                out=$(./configure $flags 2>&1 || true)
+                if echo "$out" | grep -qF "$expected_err"; then
+                    echo "    PASS"
+                else
+                    echo "    FAIL — actual output:"
+                    echo "$out" | tail -20 | sed 's/^/      /'
+                    exit 1
+                fi
+              }
+              check_conflict "--enable-spi --enable-i2c" \
+                             "Cannot enable both --enable-spi and --enable-i2c"
+              check_conflict "--enable-swtpm --enable-devtpm" \
+                             "Cannot enable both swtpm and devtpm"
+              check_conflict "--enable-infineon=slb9673 --enable-spi" \
+                             "slb9673 is I2C-only"
+
           # TIS lock
           - name: tislock
             wolftpm_config: --enable-tislock --disable-fwtpm

--- a/README.md
+++ b/README.md
@@ -207,7 +207,10 @@ make install
 --enable-wrapper        Enable wrapper code (default: enabled) - WOLFTPM2_NO_WRAPPER
 --enable-wolfcrypt      Enable wolfCrypt hooks for RNG, Auth Sessions and Parameter encryption (default: enabled) - WOLFTPM2_NO_WOLFCRYPT
 --enable-advio          Enable Advanced IO (default: disabled) - WOLFTPM_ADV_IO
+--enable-spi            Intent signal for SPI hardware build. SPI is the default transport when --enable-i2c is not set;
+                        this flag adds no compile-time macro but disables the auto-enabled swTPM/fwTPM defaults. (default: not set)
 --enable-i2c            Enable I2C TPM Support (default: disabled, requires advio) - WOLFTPM_I2C
+--enable-mmio           Enable built-in MMIO callbacks (default: disabled) - WOLFTPM_MMIO
 --enable-checkwaitstate Enable TIS / SPI Check Wait State support (default: depends on chip) - WOLFTPM_CHECK_WAIT_STATE
 --enable-smallstack     Enable options to reduce stack usage
 --enable-tislock        Enable Linux Named Semaphore for locking access to SPI device for concurrent access between processes - WOLFTPM_TIS_LOCK
@@ -220,14 +223,21 @@ make install
 --enable-st             Enable ST ST33 Support (default: disabled) - WOLFTPM_ST33
 --enable-microchip      Enable Microchip ATTPM20 Support (default: disabled) - WOLFTPM_MICROCHIP
 --enable-nuvoton        Enable Nuvoton NPCT65x/NPCT75x Support (default: disabled) - WOLFTPM_NUVOTON
+--enable-nations        Enable Nations Technology NS350 Support (default: disabled) - WOLFTPM_NATIONS
 
 --enable-devtpm         Enable using Linux kernel driver for /dev/tpmX (default: disabled) - WOLFTPM_LINUX_DEV
                         Note: With autodetect (default) this is no longer required on Linux;
                         the kernel driver is tried automatically before SPI.
---enable-swtpm          Enable using SWTPM TCP protocol. For use with simulator. (default: disabled) - WOLFTPM_SWTPM
+--enable-swtpm          Enable using SWTPM TCP protocol. For use with simulator. (default: enabled on Linux x86_64/aarch64,
+                        disabled elsewhere or when a hardware path is selected via any of
+                        --enable-spi/--enable-i2c/--enable-mmio/--enable-nuvoton/--enable-nations/
+                        --enable-infineon/--enable-st/--enable-microchip/--enable-devtpm/--enable-autodetect) - WOLFTPM_SWTPM
 --enable-swtpm=uart     Enable using SWTPM protocol over UART serial. For use with fwTPM on
                         embedded targets (e.g. STM32H5). Uses termios serial I/O instead of
                         TCP sockets. - WOLFTPM_SWTPM + WOLFTPM_SWTPM_UART
+--enable-fwtpm          Enable firmware TPM (fwTPM) server. Same default behavior as --enable-swtpm
+                        (auto-enabled on Linux x86_64/aarch64, auto-disabled when a hardware
+                        path is selected). - WOLFTPM_FWTPM_SERVER
 --enable-winapi         Use Windows TBS API. (default: disabled) - WOLFTPM_WINAPI
 
 WOLFTPM_USE_SYMMETRIC   Enables symmetric AES/Hashing/HMAC support for TLS examples.

--- a/configure.ac
+++ b/configure.ac
@@ -176,12 +176,27 @@ fi
 AC_MSG_NOTICE([wolfCrypt path: ${wcpath}])
 
 
+# SPI transport — this is the default when no other bus is selected.
+# The flag itself is an intent signal (so hardware-builds can say
+# --enable-spi explicitly); no macro is needed since the SPI HAL is
+# compiled whenever WOLFTPM_I2C isn't set.
+AC_ARG_ENABLE([spi],
+    [AS_HELP_STRING([--enable-spi],[Intent signal for SPI hardware build. SPI is the default transport when --enable-i2c is not set; this flag adds no compile-time macro but disables the auto-enabled swTPM/fwTPM defaults. (default: not set)])],
+    [ ENABLED_SPI=$enableval ],
+    [ ENABLED_SPI=no ]
+    )
+
 # I2C Support
 AC_ARG_ENABLE([i2c],
     [AS_HELP_STRING([--enable-i2c],[Enable I2C TPM Support (default: disabled)])],
     [ ENABLED_I2C=$enableval ],
     [ ENABLED_I2C=no ]
     )
+
+if test "x$ENABLED_SPI" = "xyes" && test "x$ENABLED_I2C" = "xyes"
+then
+    AC_MSG_ERROR([Cannot enable both --enable-spi and --enable-i2c])
+fi
 
 if test "x$ENABLED_I2C" = "xyes"
 then
@@ -225,29 +240,43 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_LINUX_DEV"
 fi
 
-# Native host defaults — auto-enable fwTPM and swTPM on Linux/BSD x86_64 / aarch64
-# so `make check` provides full coverage out of the box. Users can still
-# explicitly disable with --disable-fwtpm / --disable-swtpm.
+# If the user explicitly picked any hardware path (vendor, bus, kernel
+# driver, autodetect), don't default-enable the software TPMs — the SPI HAL
+# in hal/tpm_io_linux.c is excluded when WOLFTPM_SWTPM is defined.
+WOLFTPM_HW_SELECTED=no
+for _wt_v in "$enable_infineon" "$enable_st" "$enable_st33" \
+             "$enable_microchip" "$enable_mchp" \
+             "$enable_nuvoton" "$enable_nations" \
+             "$enable_spi" "$enable_i2c" "$enable_mmio" \
+             "$enable_devtpm" "$enable_autodetect" \
+             "$enable_winapi" "$enable_wintbs"; do
+    if test -n "$_wt_v" && test "x$_wt_v" != "xno"; then
+        WOLFTPM_HW_SELECTED=yes
+    fi
+done
+
+# Auto-enable fwTPM + swTPM on Linux/BSD x86_64/aarch64 so `make check`
+# works out of the box — unless a hardware path was explicitly selected.
 WOLFTPM_DEFAULT_FWTPM=no
 WOLFTPM_DEFAULT_SWTPM=no
-case $host_cpu in
-    x86_64|amd64|aarch64)
-        # Defensive exclusion: fwtpm_server uses POSIX sockets and is not
-        # currently portable to Windows / Darwin. Auto-enable on Linux/BSD only.
-        case $host_os in
-            *mingw*|*cygwin*|*msys*|*darwin*|*win32*)
-                ;;
-            *)
-                WOLFTPM_DEFAULT_FWTPM=yes
-                WOLFTPM_DEFAULT_SWTPM=yes
-                ;;
-        esac
-        ;;
-esac
+if test "x$WOLFTPM_HW_SELECTED" = "xno"; then
+    case $host_cpu in
+        x86_64|amd64|aarch64)
+            case $host_os in
+                *mingw*|*cygwin*|*msys*|*darwin*|*win32*)
+                    ;;
+                *)
+                    WOLFTPM_DEFAULT_FWTPM=yes
+                    WOLFTPM_DEFAULT_SWTPM=yes
+                    ;;
+            esac
+            ;;
+    esac
+fi
 
 # SW TPM device Support
 AC_ARG_ENABLE([swtpm],
-    [AS_HELP_STRING([--enable-swtpm],[Enable use of TPM through the SW socket driver (default: enabled on Linux x86_64/aarch64, disabled elsewhere)])],
+    [AS_HELP_STRING([--enable-swtpm],[Enable use of TPM through the SW socket driver (default: enabled on Linux x86_64/aarch64, disabled elsewhere or when any --enable-<vendor>/--enable-spi/--enable-i2c/--enable-mmio/--enable-devtpm/--enable-autodetect is explicitly set)])],
     [ ENABLED_SWTPM=$enableval ],
     [ ENABLED_SWTPM=$WOLFTPM_DEFAULT_SWTPM ]
     )
@@ -299,7 +328,7 @@ AC_SUBST([DISTCHECK_SWTPM_PORT_FLAG])
 
 # Firmware TPM (fwTPM) - software TPM 2.0 simulator
 AC_ARG_ENABLE([fwtpm],
-    [AS_HELP_STRING([--enable-fwtpm],[Enable firmware TPM (fwTPM) server (default: enabled on Linux x86_64/aarch64, disabled elsewhere)])],
+    [AS_HELP_STRING([--enable-fwtpm],[Enable firmware TPM (fwTPM) server (default: enabled on Linux x86_64/aarch64, disabled elsewhere or when any --enable-<vendor>/--enable-spi/--enable-i2c/--enable-mmio/--enable-devtpm/--enable-autodetect is explicitly set)])],
     [ ENABLED_FWTPM=$enableval ],
     [ ENABLED_FWTPM=$WOLFTPM_DEFAULT_FWTPM ]
     )
@@ -472,6 +501,11 @@ then
     else
         if test "x$ENABLED_INFINEON" = "xslb9673"
         then
+            # slb9673 is I2C-only; reject combos that imply SPI.
+            if test "x$ENABLED_SPI" = "xyes"
+            then
+                AC_MSG_ERROR([--enable-infineon=slb9673 is I2C-only; use --enable-i2c --enable-advio (not --enable-spi)])
+            fi
             enable_i2c=yes
             AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_SLB9673"
         else
@@ -787,6 +821,19 @@ echo "   * Wrappers:                  $ENABLED_WRAPPER"
 echo "   * Examples:                  $ENABLED_EXAMPLES"
 echo "   * wolfCrypt:                 $ENABLED_WOLFCRYPT"
 echo "   * Advanced IO:               $ENABLED_ADVIO"
+
+# SPI HAL is actually compiled when no other transport claims the bus.
+# Mirror the #if guards in hal/tpm_io_linux.c so the summary reflects
+# the real build state, matching how ENABLED_I2C is reported below.
+SPI_ACTUAL=yes
+if test "x$ENABLED_I2C" = "xyes"     || \
+   test "x$ENABLED_SWTPM" = "xyes"   || test "x$ENABLED_SWTPM" = "xuart" || \
+   test "x$ENABLED_DEVTPM" = "xyes"  || \
+   test "x$ENABLED_WINAPI" = "xyes"
+then
+    SPI_ACTUAL=no
+fi
+echo "   * SPI:                       $SPI_ACTUAL"
 echo "   * I2C:                       $ENABLED_I2C"
 echo "   * Linux kernel TPM device:   $ENABLED_DEVTPM"
 echo "   * SWTPM:                     $ENABLED_SWTPM"


### PR DESCRIPTION
## Fixed

- HW TPM builds silently hit SWTPM socket — --enable-<vendor> now auto-disables the aarch64/x86_64 swtpm/fwtpm defaults (root cause: PR #474 made them   
  default-on)
- hw-spdm-test.yml went green on failed tests — added pipefail so spdm_test.sh | tee propagates the exit code                                            
- SPI: summary was misleading — now reflects real HAL compile state, same as I2C:                                                                         - --enable-infineon=slb9673 --enable-spi built a broken binary — now errors                                                                               - Stale help strings for --enable-swtpm/--enable-fwtpm/--enable-spi                                                                                      
                                                                                                                                                           
 ## Added                                                                                                                                                    
                                                                                                                                                           
- --enable-spi intent flag (no macro, triggers HW auto-disable)                                                                                          
- 11 new CI matrix entries covering every auto-disable path + 3 negative conflict tests
- README entries for --enable-spi/--enable-nations/--enable-mmio 