### PR TITLE
Fix heap out-of-bounds read in TPM2_ASN_RsaUnpadPkcsv15

### DIFF
--- a/src/tpm2_asn.c
+++ b/src/tpm2_asn.c
@@ -381,7 +381,7 @@ int TPM2_ASN_RsaUnpadPkcsv15(uint8_t** pSig, int* sigSz)
                 break;
             idx++;
         }
-        if (sig[idx++] == 0x00) {
+        if (idx < *sigSz && sig[idx++] == 0x00) {
             rc = 0;
             *pSig = &sig[idx];
             *sigSz -= idx;


### PR DESCRIPTION
Add a bounds check (idx < *sigSz) before dereferencing the separator byte. Fixes #515.