### PR TITLE
configure.ac: --enable-pqc fails with current wolfSSL master because mlkem.h was renamed wc_mlkem.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -728,7 +728,7 @@ else
             [WOLFTPM_HAVE_MLKEM_FN=yes],
             [WOLFTPM_HAVE_MLKEM_FN=no],
             [[#include <wolfssl/options.h>
-              #include <wolfssl/wolfcrypt/mlkem.h>]])
+              #include <wolfssl/wolfcrypt/wc_mlkem.h>]])
         if test "x$WOLFTPM_HAVE_DILITHIUM_FN" = "xyes" && \
            test "x$WOLFTPM_HAVE_MLKEM_FN" = "xyes"
         then
@@ -756,7 +756,7 @@ then
     AC_CHECK_DECL([wc_MlKemKey_Init], [],
         [AC_MSG_ERROR([--enable-v185/--enable-pqc requires wolfSSL built with --enable-mlkem --enable-experimental])],
         [[#include <wolfssl/options.h>
-          #include <wolfssl/wolfcrypt/mlkem.h>]])
+          #include <wolfssl/wolfcrypt/wc_mlkem.h>]])
     AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_V185"
 fi
 AM_CONDITIONAL([BUILD_V185], [test "x$ENABLED_V185" = "xyes"])


### PR DESCRIPTION
## Summary
`wolfTPM/configure.ac` AC_CHECK_DECL probes for `wc_MlKemKey_Init` by including `<wolfssl/wolfcrypt/mlkem.h>`, but wolfSSL HEAD installs the header under `wc_mlkem.h` (with the `wc_` prefix). The probe fails, and `--enable-pqc` configure aborts.

This PR fixes the header include in `configure.ac` to correctly use `wc_mlkem.h`.