### PR TITLE
Fix NS350 RSA-4096 Failures

### DIFF
--- a/examples/csr/csr.c
+++ b/examples/csr/csr.c
@@ -60,7 +60,14 @@ static const char* gClientCertEccFile = ECC_CERT_PEM;
 #endif
 
 #ifndef MAX_PEM_SIZE
-#define MAX_PEM_SIZE MAX_CONTEXT_SIZE
+    /* Must hold the full PEM-encoded CSR/cert (cert body + RSA signature +
+     * ASN.1 + base64 overhead). MAX_CONTEXT_SIZE (2 KB) fits RSA-2048 but
+     * overflows at RSA-4096 where the signature alone is 512 B. */
+    #if MAX_RSA_KEY_BITS >= 4096
+        #define MAX_PEM_SIZE 4096
+    #else
+        #define MAX_PEM_SIZE MAX_CONTEXT_SIZE
+    #endif
 #endif
 
 /******************************************************************************/

--- a/examples/keygen/keygen.c
+++ b/examples/keygen/keygen.c
@@ -132,7 +132,7 @@ int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[])
     WOLFTPM2_KEYBLOB primaryBlob; /* Primary key as WOLFTPM2_KEYBLOB */
     TPMT_PUBLIC publicTemplate;
     TPMI_ALG_PUBLIC alg = TPM_ALG_RSA; /* default, see usage() for options */
-    TPMI_ALG_PUBLIC srkAlg = TPM_ALG_ECC; /* prefer ECC, but allow RSA */
+    TPMI_ALG_PUBLIC srkAlg = TPM_ALG_RSA; /* default matches seal.c / keyload.c */
     TPM_ALG_ID algSym = TPM_ALG_CTR; /* default Symmetric Cipher, see usage */
     TPM_ALG_ID paramEncAlg = TPM_ALG_NULL;
     WOLFTPM2_SESSION tpmSession;
@@ -222,8 +222,10 @@ int TPM2_Keygen_Example(void* userCtx, int argc, char *argv[])
     XMEMSET(&tpmSession, 0, sizeof(tpmSession));
     XMEMSET(&auth, 0, sizeof(auth));
 
