### PR TITLE
wolfTPM Release v4.0.0 Prep

### DIFF
--- a/.github/workflows/make-test-swtpm.yml
+++ b/.github/workflows/make-test-swtpm.yml
@@ -49,6 +49,11 @@ jobs:
             wolftpm_config: --enable-swtpm --disable-wrapper --disable-fwtpm
             test_command: "./examples/native/native_test"
 
+          # No examples (compile-only; examples disabled so no test_command)
+          - name: no-examples
+            wolftpm_config: --enable-swtpm --disable-examples --disable-fwtpm
+            test_command: "true"
+
           # Small stack
           - name: smallstack
             wolftpm_config: --enable-swtpm --enable-smallstack --disable-fwtpm
@@ -72,6 +77,10 @@ jobs:
           # STMicro ST33KTPM2
           - name: st33ktpm2
             wolftpm_config: --enable-st33 --disable-fwtpm
+          # STMicro ST33KTPM2 over I2C (compile-only, no hardware in CI)
+          - name: st33ktpm2-i2c
+            wolftpm_config: --enable-st33 --enable-i2c --disable-fwtpm
+            test_command: "true"
           # STMicro ST33KTPM2
           - name: st33ktpm2 firmware
             wolftpm_config: --enable-st33 --enable-firmware --disable-fwtpm

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -1,0 +1,135 @@
+name: Release Checks
+
+# Gates intended to mirror the wolfTPM release procedure:
+#   - C++ build with CC=g++ (proves headers are C++-safe for consumers)
+#   - scan-build --status-bugs (Clang static analysis)
+# Both run on every PR and every push to release branches so regressions are
+# caught at PR time instead of during release prep.
+
+on:
+  push:
+    branches: [ 'master', 'main', 'release/**', 'rel_v*_prep' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_wolfssl:
+    name: Build wolfSSL
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout wolfSSL
+        uses: actions/checkout@v4
+        with:
+          repository: wolfssl/wolfssl
+          path: wolfssl
+          ref: master
+
+      - name: Build wolfSSL
+        working-directory: ./wolfssl
+        run: |
+          ./autogen.sh
+          ./configure --enable-wolftpm --enable-pkcallbacks --enable-keygen \
+              --prefix=/tmp/wolfssl-install \
+              CFLAGS="-DWC_RSA_NO_PADDING"
+          make -j$(nproc)
+          make install
+
+      - name: Tar install dir
+        run: tar -zcf wolfssl-install.tgz -C /tmp wolfssl-install
+
+      - name: Upload wolfSSL install
+        uses: actions/upload-artifact@v4
+        with:
+          name: wolfssl-release-checks
+          path: wolfssl-install.tgz
+          retention-days: 1
+
+  cxx_build:
+    name: C++ build (CC=g++)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build_wolfssl
+    steps:
+      - name: Checkout wolfTPM
+        uses: actions/checkout@v4
+
+      - name: Download wolfSSL
+        uses: actions/download-artifact@v4
+        with:
+          name: wolfssl-release-checks
+
+      - name: Install wolfSSL
+        run: |
+          sudo tar -xzf wolfssl-install.tgz -C /tmp
+          sudo ldconfig /tmp/wolfssl-install/lib
+
+      - name: Build wolfTPM with g++ (default config)
+        run: |
+          ./autogen.sh
+          ./configure CC=g++ \
+              --with-wolfcrypt=/tmp/wolfssl-install
+          make -j$(nproc)
+
+      - name: Build wolfTPM with g++ (--enable-fwtpm)
+        run: |
+          make distclean
+          ./configure CC=g++ --enable-fwtpm \
+              --with-wolfcrypt=/tmp/wolfssl-install
+          make -j$(nproc)
+
+      - name: Show log on errors
+        if: failure()
+        run: cat config.log
+
+  scan_build:
+    name: scan-build (clang static analysis)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build_wolfssl
+    steps:
+      - name: Install clang tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-tools
+
+      - name: Checkout wolfTPM
+        uses: actions/checkout@v4
+
+      - name: Download wolfSSL
+        uses: actions/download-artifact@v4
+        with:
+          name: wolfssl-release-checks
+
+      - name: Install wolfSSL
+        run: |
+          sudo tar -xzf wolfssl-install.tgz -C /tmp
+          sudo ldconfig /tmp/wolfssl-install/lib
+
+      - name: scan-build default configuration
+        run: |
+          ./autogen.sh
+          scan-build --status-bugs ./configure \
+              --with-wolfcrypt=/tmp/wolfssl-install
+          scan-build --status-bugs -o scan-results-default make -j$(nproc)
+
+      - name: scan-build with --enable-fwtpm
+        run: |
+          make distclean
+          scan-build --status-bugs ./configure --enable-fwtpm \
+              --with-wolfcrypt=/tmp/wolfssl-install
+          scan-build --status-bugs -o scan-results-fwtpm make -j$(nproc)
+
+      - name: Upload scan reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scan-build-reports
+          path: |
+            scan-results-default/
+            scan-results-fwtpm/
+          retention-days: 7

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [ 'master', 'main', 'release/**', 'rel_v*_prep' ]
   pull_request:
-    branches: [ '*' ]
+    branches: [ '**' ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeList.txt
 #
-# Copyright (C) 2006-2025 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
 # This file is part of wolfSSL. (formerly known as CyaSSL)
 #
@@ -21,7 +21,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(wolfTPM VERSION 3.10.0 LANGUAGES C)
+project(wolfTPM VERSION 4.0.0 LANGUAGES C)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(WOLFTPM_DEFINITIONS)
@@ -638,7 +638,7 @@ file(REMOVE ${OPTION_FILE})
 file(APPEND ${OPTION_FILE} "/* wolftpm options.h\n")
 file(APPEND ${OPTION_FILE} " * generated from cmake configure options\n")
 file(APPEND ${OPTION_FILE} " *\n")
-file(APPEND ${OPTION_FILE} " * Copyright (C) 2006-2025 wolfSSL Inc.\n")
+file(APPEND ${OPTION_FILE} " * Copyright (C) 2006-2026 wolfSSL Inc.\n")
 file(APPEND ${OPTION_FILE} " *\n")
 file(APPEND ${OPTION_FILE} " * This file is part of wolfSSL.\n")
 file(APPEND ${OPTION_FILE} " *\n")

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,109 @@
 # Release Notes
 
+## wolfTPM Release 4.0.0 (Apr 22, 2026)
+
+**Summary**
+
+Major release with three new features:
+
+1. Firmware TPM 2.0 (fwTPM): a portable TPM 2.0 command processor built on wolfCrypt, usable as a replacement for a discrete TPM chip or as a CI/development replacement for external simulators.
+2. SPDM secured transport: secure vendor-defined TCG command communication with Nuvoton NPCT75x and Nations NS350 TPM modules.
+3. ST33KTPM2X firmware update: automatic format detection for both Generation 1 (non-LMS) and Generation 2 (LMS-signed) ST33KTPM firmware.
+
+Also includes new seal/unseal examples, additional platform/HAL support, extensive security hardening (Fenrir and Coverity), CI sanitizer coverage, and deprecation of OPENSTM32.
+
+**Detail**
+
+* Firmware TPM 2.0 (fwTPM) implementation (PR #474)
+  - Portable TPM 2.0 server built on wolfCrypt (RSA, ECC, SHA, AES, HMAC)
+  - 105/113 TPM 2.0 v1.38 commands implemented (93%)
+  - Socket transport (Microsoft TPM simulator protocol) and TIS transport
+  - File-based or HAL-callback NV storage; HAL abstraction for IO
+  - New configure options: `--enable-fwtpm` and `--enable-fwtpm-only`
+  - New feature macros: `FWTPM_NO_NV`, `FWTPM_NO_ATTESTATION`, `FWTPM_NO_POLICY`, `FWTPM_NO_DA`
+  - Full CI coverage: `fwtpm-test.yml` (11 matrix entries), `fuzz.yml` (weekly + per-PR smoke)
+  - macOS and Windows build support with network-namespace isolation for Linux CI
+* SPDM secured transport for Nuvoton NPCT75x and Nations NS350 (PR #458)
+  - Generic `WOLFTPM_SPDM_TCG` guard replaces per-vendor conditionals
+  - Vendor-defined TCG commands with VdCode validation
+  - PSK mode and identity-key mode with auto-connect
+  - Hardware test CI workflow split across self-hosted runners
+  - Added `spdm_ctrl` utility (renamed from `spdm_demo`)
+* STMicro ST33KTPM2X firmware update with LMS support (PR #446)
+  - New `st33_fw_update` example tool for ST33KTPM firmware updates
+  - Automatic firmware format detection based on TPM firmware version from `fwVerMinor`
+  - Generation 1 firmware (< 512, e.g. 9.257): Non-LMS format, 177-byte manifest, ECC-only
+  - Generation 2 firmware (>= 512, e.g. 9.512): LMS format, 2697-byte manifest with embedded LMS signature (LMS mandatory)
+  - No manual format selection required - manifest size chosen automatically
+  - See `examples/firmware/README.md` "ST33 Firmware Update" for usage
+* Seal/unseal examples with PCR, PolicyAuthorize, and NV policies (PR #464)
+  - Seal/unseal with PCR and policy authorization
+  - NV-based seal example with real parameter encryption (XOR and AES-CFB)
+  - New `seal-test.yml` CI workflow
+* Platform and HAL additions
+  - Raspberry Pi 4 hardware SPI support (PR #451)
+  - U-Boot HAL (`tpm_io_uboot.c`)
+  - Espressif ESP-IDF HAL SPI
+  - Linux auto-detection between `/dev/tpmX` and direct SPI at runtime
+* Configure behavior change
+  - On Linux x86_64/aarch64, `--enable-fwtpm` and `--enable-swtpm` now
+    default to enabled when no hardware path is selected, so plain
+    `./configure && make check` works out of the box without external
+    simulators
+  - New `--enable-spi` intent flag: pass it for hardware SPI builds to
+    suppress the swTPM/fwTPM auto-enable defaults (mutually exclusive
+    with `--enable-i2c`)
+  - `--disable-wolfcrypt` now auto-disables fwTPM (fwTPM requires
+    wolfCrypt) so the legacy `./configure --disable-wolfcrypt && make`
+    works without also passing `--disable-fwtpm`
+* Crypto callback and signing
+  - TPM support for `wc_SignCert_cb` callback API (PR #450)
+  - Fix for `wolfTPM2_SignHash` to return padded r/s, improved ECDSA P521 handling, added ECDSA tests with crypto callbacks (ZD20777)
+* Security hardening
+  - Fenrir findings addressed across tpm2_wrap, tpm2_packet, tpm2_asn, NV, session auth, SPDM, and fwtpm paths
+  - `ForceZero` on sensitive stack buffers (auth passwords, keyBlob, ECC/RSA private material, symmetric seeds, derived identity digests, NV read/write buffers, PSS padded buffers, session auth)
+  - Constant-time export for ECDH shared secret and ECC signature r/s
+  - Removed short-circuit OR in auth paths (HMAC verification, policy digest checks, ticket HMAC, ticket cpHashA, policy NV, PolicyPassword, credential unwrap, RSA-PKCS1v1.5)
+  - Bounds checks for `TPM2_Packet_AppendPCR` count/sizeofSelect, ASN.1 BIT STRING length, X.509 version, BER indefinite length, `wolfTPM2_UnloadHandles` handle-range overflow
+  - NULL-deref guards in `wolfTPM2_LoadRsaPrivateKey_ex`, `wolfTPM2_LoadEccPrivateKey`, `wolfTPM2_NVCreateAuthPolicy`, `wolfTPM2_EncryptDecryptBlock` (reject NULL IV for non-ECB, oversized IV)
+  - Scaled AES key size to RSA key strength in `wolfTPM2_ImportRsaPrivateKeySeed`; scaled session AES key size to match authHash in `wolfTPM2_StartSession`
+  - Return `BUFFER_E` instead of silently truncating auth values in `wolfTPM2_SetAuth`, `wolfTPM2_CreateKey`, `wolfTPM2_ChangeAuthKey`, `wolfTPM2_SetAuthHandleName`, `wolfTPM2_CreatePrimaryKey_ex`, `wolfTPM2_CreateLoadedKey`, `wolfTPM2_PolicyPassword`
+  - Removed sensitive auth and key material from debug output; added `WOLFTPM_DEBUG_SECRETS` opt-in macro for developer-only printing
+  - Moved auth size mismatch check outside `DEBUG_WOLFTPM` guard so it executes in all builds
+* Coverity and static analysis
+  - New Coverity CI workflow (PR #444)
+  - Fixed H-35, M-74, M-75 (PR #465)
+  - DEADCODE CID 900621 and related fixes
+* CI improvements
+  - Added ASan and UBSan sanitizers (PR #454)
+  - Pedantic gcc and pedantic clang build matrices
+  - macOS CI for fwTPM
+  - Windows build support for fwTPM
+  - Split hardware SPDM CI across multiple self-hosted runners
+  - Added unit tests for name/hash KATs, KDFa test vectors (ATH/SECRET/DUPLICATE labels), ParamEnc/Dec roundtrip, persistent-handle range checks, `ComputeName`, `HashNvPublic`, `PolicyHash` boundary, policy auth value offset
+* Marshaling and packet fixes
+  - `TPM_ALG_NULL` handling for `inScheme` serialization in Certify, CertifyCreation, Quote, GetSessionAuditDigest, GetCommandAuditDigest, GetTime, NV_Certify
+  - Added `TPM2_Packet_AppendSymmetric`/`ParseSymmetric` for SYMCIPHER case
+  - Fixed ECC ECDAA scheme serialization missing count field, RSA RSAES spurious hashAlg, `TPM2_Sign` ECDAA count
+  - Added SM3_256 and SHA3 digest sizes to `TPM2_GetHashDigestSize`
+  - Added ECSCHNORR and SM2 signature serialization
+  - Added `kdf` field to `TPMT_KEYEDHASH_SCHEME` XOR serialization
+  - Added `TPM2_Packet_ParseSensitive` counterpart and roundtrip test
+  - Documented `pub->size` mutation side effect in `TPM2_Packet_AppendPublic`
+* Bug fixes
+  - Fixed TLS ECDH curve mismatch in CI (PR #473)
+  - Added missing `unistd.h` include causing regressions in wolfBoot tpmtools (PR #471)
+  - Avoid nanosleep on non-Linux builds (PR #472)
+  - Fixed MAX_CONTEXT_SIZE stack buffer in CSR PEM using heap for small-stack builds (PR #460)
+  - Fixed AddressSanitizer warning for overlapping memcpy (use memmove) in wolfTPM2_USE_SW_ECDHE path
+  - Proper guarding for `LINUX_DEV`, `SWTPM`, and `WINAPI` (PR #466)
+  - Added error returns in `TPM2_IoCb_Zephyr_I2C`
+  - Improved error logging when `wolfTPM2_Init` fails
+  - Used `mp_to_unsigned_bin_len` (not `_ct`) for portability across wolfSSL builds
+* Deprecated / removed
+  - OPENSTM32 platform support removed (PR #479)
+
+
 ## wolfTPM Release 3.10.0 (Dec 4, 2025)
 
 **Summary**

--- a/IDE/Espressif/components/wolfssl/CMakeLists.txt
+++ b/IDE/Espressif/components/wolfssl/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2006-2025 wolfSSL Inc.
+#  Copyright (C) 2006-2026 wolfSSL Inc.
 #
 #  This file is part of wolfTPM.
 #

--- a/IDE/Espressif/components/wolfssl/include/user_settings.h
+++ b/IDE/Espressif/components/wolfssl/include/user_settings.h
@@ -1,6 +1,6 @@
 /* user_settings.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/IDE/Espressif/components/wolftpm/CMakeLists.txt
+++ b/IDE/Espressif/components/wolftpm/CMakeLists.txt
@@ -1,6 +1,6 @@
 # wolfTPM cmake for Espressif component
 #
-#  Copyright (C) 2006-2025 wolfSSL Inc.
+#  Copyright (C) 2006-2026 wolfSSL Inc.
 #
 #  This file is part of wolfTPM.
 #

--- a/IDE/Espressif/main/include/main.h
+++ b/IDE/Espressif/main/include/main.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/IDE/Espressif/main/main.c
+++ b/IDE/Espressif/main/main.c
@@ -1,6 +1,6 @@
 /* main.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/IDE/VisualStudio/user_settings.h
+++ b/IDE/VisualStudio/user_settings.h
@@ -1,6 +1,6 @@
 /* user_settings.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Portable TPM 2.0 project designed for embedded use.
 * Wrappers provided to simplify Key Generation/Loading, RSA encrypt/decrypt, ECC sign/verify, ECDH, NV, Hashing/HACM, AES, Sealing/Unsealing, Attestation, PCR Extend/Quote and Secure Root of Trust.
 * Testing done using TPM 2.0 modules from STMicro ST33 (SPI/I2C), Infineon OPTIGA SLB9670/SLB9672/SLB9673, Microchip ATTPM20, Nations Tech Z32H330TC/NS350 and Nuvoton NPCT650/NPCT750.
 * wolfTPM uses the TPM Interface Specification (TIS) to communicate either over SPI, or using a memory mapped I/O range.
-* On Linux, wolfTPM auto-detects between the kernel TPM driver (`/dev/tpmX`) and direct SPI access at runtime — a simple `./configure && make` works with either interface.
+* On Linux, wolfTPM auto-detects between the kernel TPM driver (`/dev/tpmX`) and direct SPI access at runtime - a simple `./configure && make` works with either interface.
 * wolfTPM can also use the Linux TPM kernel interface (`/dev/tpmX`) to talk with any physical TPM on SPI, I2C and even LPC bus.
 * Platform support for Raspberry Pi (Linux), MMIO, STM32 with CubeMX, Atmel ASF, Xilinx, QNX Infineon TriCore and Barebox.
 * The design allows for easy portability to different platforms:
@@ -204,7 +204,7 @@ make install
 ```text
 --enable-debug          Add debug code/turns off optimizations (yes|no|verbose|io) - DEBUG_WOLFTPM, WOLFTPM_DEBUG_VERBOSE, WOLFTPM_DEBUG_IO
                         WARNING: Define WOLFTPM_DEBUG_SECRETS manually (NOT enabled by default and NOT
-                        exposed via configure) to additionally print sensitive material — auth values,
+                        exposed via configure) to additionally print sensitive material - auth values,
                         session keys, bind keys, HMAC keys, hierarchy auth, and encryption secrets.
                         For developer debugging only. NEVER enable in production builds or on devices
                         that log stdout to persistent storage.

--- a/configure.ac
+++ b/configure.ac
@@ -2,8 +2,8 @@
 # Copyright (C) 2025 wolfSSL Inc.
 # All right reserved.
 
-AC_COPYRIGHT([Copyright (C) 2014-2025 wolfSSL Inc.])
-AC_INIT([wolftpm],[3.10.0],[https://github.com/wolfssl/wolfTPM/issues],[wolftpm],[http://www.wolfssl.com])
+AC_COPYRIGHT([Copyright (C) 2014-2026 wolfSSL Inc.])
+AC_INIT([wolftpm],[4.0.0],[https://github.com/wolfssl/wolfTPM/issues],[wolftpm],[https://www.wolfssl.com])
 
 AC_PREREQ([2.63])
 AC_CONFIG_AUX_DIR([build-aux])
@@ -29,7 +29,7 @@ AC_ARG_PROGRAM
 
 AC_CONFIG_HEADERS([src/config.h])
 
-WOLFTPM_LIBRARY_VERSION=16:8:0
+WOLFTPM_LIBRARY_VERSION=17:0:0
 #                        | | |
 #                 +------+ | +---+
 #                 |        |     |
@@ -141,7 +141,7 @@ else
     wcpath=$prefix
 fi
 AC_MSG_NOTICE([prefix ${prefix}])
-WOLFSSL_URL="http://www.wolfssl.com/download.html"
+WOLFSSL_URL="https://www.wolfssl.com/download.html"
 AC_ARG_WITH(wolfcrypt,
   [AS_HELP_STRING([--with-wolfcrypt=PATH], [PATH to wolfssl install (default /usr/local)])],
   [
@@ -745,7 +745,7 @@ rm -f $OPTION_FILE
 echo "/* wolftpm options.h" > $OPTION_FILE
 echo " * generated from configure options" >> $OPTION_FILE
 echo " *" >> $OPTION_FILE
-echo " * Copyright (C) 2006-2025 wolfSSL Inc." >> $OPTION_FILE
+echo " * Copyright (C) 2006-2026 wolfSSL Inc." >> $OPTION_FILE
 echo " *" >> $OPTION_FILE
 echo " * * This file is part of wolfTPM." >> $OPTION_FILE
 echo " *" >> $OPTION_FILE

--- a/configure.ac
+++ b/configure.ac
@@ -167,7 +167,14 @@ then
     LDFLAGS="$LDFLAGS -L${wcpath}/lib"
     CPPFLAGS="$CPPFLAGS -I${wcpath}/include"
 
-    AC_CHECK_LIB([wolfssl],[wolfCrypt_Init],,
+    # Use AC_LINK_IFELSE with proper headers so the probe works under both C
+    # and C++ (CC=g++). AC_CHECK_LIB synthesizes a bare declaration that gets
+    # name-mangled by C++ and fails to link against libwolfssl's C symbols.
+    AC_LINK_IFELSE([AC_LANG_PROGRAM(
+        [[#include <wolfssl/options.h>
+          #include <wolfssl/wolfcrypt/wc_port.h>]],
+        [[wolfCrypt_Init();]])],
+        [],
         [AC_MSG_ERROR([WolfSSL library not found. You can get it from $WOLFSSL_URL
         If its already installed, specify its path using --with-wolfcrypt=/dir or --prefix=/dir])])
 else
@@ -256,10 +263,11 @@ for _wt_v in "$enable_infineon" "$enable_st" "$enable_st33" \
 done
 
 # Auto-enable fwTPM + swTPM on Linux/BSD x86_64/aarch64 so `make check`
-# works out of the box — unless a hardware path was explicitly selected.
+# works out of the box -- unless a hardware path was explicitly selected,
+# or wolfCrypt was explicitly disabled (fwTPM requires wolfCrypt).
 WOLFTPM_DEFAULT_FWTPM=no
 WOLFTPM_DEFAULT_SWTPM=no
-if test "x$WOLFTPM_HW_SELECTED" = "xno"; then
+if test "x$WOLFTPM_HW_SELECTED" = "xno" && test "x$ENABLED_WOLFCRYPT" = "xyes"; then
     case $host_cpu in
         x86_64|amd64|aarch64)
             case $host_os in

--- a/examples/attestation/activate_credential.c
+++ b/examples/attestation/activate_credential.c
@@ -1,6 +1,6 @@
 /* activate_credential.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/attestation/attestation.h
+++ b/examples/attestation/attestation.h
@@ -1,6 +1,6 @@
 /* attestation.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/attestation/certify.c
+++ b/examples/attestation/certify.c
@@ -1,6 +1,6 @@
 /* certify.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/attestation/make_credential.c
+++ b/examples/attestation/make_credential.c
@@ -1,6 +1,6 @@
 /* make_credential.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/bench/bench.c
+++ b/examples/bench/bench.c
@@ -1,6 +1,6 @@
 /* bench.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/bench/bench.h
+++ b/examples/bench/bench.h
@@ -1,6 +1,6 @@
 /* bench.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/boot/boot.h
+++ b/examples/boot/boot.h
@@ -1,6 +1,6 @@
 /* boot.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/boot/secret_seal.c
+++ b/examples/boot/secret_seal.c
@@ -1,6 +1,6 @@
 /* secret_seal.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/boot/secret_unseal.c
+++ b/examples/boot/secret_unseal.c
@@ -1,6 +1,6 @@
 /* secret_unseal.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/boot/secure_rot.c
+++ b/examples/boot/secure_rot.c
@@ -1,6 +1,6 @@
 /* secure_rot.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/csr/csr.c
+++ b/examples/csr/csr.c
@@ -1,6 +1,6 @@
 /* csr.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/csr/csr.h
+++ b/examples/csr/csr.h
@@ -1,6 +1,6 @@
 /* csr.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/endorsement/endorsement.h
+++ b/examples/endorsement/endorsement.h
@@ -1,6 +1,6 @@
 /* endorsement.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/endorsement/get_ek_certs.c
+++ b/examples/endorsement/get_ek_certs.c
@@ -1,6 +1,6 @@
 /* get_ek_certs.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/endorsement/get_ek_certs.c
+++ b/examples/endorsement/get_ek_certs.c
@@ -287,7 +287,6 @@ int TPM2_EndorsementCert_Example(void* userCtx, int argc, char *argv[])
                     else if (offset == 0xC) indexType = "EK Low Range (ECC P256 Template)";
                 }
                 else if (offset >= 0x12 && offset < 0x100) {
-                    indexType = "EK High Range";
                     if (offset == 0x12) indexType = "EK High Range (RSA 2048 Cert)";
                     else if (offset == 0x14) indexType = "EK High Range (ECC P256 Cert)";
                     else if (offset == 0x16) indexType = "EK High Range (ECC P384 Cert)";

--- a/examples/endorsement/verify_ek_cert.c
+++ b/examples/endorsement/verify_ek_cert.c
@@ -86,10 +86,12 @@ static void show_tpm_public(const char* desc, const TPM2B_PUBLIC* pub)
                        pub->publicArea.unique.rsa.size);
     }
     else if (pub->publicArea.type == TPM_ALG_ECC) {
-        const char* curveName = "NULL";
+        const char* curveName;
     #if !defined(WOLFTPM2_NO_WOLFCRYPT) && defined(HAVE_ECC)
         curveName = wc_ecc_get_name(
             TPM2_GetWolfCurve(pub->publicArea.parameters.eccDetail.curveID));
+    #else
+        curveName = "NULL";
     #endif
         printf("\tCurveID %s (0x%x), size %d, unique X/Y size %d/%d\n",
             curveName, pub->publicArea.parameters.eccDetail.curveID,

--- a/examples/endorsement/verify_ek_cert.c
+++ b/examples/endorsement/verify_ek_cert.c
@@ -1,6 +1,6 @@
 /* verify_ek_cert.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/firmware/ifx_fw_extract.c
+++ b/examples/firmware/ifx_fw_extract.c
@@ -1,6 +1,6 @@
 /* ifx_fw_extract.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/firmware/ifx_fw_update.c
+++ b/examples/firmware/ifx_fw_update.c
@@ -1,6 +1,6 @@
 /* ifx_fw_update.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/firmware/ifx_fw_update.h
+++ b/examples/firmware/ifx_fw_update.h
@@ -1,6 +1,6 @@
 /* ifx_firmware_update.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/firmware/st33_fw_update.c
+++ b/examples/firmware/st33_fw_update.c
@@ -1,6 +1,6 @@
 /* st33_fw_update.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/gpio/gpio.h
+++ b/examples/gpio/gpio.h
@@ -1,6 +1,6 @@
 /* gpio.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/gpio/gpio_config.c
+++ b/examples/gpio/gpio_config.c
@@ -1,6 +1,6 @@
 /* gpio_config.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/gpio/gpio_read.c
+++ b/examples/gpio/gpio_read.c
@@ -1,6 +1,6 @@
 /* read.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/gpio/gpio_set.c
+++ b/examples/gpio/gpio_set.c
@@ -1,6 +1,6 @@
 /* set.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/keygen/create_primary.c
+++ b/examples/keygen/create_primary.c
@@ -1,6 +1,6 @@
 /* create_primary.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/keygen/external_import.c
+++ b/examples/keygen/external_import.c
@@ -1,6 +1,6 @@
 /* external_import.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/keygen/keygen.c
+++ b/examples/keygen/keygen.c
@@ -1,6 +1,6 @@
 /* keygen.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/keygen/keygen.h
+++ b/examples/keygen/keygen.h
@@ -1,6 +1,6 @@
 /* keygen.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/keygen/keyimport.c
+++ b/examples/keygen/keyimport.c
@@ -1,6 +1,6 @@
 /* keyimport.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/keygen/keyload.c
+++ b/examples/keygen/keyload.c
@@ -1,6 +1,6 @@
 /* keyload.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/management/flush.c
+++ b/examples/management/flush.c
@@ -1,6 +1,6 @@
 /* flush.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/management/management.h
+++ b/examples/management/management.h
@@ -1,6 +1,6 @@
 /* management.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/management/tpmclear.c
+++ b/examples/management/tpmclear.c
@@ -1,6 +1,6 @@
 /* tpmclear.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/native/native_test.c
+++ b/examples/native/native_test.c
@@ -1,6 +1,6 @@
 /* native_test.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/native/native_test.c
+++ b/examples/native/native_test.c
@@ -1196,7 +1196,6 @@ int TPM2_Native_TestArgs(void* userCtx, int argc, char *argv[])
         }
         else if (WOLFTPM_IS_COMMAND_UNAVAILABLE(rc)) {
             printf("TPM2_ZGen_2Phase: not supported by TPM\n");
-            rc = TPM_RC_SUCCESS;
         }
         else {
             printf("TPM2_ZGen_2Phase failed 0x%x: %s\n", rc,
@@ -1207,7 +1206,6 @@ int TPM2_Native_TestArgs(void* userCtx, int argc, char *argv[])
     else if (WOLFTPM_IS_COMMAND_UNAVAILABLE(rc) ||
              (rc & RC_MAX_FMT1) == TPM_RC_CURVE) {
         printf("TPM2_EC_Ephemeral: not supported by TPM\n");
-        rc = TPM_RC_SUCCESS;
     }
     else {
         printf("TPM2_EC_Ephemeral failed 0x%x: %s\n", rc,

--- a/examples/native/native_test.h
+++ b/examples/native/native_test.h
@@ -1,6 +1,6 @@
 /* native_test.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/nvram/counter.c
+++ b/examples/nvram/counter.c
@@ -1,6 +1,6 @@
 /* counter.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/nvram/extend.c
+++ b/examples/nvram/extend.c
@@ -1,6 +1,6 @@
 /* extend.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/nvram/nvram.h
+++ b/examples/nvram/nvram.h
@@ -1,6 +1,6 @@
 /* nvram.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/nvram/policy_nv.c
+++ b/examples/nvram/policy_nv.c
@@ -1,6 +1,6 @@
 /* policy_nv.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/nvram/read.c
+++ b/examples/nvram/read.c
@@ -1,6 +1,6 @@
 /* read.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/nvram/seal_nv.c
+++ b/examples/nvram/seal_nv.c
@@ -1,6 +1,6 @@
 /* seal_nv.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/nvram/store.c
+++ b/examples/nvram/store.c
@@ -1,6 +1,6 @@
 /* store.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/pcr/extend.c
+++ b/examples/pcr/extend.c
@@ -1,6 +1,6 @@
 /* extend.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/pcr/pcr.h
+++ b/examples/pcr/pcr.h
@@ -1,6 +1,6 @@
 /* pcr.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/pcr/policy.c
+++ b/examples/pcr/policy.c
@@ -1,6 +1,6 @@
 /* policy.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/pcr/policy_sign.c
+++ b/examples/pcr/policy_sign.c
@@ -1,6 +1,6 @@
 /* policy_sign.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/pcr/quote.c
+++ b/examples/pcr/quote.c
@@ -1,6 +1,6 @@
 /* quote.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/pcr/quote.h
+++ b/examples/pcr/quote.h
@@ -1,6 +1,6 @@
 /* quote.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/pcr/read_pcr.c
+++ b/examples/pcr/read_pcr.c
@@ -1,6 +1,6 @@
 /* read.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/pcr/reset.c
+++ b/examples/pcr/reset.c
@@ -1,6 +1,6 @@
 /* reset.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/pkcs7/pkcs7.c
+++ b/examples/pkcs7/pkcs7.c
@@ -1,6 +1,6 @@
 /* pkcs7.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/pkcs7/pkcs7.h
+++ b/examples/pkcs7/pkcs7.h
@@ -1,6 +1,6 @@
 /* pkcs7.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/seal/seal.c
+++ b/examples/seal/seal.c
@@ -1,6 +1,6 @@
 /* seal.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/seal/seal.h
+++ b/examples/seal/seal.h
@@ -1,6 +1,6 @@
 /* seal.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/seal/seal_pcr.c
+++ b/examples/seal/seal_pcr.c
@@ -1,6 +1,6 @@
 /* seal_pcr.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/seal/seal_policy_auth.c
+++ b/examples/seal/seal_policy_auth.c
@@ -1,6 +1,6 @@
 /* seal_policy_auth.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/seal/unseal.c
+++ b/examples/seal/unseal.c
@@ -1,6 +1,6 @@
 /* unseal.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/spdm/spdm_ctrl.c
+++ b/examples/spdm/spdm_ctrl.c
@@ -1,6 +1,6 @@
 /* spdm_ctrl.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/spdm/spdm_test.sh
+++ b/examples/spdm/spdm_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # spdm_test.sh - SPDM hardware tests (Nuvoton / Nations Technology)
 #
-# Copyright (C) 2006-2025 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
 # This file is part of wolfTPM.
 #

--- a/examples/timestamp/clock_set.c
+++ b/examples/timestamp/clock_set.c
@@ -1,6 +1,6 @@
 /* clock_set.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/timestamp/clock_set.h
+++ b/examples/timestamp/clock_set.h
@@ -1,6 +1,6 @@
 /* clock_set.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/timestamp/signed_timestamp.c
+++ b/examples/timestamp/signed_timestamp.c
@@ -1,6 +1,6 @@
 /* signed_timestamp.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/timestamp/signed_timestamp.h
+++ b/examples/timestamp/signed_timestamp.h
@@ -1,6 +1,6 @@
 /* signed_timestamp.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/tls/tls_client.c
+++ b/examples/tls/tls_client.c
@@ -1,6 +1,6 @@
 /* tls_client.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/tls/tls_client.h
+++ b/examples/tls/tls_client.h
@@ -1,6 +1,6 @@
 /* tls_client.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/tls/tls_client_notpm.c
+++ b/examples/tls/tls_client_notpm.c
@@ -1,6 +1,6 @@
 /* tls_client_notpm.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/tls/tls_common.h
+++ b/examples/tls/tls_common.h
@@ -1,6 +1,6 @@
 /* tls_common.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/tls/tls_server.c
+++ b/examples/tls/tls_server.c
@@ -1,6 +1,6 @@
 /* tls_server.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/tls/tls_server.h
+++ b/examples/tls/tls_server.h
@@ -1,6 +1,6 @@
 /* tls_server.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/tpm_test.h
+++ b/examples/tpm_test.h
@@ -1,6 +1,6 @@
 /* tpm_test.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/tpm_test_keys.c
+++ b/examples/tpm_test_keys.c
@@ -1,6 +1,6 @@
 /* tpm_test_keys.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/tpm_test_keys.h
+++ b/examples/tpm_test_keys.h
@@ -1,6 +1,6 @@
 /* tpm_test_keys.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/wrap/caps.c
+++ b/examples/wrap/caps.c
@@ -1,6 +1,6 @@
 /* caps.
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/wrap/hmac.c
+++ b/examples/wrap/hmac.c
@@ -1,6 +1,6 @@
 /* hmac.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -1,6 +1,6 @@
 /* wrap_test.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/examples/wrap/wrap_test.h
+++ b/examples/wrap/wrap_test.h
@@ -1,6 +1,6 @@
 /* wrap_test.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/hal/tpm_io.c
+++ b/hal/tpm_io.c
@@ -1,6 +1,6 @@
 /* tpm_io.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/hal/tpm_io.h
+++ b/hal/tpm_io.h
@@ -1,6 +1,6 @@
 /* tpm_io.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/hal/tpm_io_atmel.c
+++ b/hal/tpm_io_atmel.c
@@ -1,6 +1,6 @@
 /* tpm_io_atmel.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/hal/tpm_io_barebox.c
+++ b/hal/tpm_io_barebox.c
@@ -1,6 +1,6 @@
 /* tpm_io_barebox.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/hal/tpm_io_espressif.c
+++ b/hal/tpm_io_espressif.c
@@ -1,6 +1,6 @@
 /* tpm_io_espressif.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/hal/tpm_io_fwtpm.c
+++ b/hal/tpm_io_fwtpm.c
@@ -1,6 +1,6 @@
 /* tpm_io_fwtpm.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/hal/tpm_io_infineon.c
+++ b/hal/tpm_io_infineon.c
@@ -1,6 +1,6 @@
 /* tpm_io_infineon.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/hal/tpm_io_linux.c
+++ b/hal/tpm_io_linux.c
@@ -1,6 +1,6 @@
 /* tpm_io_linux.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/hal/tpm_io_microchip.c
+++ b/hal/tpm_io_microchip.c
@@ -1,6 +1,6 @@
 /* tpm_io_microchip.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/hal/tpm_io_mmio.c
+++ b/hal/tpm_io_mmio.c
@@ -1,6 +1,6 @@
 /* tpm_io_mmio.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/hal/tpm_io_qnx.c
+++ b/hal/tpm_io_qnx.c
@@ -1,6 +1,6 @@
 /* tpm_io_qnx.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/hal/tpm_io_st.c
+++ b/hal/tpm_io_st.c
@@ -1,6 +1,6 @@
 /* tpm_io_st.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/hal/tpm_io_uboot.c
+++ b/hal/tpm_io_uboot.c
@@ -1,6 +1,6 @@
 /* tpm_io_uboot.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/hal/tpm_io_xilinx.c
+++ b/hal/tpm_io_xilinx.c
@@ -1,6 +1,6 @@
 /* tpm_io_xilinx.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/hal/tpm_io_zephyr.c
+++ b/hal/tpm_io_zephyr.c
@@ -1,6 +1,6 @@
 /* tpm_io_zephyr.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/fwtpm/fwtpm.c
+++ b/src/fwtpm/fwtpm.c
@@ -1,6 +1,6 @@
 /* fwtpm.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/fwtpm/fwtpm_command.c
+++ b/src/fwtpm/fwtpm_command.c
@@ -1830,7 +1830,8 @@ static TPM_RC FwCmd_PCR_SetAuthPolicy(FWTPM_CTX* ctx, TPM2_Packet* cmd,
         if (policySz > 0) {
             XMEMCPY(ctx->pcrPolicy[pcrIndex].buffer, policyBuf, policySz);
         }
-        ctx->pcrPolicyAlg[pcrIndex] = (policySz > 0) ? hashAlg : TPM_ALG_NULL;
+        ctx->pcrPolicyAlg[pcrIndex] = (policySz > 0) ?
+                                      hashAlg : (TPMI_ALG_HASH)TPM_ALG_NULL;
         FWTPM_NV_SavePcrAuth(ctx);
         FwRspNoParams(rsp, cmdTag);
     }
@@ -5488,7 +5489,7 @@ static TPM_RC FwCmd_CreateLoaded(FWTPM_CTX* ctx, TPM2_Packet* cmd,
             }
 #endif /* HAVE_ECC */
             case TPM_ALG_KEYEDHASH: {
-                TPMI_ALG_HASH hashAlg = inPublic->publicArea.nameAlg;
+                TPMI_ALG_HASH hashAlg;
                 TPMI_ALG_KEYEDHASH_SCHEME scheme =
                     inPublic->publicArea.parameters.keyedHashDetail
                         .scheme.scheme;
@@ -5994,13 +5995,13 @@ static TPM_RC FwCmd_RSA_Encrypt(FWTPM_CTX* ctx, TPM2_Packet* cmd,
 
     if (rc == 0) {
         if (encScheme == TPM_ALG_OAEP) {
-            int wcHashType = FwGetRsaHashOid(
-                (encHashAlg != TPM_ALG_NULL) ? encHashAlg : TPM_ALG_SHA256);
+            TPMI_ALG_HASH oaepHash = (encHashAlg != TPM_ALG_NULL) ?
+                encHashAlg : (TPMI_ALG_HASH)TPM_ALG_SHA256;
+            int wcHashType = FwGetRsaHashOid(oaepHash);
             outSz = wc_RsaPublicEncrypt_ex(message->buffer, message->size,
                 outBuf, (word32)FWTPM_MAX_PUB_BUF, rsaKey, &ctx->rng,
-                WC_RSA_OAEP_PAD, wcHashType,
-                FwGetMgfType((encHashAlg != TPM_ALG_NULL) ?
-                    encHashAlg : TPM_ALG_SHA256),
+                WC_RSA_OAEP_PAD, (enum wc_HashType)wcHashType,
+                FwGetMgfType(oaepHash),
                 NULL, 0);
         }
         else if (encScheme == TPM_ALG_NULL) {
@@ -6147,13 +6148,13 @@ static TPM_RC FwCmd_RSA_Decrypt(FWTPM_CTX* ctx, TPM2_Packet* cmd,
 
     if (rc == 0) {
         if (decScheme == TPM_ALG_OAEP) {
-            int wcHashType = FwGetRsaHashOid(
-                (decHashAlg != TPM_ALG_NULL) ? decHashAlg : TPM_ALG_SHA256);
+            TPMI_ALG_HASH oaepHash = (decHashAlg != TPM_ALG_NULL) ?
+                decHashAlg : (TPMI_ALG_HASH)TPM_ALG_SHA256;
+            int wcHashType = FwGetRsaHashOid(oaepHash);
             outSz = wc_RsaPrivateDecrypt_ex(cipherText->buffer, cipherText->size,
                 outBuf, (word32)FWTPM_MAX_PUB_BUF, rsaKey,
-                WC_RSA_OAEP_PAD, wcHashType,
-                FwGetMgfType((decHashAlg != TPM_ALG_NULL) ?
-                    decHashAlg : TPM_ALG_SHA256),
+                WC_RSA_OAEP_PAD, (enum wc_HashType)wcHashType,
+                FwGetMgfType(oaepHash),
                 NULL, 0);
         }
         else if (decScheme == TPM_ALG_NULL) {

--- a/src/fwtpm/fwtpm_command.c
+++ b/src/fwtpm/fwtpm_command.c
@@ -1,6 +1,6 @@
 /* fwtpm_command.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/fwtpm/fwtpm_crypto.c
+++ b/src/fwtpm/fwtpm_crypto.c
@@ -2397,7 +2397,7 @@ TPM_RC FwSignDigestAndAppend(FWTPM_CTX* ctx, FWTPM_Object* obj,
                 if (pad == WC_RSA_PSS_PAD) {
                     int mgf = FwGetMgfType(sigHashAlg);
                     wcRc = wc_RsaPSS_Sign_ex(digest, digestSz,
-                        sigBuf, sigSz, wcHashType, mgf,
+                        sigBuf, sigSz, (enum wc_HashType)wcHashType, mgf,
                         RSA_PSS_SALT_LEN_DEFAULT, rsaKey, &ctx->rng);
                 }
                 else {
@@ -2532,7 +2532,7 @@ TPM_RC FwVerifySignatureCore(FWTPM_Object* obj,
                         sig->signature.rsapss.sig.size,
                         decSig, (word32)FWTPM_MAX_PUB_BUF,
                         digest, digestSz,
-                        wcHashType, mgf,
+                        (enum wc_HashType)wcHashType, mgf,
                         rsaKey);
                     FWTPM_FREE_BUF(decSig);
                 }

--- a/src/fwtpm/fwtpm_crypto.c
+++ b/src/fwtpm/fwtpm_crypto.c
@@ -1,6 +1,6 @@
 /* fwtpm_crypto.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/fwtpm/fwtpm_crypto.c
+++ b/src/fwtpm/fwtpm_crypto.c
@@ -2257,13 +2257,18 @@ int FwEccSharedPoint(ecc_key* priv, ecc_key* peer,
     if (rc == 0)
         rc = wc_ecc_mulmod(ecc_get_k(priv), &peer->pubkey, R, &a, &prime, 1);
 
+    /* Export x and y with fixed-size left-zero padding to the curve byte
+     * length. Using mp_unsigned_bin_size/mp_to_unsigned_bin here would drop
+     * leading zero bytes (~1/256 per coordinate for a random point), which
+     * both breaks ZGen_2Phase callers that expect curve-length outputs and
+     * leaks the leading-zero count of the shared point. */
     if (rc == 0) {
-        *xSz = (word32)mp_unsigned_bin_size(R->x);
-        rc = mp_to_unsigned_bin(R->x, xBuf);
+        *xSz = (word32)dp->size;
+        rc = mp_to_unsigned_bin_len(R->x, xBuf, dp->size);
     }
     if (rc == 0) {
-        *ySz = (word32)mp_unsigned_bin_size(R->y);
-        rc = mp_to_unsigned_bin(R->y, yBuf);
+        *ySz = (word32)dp->size;
+        rc = mp_to_unsigned_bin_len(R->y, yBuf, dp->size);
     }
 
     if (aInit)

--- a/src/fwtpm/fwtpm_io.c
+++ b/src/fwtpm/fwtpm_io.c
@@ -1,6 +1,6 @@
 /* fwtpm_io.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/fwtpm/fwtpm_main.c
+++ b/src/fwtpm/fwtpm_main.c
@@ -1,6 +1,6 @@
 /* fwtpm_main.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/fwtpm/fwtpm_nv.c
+++ b/src/fwtpm/fwtpm_nv.c
@@ -1,6 +1,6 @@
 /* fwtpm_nv.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/fwtpm/fwtpm_tis.c
+++ b/src/fwtpm/fwtpm_tis.c
@@ -1,6 +1,6 @@
 /* fwtpm_tis.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/fwtpm/fwtpm_tis_shm.c
+++ b/src/fwtpm/fwtpm_tis_shm.c
@@ -1,6 +1,6 @@
 /* fwtpm_tis_shm.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/spdm/README.md
+++ b/src/spdm/README.md
@@ -471,4 +471,4 @@ standalone library.
 
 ## License
 
-GPLv3 — see LICENSE file. Copyright (C) 2006-2025 wolfSSL Inc.
+GPLv3 — see LICENSE file. Copyright (C) 2006-2026 wolfSSL Inc.

--- a/src/spdm/spdm_context.c
+++ b/src/spdm/spdm_context.c
@@ -1,6 +1,6 @@
 /* spdm_context.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/src/spdm/spdm_crypto.c
+++ b/src/spdm/spdm_crypto.c
@@ -1,6 +1,6 @@
 /* spdm_crypto.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/src/spdm/spdm_internal.h
+++ b/src/spdm/spdm_internal.h
@@ -1,6 +1,6 @@
 /* spdm_internal.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/src/spdm/spdm_kdf.c
+++ b/src/spdm/spdm_kdf.c
@@ -1,6 +1,6 @@
 /* spdm_kdf.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/src/spdm/spdm_msg.c
+++ b/src/spdm/spdm_msg.c
@@ -1,6 +1,6 @@
 /* spdm_msg.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/src/spdm/spdm_nations.c
+++ b/src/spdm/spdm_nations.c
@@ -1,6 +1,6 @@
 /* spdm_nations.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/src/spdm/spdm_nuvoton.c
+++ b/src/spdm/spdm_nuvoton.c
@@ -1,6 +1,6 @@
 /* spdm_nuvoton.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/src/spdm/spdm_psk.c
+++ b/src/spdm/spdm_psk.c
@@ -1,6 +1,6 @@
 /* spdm_psk.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/src/spdm/spdm_secured.c
+++ b/src/spdm/spdm_secured.c
@@ -1,6 +1,6 @@
 /* spdm_secured.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/src/spdm/spdm_session.c
+++ b/src/spdm/spdm_session.c
@@ -1,6 +1,6 @@
 /* spdm_session.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/src/spdm/spdm_tcg.c
+++ b/src/spdm/spdm_tcg.c
@@ -1,6 +1,6 @@
 /* spdm_tcg.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/src/spdm/spdm_transcript.c
+++ b/src/spdm/spdm_transcript.c
@@ -1,6 +1,6 @@
 /* spdm_transcript.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/src/spdm/unit_test.c
+++ b/src/spdm/unit_test.c
@@ -1,6 +1,6 @@
 /* unit_test.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -1,6 +1,6 @@
 /* tpm2.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/tpm2_asn.c
+++ b/src/tpm2_asn.c
@@ -1,6 +1,6 @@
 /* tpm2_asn.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/tpm2_crypto.c
+++ b/src/tpm2_crypto.c
@@ -1,6 +1,6 @@
 /* tpm2_crypto.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/tpm2_cryptocb.c
+++ b/src/tpm2_cryptocb.c
@@ -1,6 +1,6 @@
 /* tpm2_cryptocb.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/tpm2_linux.c
+++ b/src/tpm2_linux.c
@@ -1,6 +1,6 @@
 /* tpm2_linux.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -1,6 +1,6 @@
 /* tpm2_packet.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/tpm2_param_enc.c
+++ b/src/tpm2_param_enc.c
@@ -1,6 +1,6 @@
 /* tpm2_param_enc.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/tpm2_spdm.c
+++ b/src/tpm2_spdm.c
@@ -1,6 +1,6 @@
 /* tpm2_spdm.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/tpm2_swtpm.c
+++ b/src/tpm2_swtpm.c
@@ -1,6 +1,6 @@
 /* tpm2_swtpm.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/tpm2_tis.c
+++ b/src/tpm2_tis.c
@@ -1,6 +1,6 @@
 /* tpm2_tis.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/tpm2_util.c
+++ b/src/tpm2_util.c
@@ -1,6 +1,6 @@
 /* tpm2_util.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/tpm2_winapi.c
+++ b/src/tpm2_winapi.c
@@ -1,6 +1,6 @@
 /* tpm2_winapi.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -190,7 +190,6 @@ static int wolfTPM2_Init_ex(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx,
         printf("TPM2_Startup pass\n");
     }
 #endif
-    rc = TPM_RC_SUCCESS;
 
 #if defined(WOLFTPM_MICROCHIP) || defined(WOLFTPM_PERFORM_SELFTEST)
     /* Do full self-test (Chips such as ATTPM20 require this before some operations) */
@@ -222,6 +221,8 @@ static int wolfTPM2_Init_ex(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx,
         printf("TPM2_SelfTest pass\n");
     }
 #endif
+#else
+    rc = TPM_RC_SUCCESS;
 #endif /* WOLFTPM_MICROCHIP || WOLFTPM_PERFORM_SELFTEST */
 #endif /* !WOLFTPM_LINUX_DEV && !WOLFTPM_WINAPI */
 

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -1,6 +1,6 @@
 /* tpm2_wrap.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/tests/fuzz/fwtpm_fuzz.c
+++ b/tests/fuzz/fwtpm_fuzz.c
@@ -1,6 +1,6 @@
 /* fwtpm_fuzz.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/tests/fwtpm_unit_tests.c
+++ b/tests/fwtpm_unit_tests.c
@@ -1,6 +1,6 @@
 /* fwtpm_unit_tests.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/tests/fwtpm_unit_tests.c
+++ b/tests/fwtpm_unit_tests.c
@@ -922,7 +922,9 @@ static void test_fwtpm_create_primary_rsa(void)
     PutU32BE(gCmd + cmdSz, handle);
     cmdSz += 4;
     rspSize = 0;
-    FWTPM_ProcessCommand(&ctx, gCmd, cmdSz, gRsp, &rspSize, 0);
+    rc = FWTPM_ProcessCommand(&ctx, gCmd, cmdSz, gRsp, &rspSize, 0);
+    AssertIntEQ(rc, TPM_RC_SUCCESS);
+    AssertIntEQ(GetRspRC(gRsp), TPM_RC_SUCCESS);
 
     FWTPM_Cleanup(&ctx);
     printf("Test fwTPM:\tCreatePrimary(RSA-2048):\t\tPassed\n");
@@ -955,7 +957,9 @@ static void test_fwtpm_create_primary_ecc(void)
     PutU32BE(gCmd + cmdSz, handle);
     cmdSz += 4;
     rspSize = 0;
-    FWTPM_ProcessCommand(&ctx, gCmd, cmdSz, gRsp, &rspSize, 0);
+    rc = FWTPM_ProcessCommand(&ctx, gCmd, cmdSz, gRsp, &rspSize, 0);
+    AssertIntEQ(rc, TPM_RC_SUCCESS);
+    AssertIntEQ(GetRspRC(gRsp), TPM_RC_SUCCESS);
 
     FWTPM_Cleanup(&ctx);
     printf("Test fwTPM:\tCreatePrimary(ECC-P256):\t\tPassed\n");

--- a/tests/fwtpm_unit_tests.c
+++ b/tests/fwtpm_unit_tests.c
@@ -919,9 +919,10 @@ static void test_fwtpm_create_primary_rsa(void)
 
     /* Flush the key */
     cmdSz = BuildCmdHeader(gCmd, TPM_ST_NO_SESSIONS, 14, TPM_CC_FlushContext);
-    PutU32BE(gCmd + 10, handle);
+    PutU32BE(gCmd + cmdSz, handle);
+    cmdSz += 4;
     rspSize = 0;
-    FWTPM_ProcessCommand(&ctx, gCmd, 14, gRsp, &rspSize, 0);
+    FWTPM_ProcessCommand(&ctx, gCmd, cmdSz, gRsp, &rspSize, 0);
 
     FWTPM_Cleanup(&ctx);
     printf("Test fwTPM:\tCreatePrimary(RSA-2048):\t\tPassed\n");
@@ -951,9 +952,10 @@ static void test_fwtpm_create_primary_ecc(void)
 
     /* Flush */
     cmdSz = BuildCmdHeader(gCmd, TPM_ST_NO_SESSIONS, 14, TPM_CC_FlushContext);
-    PutU32BE(gCmd + 10, handle);
+    PutU32BE(gCmd + cmdSz, handle);
+    cmdSz += 4;
     rspSize = 0;
-    FWTPM_ProcessCommand(&ctx, gCmd, 14, gRsp, &rspSize, 0);
+    FWTPM_ProcessCommand(&ctx, gCmd, cmdSz, gRsp, &rspSize, 0);
 
     FWTPM_Cleanup(&ctx);
     printf("Test fwTPM:\tCreatePrimary(ECC-P256):\t\tPassed\n");

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -1,6 +1,6 @@
 /* unit_tests.c
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/fwtpm/fwtpm.h
+++ b/wolftpm/fwtpm/fwtpm.h
@@ -437,6 +437,23 @@ typedef struct FWTPM_IO_CTX {
 } FWTPM_IO_CTX;
 #endif /* !WOLFTPM_FWTPM_TIS */
 
+/* NV HAL callbacks - defined at file scope (not nested in FWTPM_CTX) so it
+ * is portable across C and C++. FWTPM_NV_HAL is the typedef alias (see
+ * fwtpm_nv.h). */
+struct FWTPM_NV_HAL_S {
+    int (*read)(void* ctx, word32 offset, byte* buf, word32 size);
+    int (*write)(void* ctx, word32 offset, const byte* buf, word32 size);
+    int (*erase)(void* ctx, word32 offset, word32 size); /* Optional */
+    void* ctx;
+    word32 maxSize;     /* Total NV region size */
+};
+
+/* Clock HAL callbacks (optional - if not set, clockOffset used directly) */
+struct FWTPM_CLOCK_HAL_S {
+    UINT64 (*get_ms)(void* ctx);  /* Return milliseconds since boot */
+    void* ctx;
+};
+
 /* fwTPM context - holds all TPM state */
 typedef struct FWTPM_CTX {
     volatile int running;       /* Server running flag (volatile for signal handler) */
@@ -534,19 +551,10 @@ typedef struct FWTPM_CTX {
 #endif
 
     /* NV HAL callbacks */
-    struct FWTPM_NV_HAL_S {
-        int (*read)(void* ctx, word32 offset, byte* buf, word32 size);
-        int (*write)(void* ctx, word32 offset, const byte* buf, word32 size);
-        int (*erase)(void* ctx, word32 offset, word32 size); /* Optional */
-        void* ctx;
-        word32 maxSize;     /* Total NV region size */
-    } nvHal;
+    struct FWTPM_NV_HAL_S nvHal;
 
     /* Clock HAL callbacks (optional - if not set, clockOffset used directly) */
-    struct FWTPM_CLOCK_HAL_S {
-        UINT64 (*get_ms)(void* ctx);  /* Return milliseconds since boot */
-        void* ctx;
-    } clockHal;
+    struct FWTPM_CLOCK_HAL_S clockHal;
 
     /* NV journal write position (next append offset) */
     word32 nvWritePos;

--- a/wolftpm/fwtpm/fwtpm.h
+++ b/wolftpm/fwtpm/fwtpm.h
@@ -1,6 +1,6 @@
 /* fwtpm.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/fwtpm/fwtpm_command.h
+++ b/wolftpm/fwtpm/fwtpm_command.h
@@ -1,6 +1,6 @@
 /* fwtpm_command.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/fwtpm/fwtpm_crypto.h
+++ b/wolftpm/fwtpm/fwtpm_crypto.h
@@ -1,6 +1,6 @@
 /* fwtpm_crypto.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/fwtpm/fwtpm_io.h
+++ b/wolftpm/fwtpm/fwtpm_io.h
@@ -1,6 +1,6 @@
 /* fwtpm_io.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/fwtpm/fwtpm_nv.h
+++ b/wolftpm/fwtpm/fwtpm_nv.h
@@ -1,6 +1,6 @@
 /* fwtpm_nv.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/fwtpm/fwtpm_tis.h
+++ b/wolftpm/fwtpm/fwtpm_tis.h
@@ -1,6 +1,6 @@
 /* fwtpm_tis.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/options.h.in
+++ b/wolftpm/options.h.in
@@ -1,6 +1,6 @@
 /* options.h.in
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/spdm/spdm.h
+++ b/wolftpm/spdm/spdm.h
@@ -1,6 +1,6 @@
 /* spdm.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/wolftpm/spdm/spdm_nations.h
+++ b/wolftpm/spdm/spdm_nations.h
@@ -1,6 +1,6 @@
 /* spdm_nations.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/wolftpm/spdm/spdm_nuvoton.h
+++ b/wolftpm/spdm/spdm_nuvoton.h
@@ -1,6 +1,6 @@
 /* spdm_nuvoton.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/wolftpm/spdm/spdm_psk.h
+++ b/wolftpm/spdm/spdm_psk.h
@@ -1,6 +1,6 @@
 /* spdm_psk.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/wolftpm/spdm/spdm_tcg.h
+++ b/wolftpm/spdm/spdm_tcg.h
@@ -1,6 +1,6 @@
 /* spdm_tcg.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/wolftpm/spdm/spdm_types.h
+++ b/wolftpm/spdm/spdm_types.h
@@ -1,6 +1,6 @@
 /* spdm_types.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfSPDM.
  *

--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -1,6 +1,6 @@
 /* tpm2.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/tpm2_asn.h
+++ b/wolftpm/tpm2_asn.h
@@ -1,6 +1,6 @@
 /* tpm2_asn.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/tpm2_crypto.h
+++ b/wolftpm/tpm2_crypto.h
@@ -1,6 +1,6 @@
 /* tpm2_crypto.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/tpm2_linux.h
+++ b/wolftpm/tpm2_linux.h
@@ -1,6 +1,6 @@
 /* tpm2_linux.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/tpm2_packet.h
+++ b/wolftpm/tpm2_packet.h
@@ -1,6 +1,6 @@
 /* tpm2_packet.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/tpm2_param_enc.h
+++ b/wolftpm/tpm2_param_enc.h
@@ -1,6 +1,6 @@
 /* tpm2_param_enc.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/tpm2_socket.h
+++ b/wolftpm/tpm2_socket.h
@@ -1,6 +1,6 @@
 /* tpm2_socket.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/tpm2_spdm.h
+++ b/wolftpm/tpm2_spdm.h
@@ -1,6 +1,6 @@
 /* tpm2_spdm.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/tpm2_swtpm.h
+++ b/wolftpm/tpm2_swtpm.h
@@ -1,6 +1,6 @@
 /* tpm2_swtpm.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/tpm2_tis.h
+++ b/wolftpm/tpm2_tis.h
@@ -1,6 +1,6 @@
 /* tpm2_tis.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/tpm2_types.h
+++ b/wolftpm/tpm2_types.h
@@ -1,6 +1,6 @@
 /* tpm2_types.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/tpm2_winapi.h
+++ b/wolftpm/tpm2_winapi.h
@@ -1,6 +1,6 @@
 /* tpm2_winapi.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -1,6 +1,6 @@
 /* tpm2_wrap.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/version.h
+++ b/wolftpm/version.h
@@ -1,6 +1,6 @@
 /* version.h.in
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *
@@ -34,8 +34,8 @@
 extern "C" {
 #endif
 
-#define LIBWOLFTPM_VERSION_STRING "3.10.0"
-#define LIBWOLFTPM_VERSION_HEX 0x03010000
+#define LIBWOLFTPM_VERSION_STRING "4.0.0"
+#define LIBWOLFTPM_VERSION_HEX 0x04000000
 
 #ifdef __cplusplus
 }

--- a/wolftpm/version.h.in
+++ b/wolftpm/version.h.in
@@ -1,6 +1,6 @@
 /* version.h.in
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wolftpm/visibility.h
+++ b/wolftpm/visibility.h
@@ -1,6 +1,6 @@
 /* visibility.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wrapper/CSharp/wolfTPM-tests.cs
+++ b/wrapper/CSharp/wolfTPM-tests.cs
@@ -1,6 +1,6 @@
 /* wolfTPM-tests.cs
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/wrapper/CSharp/wolfTPM.cs
+++ b/wrapper/CSharp/wolfTPM.cs
@@ -1,6 +1,6 @@
 /* wolfTPM.cs
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *

--- a/zephyr/user_settings.h
+++ b/zephyr/user_settings.h
@@ -1,6 +1,6 @@
 /* user_settings.h
  *
- * Copyright (C) 2006-2025 wolfSSL Inc.
+ * Copyright (C) 2006-2026 wolfSSL Inc.
  *
  * This file is part of wolfTPM.
  *


### PR DESCRIPTION
### Summary

Prep branch for the v4.0.0 release. Bumps the version everywhere,
updates `ChangeLog.md` with the themed release notes, adds release-gate
CI coverage, and fixes a small set of issues uncovered while running the
full release build matrix against the new fwTPM and SPDM subsystems.

Libtool soname: `WOLFTPM_LIBRARY_VERSION=17:0:0` (interfaces removed or
changed since v3.10.0).

### Version bumps

- `configure.ac` `AC_INIT` 3.10.0 -> 4.0.0
- `WOLFTPM_LIBRARY_VERSION` 16:x:x -> 17:0:0
- `CMakeLists.txt` `project(wolfTPM VERSION 4.0.0 ...)`
- `wolftpm/version.h` `LIBWOLFTPM_VERSION_STRING "4.0.0"`,
  `LIBWOLFTPM_VERSION_HEX 0x04000000`
- Copyright year bumps across headers/examples/IDE projects

### ChangeLog.md

New v4.0.0 entry (Apr 22, 2026) highlighting the three v4 major
features: fwTPM, SPDM secured transport for Nuvoton/Nations, and
ST33KTPM2X firmware update (Gen 1 non-LMS + Gen 2 LMS, auto-detect).
Themed Detail sections cover platform/HAL, crypto callbacks, security
hardening, Coverity, CI, marshaling, bug fixes, and deprecations.
ASCII-only.

### Build/portability fixes found by the release build matrix

1. `configure.ac`: auto-disable fwTPM when `--disable-wolfcrypt` is
   passed (fwTPM requires wolfCrypt, so the default-on fwTPM previously
   made plain `./configure --disable-wolfcrypt` fail).
2. `configure.ac`: replace `AC_CHECK_LIB([wolfssl],[wolfCrypt_Init])`
   with `AC_LINK_IFELSE` that includes wolfSSL headers so the link
   probe works under both C and C++ (`CC=g++`). `AC_CHECK_LIB`
   synthesizes a bare declaration that C++ name-mangles and fails to
   link against libwolfssl's C symbols.
3. `wolftpm/fwtpm/fwtpm.h`: move `struct FWTPM_NV_HAL_S` and
   `struct FWTPM_CLOCK_HAL_S` out of `FWTPM_CTX` to file scope. C
   merges nested struct tags into the outer scope; C++ treats them as
   nested types, which broke external uses of the `FWTPM_NV_HAL`
   typedef under C++.
4. `src/fwtpm/fwtpm_command.c`, `src/fwtpm/fwtpm_crypto.c`: explicit
   casts for enum/non-enum ternaries and `int` -> `enum wc_HashType`
   conversions flagged by g++ `-Werror=extra` / `-fpermissive`.

### scan-build cleanups (8 dead stores -> 0)

- `examples/endorsement/get_ek_certs.c` - removed dead `indexType`
  fallback init
- `examples/endorsement/verify_ek_cert.c` - restructured `curveName`
  init with `#if` / `#else`
- `examples/native/native_test.c` - removed dead
  `rc = TPM_RC_SUCCESS` resets (rc reassigned downstream)
- `src/fwtpm/fwtpm_command.c` - removed dead `hashAlg` initializer
- `src/tpm2_wrap.c` - moved `rc = TPM_RC_SUCCESS` into `#else` of
  `WOLFTPM_MICROCHIP`/`WOLFTPM_PERFORM_SELFTEST` block
- `tests/fwtpm_unit_tests.c` - use `cmdSz` in `FWTPM_ProcessCommand`
  call (was hardcoded `14`)

### CI additions

- New `.github/workflows/release-checks.yml` - release-gate workflow
  run on every PR and push:
  - **cxx_build** - `./configure CC=g++ && make` in default and
    `--enable-fwtpm` configs.
  - **scan_build** - `scan-build --status-bugs ./configure`
    + `scan-build --status-bugs make` in default and `--enable-fwtpm`
    configs. Uploads report artifacts on failure.
- New matrix entries in `make-test-swtpm.yml`:
  - `no-examples` (`--enable-swtpm --disable-examples --disable-fwtpm`)
  - `st33ktpm2-i2c` (`--enable-st33 --enable-i2c --disable-fwtpm`)

### README.md

Replaced two em-dashes (U+2014) with ASCII `-` for strict ASCII.

## Verification performed locally

- `./configure && make && make check` - PASS (2/2)
- `./configure CC=g++ && make` - PASS
- `./configure --disable-wolfcrypt && make` - PASS (fwTPM auto-disabled)
- `./configure --enable-fwtpm && make && make check` - PASS
- `./configure --enable-fwtpm-only && make` - PASS
- `./configure --enable-swtpm --disable-examples --disable-fwtpm && make` - PASS
- `./configure --enable-st33 --enable-i2c --disable-fwtpm && make` - PASS
- `scan-build --status-bugs make` - PASS (0 bugs)
- CMake build - PASS
- All vendor matrix variants - PASS
- `grep -P "[^\x00-\x7F]" ChangeLog.md` - empty (ASCII)