-    if (alg == TPM_ALG_RSA)
-        srkAlg = TPM_ALG_RSA;
+    /* Only use the ECC SRK for ECC child keys; RSA, SYMCIPHER, KEYEDHASH
+     * all stay on the RSA SRK so that keyload/seal can round-trip them. */
+    if (alg == TPM_ALG_ECC)
+        srkAlg = TPM_ALG_ECC;
     if (alg == TPM_ALG_SYMCIPHER) {
         rc = symChoice(symMode, &algSym, &keyBits);
         if (rc != TPM_RC_SUCCESS) {

--- a/examples/keygen/keyload.c
+++ b/examples/keygen/keyload.c
@@ -67,7 +67,7 @@ int TPM2_Keyload_Example(void* userCtx, int argc, char *argv[])
     WOLFTPM2_KEYBLOB newKey;
     WOLFTPM2_KEY persistKey;
     TPM_ALG_ID alg;
-    TPMI_ALG_PUBLIC srkAlg = TPM_ALG_ECC; /* prefer ECC, but allow RSA */
+    TPMI_ALG_PUBLIC srkAlg = TPM_ALG_RSA; /* default matches seal.c */
     TPM_ALG_ID paramEncAlg = TPM_ALG_NULL;
     WOLFTPM2_SESSION tpmSession;
     const char* inputFile = "keyblob.bin";
@@ -133,8 +133,11 @@ int TPM2_Keyload_Example(void* userCtx, int argc, char *argv[])
 #endif
 
     alg = newKey.pub.publicArea.type;
-    if (alg == TPM_ALG_RSA)
-        srkAlg = TPM_ALG_RSA;
+    /* Only switch to the ECC SRK when the stored key itself is ECC; other
+     * child types (RSA, KEYEDHASH from seal, SYMCIPHER) stay on the RSA SRK
+     * so the parent algorithm matches how those keys were created. */
+    if (alg == TPM_ALG_ECC)
+        srkAlg = TPM_ALG_ECC;
     printf("Loading %s key\n", TPM2_GetAlgName(alg));
 
     if (endorseKey) {

--- a/examples/nvram/read.c
+++ b/examples/nvram/read.c
@@ -267,8 +267,12 @@ int TPM2_NVRAM_Read_Example(void* userCtx, int argc, char *argv[])
         nvIndex);
 
     if (!nvExtend && !partialRead) {
-        /* get SRK */
-        rc = getPrimaryStoragekey(&dev, &storage, TPM_ALG_RSA);
+        /* Select the SRK algorithm based on the stored key's type so an
+         * ECC child isn't loaded under an RSA parent (or vice versa). */
+        TPMI_ALG_PUBLIC srkAlg =
+            (keyBlob.pub.publicArea.type == TPM_ALG_ECC)
+                ? TPM_ALG_ECC : TPM_ALG_RSA;
+        rc = getPrimaryStoragekey(&dev, &storage, srkAlg);
         if (rc != 0) goto exit;
 
         printf("Trying to load the key extracted from NVRAM\n");

--- a/examples/pkcs7/pkcs7.c
+++ b/examples/pkcs7/pkcs7.c
@@ -57,7 +57,14 @@
 #endif
 
 #ifndef MAX_PKCS7_SIZE
-#define MAX_PKCS7_SIZE MAX_CONTEXT_SIZE
+    /* Must hold the full SignedData blob (cert + signature + ASN.1 overhead).
+     * MAX_CONTEXT_SIZE (2 KB) is enough for RSA-2048 but overflows at
+     * RSA-4096 where the signature alone is 512 B. */
+    #if MAX_RSA_KEY_BITS >= 4096
+        #define MAX_PKCS7_SIZE 4096
+    #else
+        #define MAX_PKCS7_SIZE MAX_CONTEXT_SIZE
+    #endif
 #endif
 
 /******************************************************************************/

--- a/examples/wrap/wrap_test.c
+++ b/examples/wrap/wrap_test.c
@@ -338,7 +338,9 @@ int TPM2_Wrapper_TestArgs(void* userCtx, int argc, char *argv[])
     if (rc != 0) goto exit;
 
     /* Perform RSA encrypt / decrypt (no pad) */
-    message.size = 256; /* test message 0x11,0x11,etc */
+    /* With TPM_ALG_NULL padding, the TPM returns a full modulus-sized
+     * plaintext on decrypt, so the message must also be modulus-sized. */
+    message.size = rsaKey.pub.publicArea.parameters.rsaDetail.keyBits / 8;
     XMEMSET(message.buffer, 0x11, message.size);
     cipher.size = sizeof(cipher.buffer); /* encrypted data */
     rc = wolfTPM2_RsaEncrypt(&dev, &rsaKey, TPM_ALG_NULL,


### PR DESCRIPTION
## Summary      
                                                                                                                                                           
  Fix four host-side example failures  against wolfTPM                                                                                    
  4.0.0 on Nations NS350 with a 4096-bit RSA build, plus three same-class                                                                                  
  issues uncovered while verifying the full example suite at RSA-4096.                                                                                     
  No `src/` or `wolftpm/` changes  

### Fixes                                                                                                                                                                                                                     
                                                                                                                                                           
  - **wrap_test** — `TPM_RC_TESTING (0x90a)`: message size hardcoded to                                                                                    
    256 bytes. Derive from `keyBits/8` so RSA-4096 works. (6942a8e)
  - **pkcs7** — `BUFFER_E (0xffffff7c)`: `MAX_PKCS7_SIZE` was 2 KB, too                                                                                    
    small for an RSA-4096 signed blob. Gate on `MAX_RSA_KEY_BITS` so                                                                                       
    2048-bit builds are byte-identical. (90846ba)                                                                                                          
  - **nvram/read -aes** — `TPM_RC_INTEGRITY`: hardcoded RSA SRK failed                                                                                     
    to load an ECC child. Pick SRK from `keyBlob.pub.publicArea.type`.                                                                                     
    (eea8741)                                                                                                                                              
  - **seal + keyload -persistent** — `TPM_RC_INTEGRITY`: `seal.c` uses                                                                                     
    RSA SRK but `keyload` defaulted to ECC for KEYEDHASH blobs. Default                                                                                    
    `keyload` to RSA; switch to ECC only when the child is ECC. (34108a8)                                                                                  
  - **keygen** — aligned SRK default with `keyload`/`seal` so
    SYMCIPHER/KEYEDHASH blobs round-trip consistently. (52cdcdc)                                                                                           
  - **csr** — same buffer issue as pkcs7 in `MAX_PEM_SIZE`; same                                                                                           
    `MAX_RSA_KEY_BITS` gate. (ebb98f1)                                                                                                                     
  - **native_test** — flush unused EK before `CreateLoaded` so the test                                                                                    
    fits within NS350's 2-transient-object limit at RSA-4096. No-op on                                                                                     
    TPMs with spare object memory. (88c40e5)