### PR TITLE
Speed up wolfTPM CI: cache wolfSSL builds + parallelize compiles

### DIFF
--- a/.github/actions/setup-wolfssl/action.yml
+++ b/.github/actions/setup-wolfssl/action.yml
@@ -1,0 +1,135 @@
+name: Setup wolfSSL
+description: >-
+  Build (or restore from cache) and install wolfSSL for wolfTPM CI. Resolves the
+  requested ref to a commit so the cache key is stable per upstream commit,
+  restores the previously built ./wolfssl tree on a hit, and otherwise does a
+  shallow clone + parallel build. The full source tree is left in ./wolfssl so
+  run_examples.sh can exec $WOLFSSL_PATH/examples/server/server.
+
+inputs:
+  configure-flags:
+    description: wolfSSL ./configure enable/disable flags (no CFLAGS/LDFLAGS here).
+    required: false
+    default: --enable-wolftpm --enable-pkcallbacks
+  cflags:
+    description: Extra CFLAGS. Passed only when non-empty so wolfSSL keeps its default optimization flags.
+    required: false
+    default: ""
+  ldflags:
+    description: Extra LDFLAGS. Passed only when non-empty.
+    required: false
+    default: ""
+  cc:
+    description: C compiler to build wolfSSL with.
+    required: false
+    default: gcc
+  prefix:
+    description: >-
+      Install prefix. Empty (default) installs to /usr/local via sudo + ldconfig.
+      When set, configures --prefix and installs without sudo (for --with-wolfcrypt).
+    required: false
+    default: ""
+  ref:
+    description: wolfSSL git ref (branch, tag, or commit) to build.
+    required: false
+    default: master
+  parallel:
+    description: Pass -j$(nproc) to make when "true".
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve wolfSSL ${{ inputs.ref }} and compute cache key
+      id: key
+      shell: bash
+      run: |
+        set -eo pipefail
+        # Resolve the ref to a commit so the cache key tracks the upstream tree,
+        # not a moving branch name. ls-remote returns nothing for a raw SHA, in
+        # which case the ref already is the commit.
+        URL=https://github.com/wolfSSL/wolfssl.git
+        # Peel annotated tags to their commit (the ^{} line); branches and
+        # lightweight tags have no ^{} line so this is empty for them. Fall
+        # back to the direct ref, then to treating the ref as a raw commit.
+        SHA=$(git ls-remote "$URL" "${{ inputs.ref }}^{}" | awk 'NR==1{print $1}')
+        if [ -z "$SHA" ]; then
+          SHA=$(git ls-remote "$URL" "${{ inputs.ref }}" | awk 'NR==1{print $1}')
+        fi
+        if [ -z "$SHA" ]; then
+          SHA="${{ inputs.ref }}"
+        fi
+        # Fold every build-affecting input into the key so different configs do
+        # not collide and identical configs (across jobs/workflows) share a hit.
+        # macOS runners have shasum, not sha256sum.
+        HASH_CMD="sha256sum"
+        command -v sha256sum >/dev/null 2>&1 || HASH_CMD="shasum -a 256"
+        CFGHASH=$(printf '%s\037%s\037%s\037%s\037%s' \
+            "${{ inputs.configure-flags }}" \
+            "${{ inputs.cflags }}" \
+            "${{ inputs.ldflags }}" \
+            "${{ inputs.cc }}" \
+            "${{ inputs.prefix }}" | $HASH_CMD | cut -c1-16)
+        echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+        echo "cache-key=wolfssl-${{ runner.os }}-${SHA}-${CFGHASH}-v1" >> "$GITHUB_OUTPUT"
+        echo "wolfSSL ${{ inputs.ref }} -> $SHA (cfg $CFGHASH)"
+
+    - name: Restore wolfSSL build cache
+      id: cache
+      uses: actions/cache@v4
+      with:
+        # Cache the whole built source tree: install needs the libs, and
+        # run_examples.sh needs examples/server + examples/client + certs.
+        path: wolfssl
+        key: ${{ steps.key.outputs.cache-key }}
+
+    - name: Build wolfSSL (cache miss)
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -eo pipefail
+        rm -rf wolfssl
+        # Fetch the exact resolved commit so the built tree matches the cache
+        # key. GitHub allows fetching any reachable commit, so this works for
+        # branch tips, peeled tags, and raw commit SHAs alike.
+        git init -q wolfssl
+        cd wolfssl
+        git remote add origin https://github.com/wolfSSL/wolfssl.git
+        git fetch --depth 1 origin "${{ steps.key.outputs.sha }}"
+        git checkout -q --detach FETCH_HEAD
+        ./autogen.sh
+        ARGS='${{ inputs.configure-flags }}'
+        if [ -n "${{ inputs.prefix }}" ]; then
+          ARGS="$ARGS --prefix=${{ inputs.prefix }}"
+        fi
+        # Only append CFLAGS/LDFLAGS when non-empty: an empty CFLAGS= would
+        # override wolfSSL's default -Os/-O2 selection.
+        if [ -n "${{ inputs.cflags }}" ]; then
+          ARGS="$ARGS CFLAGS=\"${{ inputs.cflags }}\""
+        fi
+        if [ -n "${{ inputs.ldflags }}" ]; then
+          ARGS="$ARGS LDFLAGS=\"${{ inputs.ldflags }}\""
+        fi
+        eval CC="${{ inputs.cc }}" ./configure $ARGS
+        if [ "${{ inputs.parallel }}" = "true" ]; then
+          make -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)"
+        else
+          make
+        fi
+
+    - name: Install wolfSSL
+      shell: bash
+      run: |
+        set -eo pipefail
+        cd wolfssl
+        # On a cache hit the tree is already built (mtimes preserved by the
+        # cache tar), so this only copies artifacts into place.
+        if [ -n "${{ inputs.prefix }}" ]; then
+          make install
+        else
+          sudo make install
+          if command -v ldconfig >/dev/null 2>&1; then
+            sudo ldconfig
+          fi
+        fi

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -147,12 +147,31 @@ jobs:
         sudo apt-get install -y cmake
 
 #pull and build wolfssl
+    # Every matrix entry builds the identical wolfSSL (only the wolfTPM options
+    # vary), so cache the install prefix keyed on the resolved wolfSSL commit +
+    # OS. Tests are ctest against wolfTPM, so the wolfSSL source tree is not
+    # needed once installed -- caching install/ alone is sufficient.
+    - name: Resolve wolfSSL commit
+      id: wolfssl_rev
+      shell: bash
+      run: echo "sha=$(git ls-remote https://github.com/wolfSSL/wolfssl.git master | awk 'NR==1{print $1}')" >> "$GITHUB_OUTPUT"
+
+    - name: Cache wolfSSL install
+      id: wolfssl_cache
+      uses: actions/cache@v4
+      with:
+        path: install
+        key: wolfssl-cmake-${{ runner.os }}-${{ steps.wolfssl_rev.outputs.sha }}-v1
+
     - name: Checkout wolfssl
+      if: steps.wolfssl_cache.outputs.cache-hit != 'true'
       uses: actions/checkout@master
       with:
         repository: wolfssl/wolfssl
+        ref: ${{ steps.wolfssl_rev.outputs.sha }}
         path: wolfssl
     - name: Build wolfssl
+      if: steps.wolfssl_cache.outputs.cache-hit != 'true'
       working-directory: ./wolfssl
       shell: bash
       run: |
@@ -162,7 +181,7 @@ jobs:
         cmake -DWOLFSSL_TPM=yes -DWOLFSSL_INSTALL=yes \
             -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install" \
             -DCMAKE_C_FLAGS="-DWC_RSA_NO_PADDING -DWOLFSSL_PUBLIC_MP" ..
-        cmake --build . --config Release
+        cmake --build . --config Release --parallel
         cmake --install . --config Release
 
 #build wolftpm
@@ -174,7 +193,7 @@ jobs:
         cmake ${{ matrix.config.options }} \
             -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install" \
             -DWITH_WOLFSSL="$GITHUB_WORKSPACE/install" ..
-        cmake --build . --config Release
+        cmake --build . --config Release --parallel
         cmake --install . --config Release
 
     - name: Test fwTPM
@@ -209,20 +228,37 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake
 
+      # Same wolfSSL config as the matrix build above, so it shares that cache
+      # entry (key includes only OS + commit, not the wolfTPM options).
+      - name: Resolve wolfSSL commit
+        id: wolfssl_rev
+        shell: bash
+        run: echo "sha=$(git ls-remote https://github.com/wolfSSL/wolfssl.git master | awk 'NR==1{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache wolfSSL install
+        id: wolfssl_cache
+        uses: actions/cache@v4
+        with:
+          path: install
+          key: wolfssl-cmake-${{ runner.os }}-${{ steps.wolfssl_rev.outputs.sha }}-v1
+
       - name: Checkout wolfssl
+        if: steps.wolfssl_cache.outputs.cache-hit != 'true'
         uses: actions/checkout@master
         with:
           repository: wolfssl/wolfssl
+          ref: ${{ steps.wolfssl_rev.outputs.sha }}
           path: wolfssl
 
       - name: Build and install wolfssl
+        if: steps.wolfssl_cache.outputs.cache-hit != 'true'
         working-directory: ./wolfssl
         run: |
           mkdir build && cd build
           cmake -DWOLFSSL_TPM=yes -DWOLFSSL_INSTALL=yes \
               -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install" \
               -DCMAKE_C_FLAGS="-DWC_RSA_NO_PADDING -DWOLFSSL_PUBLIC_MP" ..
-          cmake --build .
+          cmake --build . --parallel
           cmake --install .
 
       - name: Build and install wolftpm (static, cmake-config wolfssl)
@@ -236,5 +272,5 @@ jobs:
               -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/install" \
               -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/install" \
               ..
-          cmake --build .
+          cmake --build . --parallel
           cmake --install .

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -2,49 +2,51 @@ name: Fuzz Testing
 
 on:
   schedule:
-    - cron: '0 4 * * 1'  # Weekly Monday 4am UTC
+    - cron: '0 4 * * *'  # Nightly 4am UTC
   workflow_dispatch:       # Manual trigger
   pull_request:
     branches: [ '*' ]
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
+  push:
+    branches: [ master ]
 
 jobs:
-  fuzz:
+  # The matrix context is not available in a job-level if:, so route by run
+  # type here instead: 600s full runs go to the nightly schedule / manual
+  # dispatch; 60s smoke runs go to non-draft PR open/reopen/ready and merges
+  # to master. Intermediate PR pushes (synchronize) are not a trigger.
+  select:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.pick.outputs.matrix }}
+    steps:
+      - name: Pick fuzz matrix for ${{ github.event_name }}
+        id: pick
+        run: |
+          # schedule / dispatch -> full (600s); PR / push -> smoke (60s).
+          case "${{ github.event_name }}" in
+            schedule|workflow_dispatch) WANT=false ;;
+            *)                          WANT=true  ;;
+          esac
+          PQC="--enable-dilithium --enable-mlkem --enable-experimental --enable-harden"
+          MATRIX=$(jq -nc --argjson want "$WANT" --arg pqc "$PQC" '{
+            include: [
+              {name:"fuzz-full",      fuzz_time:600, smoke_only:false, wolfssl_extra_flags:"",   wolftpm_extra_flags:"",              max_len:4096},
+              {name:"fuzz-smoke",     fuzz_time:60,  smoke_only:true,  wolfssl_extra_flags:"",   wolftpm_extra_flags:"",              max_len:4096},
+              {name:"fuzz-full-pqc",  fuzz_time:600, smoke_only:false, wolfssl_extra_flags:$pqc, wolftpm_extra_flags:"--enable-v185", max_len:8192},
+              {name:"fuzz-smoke-pqc", fuzz_time:60,  smoke_only:true,  wolfssl_extra_flags:$pqc, wolftpm_extra_flags:"--enable-v185", max_len:8192}
+            ] | map(select(.smoke_only == $want))
+          }')
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+  fuzz:
+    needs: select
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          # Classical (v1.38) full fuzz run (weekly/manual) - 10 minutes
-          - name: fuzz-full
-            fuzz_time: 600
-            smoke_only: false
-            wolfssl_extra_flags: ""
-            wolftpm_extra_flags: ""
-            max_len: 4096
-          # Classical (v1.38) quick smoke test (PR) - 60 seconds
-          - name: fuzz-smoke
-            fuzz_time: 60
-            smoke_only: true
-            wolfssl_extra_flags: ""
-            wolftpm_extra_flags: ""
-            max_len: 4096
-          # v1.85 PQC full fuzz run (weekly/manual) - 10 minutes
-          - name: fuzz-full-pqc
-            fuzz_time: 600
-            smoke_only: false
-            wolfssl_extra_flags: "--enable-dilithium --enable-mlkem --enable-experimental --enable-harden"
-            wolftpm_extra_flags: "--enable-v185"
-            max_len: 8192
-          # v1.85 PQC quick smoke test (PR) - 60 seconds
-          - name: fuzz-smoke-pqc
-            fuzz_time: 60
-            smoke_only: true
-            wolfssl_extra_flags: "--enable-dilithium --enable-mlkem --enable-experimental --enable-harden"
-            wolftpm_extra_flags: "--enable-v185"
-            max_len: 8192
+      matrix: ${{ fromJson(needs.select.outputs.matrix) }}
 
     steps:
       - name: Checkout wolfTPM

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -52,26 +52,16 @@ jobs:
       - name: Checkout wolfTPM
         uses: actions/checkout@v4
 
-      - name: Checkout wolfSSL
-        uses: actions/checkout@v4
-        with:
-          repository: wolfssl/wolfssl
-          path: wolfssl
-
       - name: ASLR workaround
         run: sudo sysctl vm.mmap_rnd_bits=28
 
-      - name: Build wolfSSL with fuzzer support
-        working-directory: ./wolfssl
-        run: |
-          ./autogen.sh
-          CC=clang ./configure --enable-wolftpm --enable-pkcallbacks --enable-keygen \
-            ${{ matrix.wolfssl_extra_flags }} \
-            CFLAGS="-fsanitize=fuzzer-no-link,address -fno-omit-frame-pointer -g -O1 -DWC_RSA_NO_PADDING" \
-            LDFLAGS="-fsanitize=address"
-          make -j$(nproc)
-          sudo make install
-          sudo ldconfig
+      - name: Setup wolfSSL with fuzzer support
+        uses: ./.github/actions/setup-wolfssl
+        with:
+          cc: clang
+          configure-flags: --enable-wolftpm --enable-pkcallbacks --enable-keygen ${{ matrix.wolfssl_extra_flags }}
+          cflags: -fsanitize=fuzzer-no-link,address -fno-omit-frame-pointer -g -O1 -DWC_RSA_NO_PADDING
+          ldflags: -fsanitize=address
 
       - name: Build fuzz target
         run: |

--- a/.github/workflows/fwtpm-test.yml
+++ b/.github/workflows/fwtpm-test.yml
@@ -210,12 +210,6 @@ jobs:
       - name: Checkout wolfTPM
         uses: actions/checkout@v4
 
-      - name: Checkout wolfSSL
-        uses: actions/checkout@v4
-        with:
-          repository: wolfssl/wolfssl
-          path: wolfssl
-
       - name: Install tpm2-tools
         if: ${{ !matrix.build_only && runner.os != 'macOS' }}
         run: |
@@ -234,27 +228,13 @@ jobs:
           brew install autoconf automake libtool pkg-config
           echo "tpm2-tools install skipped on macOS; fwtpm_check.sh handles absence"
 
-      - name: Build wolfSSL
-        working-directory: ./wolfssl
-        run: |
-          ./autogen.sh
-          CONFIGURE_ARGS="${{ matrix.wolfssl_config }}"
-          EXTRA_CFLAGS="${{ matrix.extra_cflags }}"
-          EXTRA_LDFLAGS="${{ matrix.extra_ldflags }}"
-          WOLFSSL_CFLAGS="-DWC_RSA_NO_PADDING"
-          if [ -n "$EXTRA_CFLAGS" ]; then
-            WOLFSSL_CFLAGS="$WOLFSSL_CFLAGS $EXTRA_CFLAGS"
-          fi
-          CONFIGURE_ARGS="$CONFIGURE_ARGS CFLAGS=\"$WOLFSSL_CFLAGS\""
-          if [ -n "$EXTRA_LDFLAGS" ]; then
-            CONFIGURE_ARGS="$CONFIGURE_ARGS LDFLAGS=\"$EXTRA_LDFLAGS\""
-          fi
-          CC=${{ matrix.cc || 'gcc' }} eval ./configure $CONFIGURE_ARGS
-          make
-          sudo make install
-          if command -v ldconfig >/dev/null 2>&1; then
-            sudo ldconfig
-          fi
+      - name: Setup wolfSSL
+        uses: ./.github/actions/setup-wolfssl
+        with:
+          cc: ${{ matrix.cc || 'gcc' }}
+          configure-flags: ${{ matrix.wolfssl_config }}
+          cflags: -DWC_RSA_NO_PADDING ${{ matrix.extra_cflags }}
+          ldflags: ${{ matrix.extra_ldflags }}
 
       - name: Build wolfTPM
         run: |
@@ -269,11 +249,13 @@ jobs:
             CONFIGURE_ARGS="$CONFIGURE_ARGS LDFLAGS=\"$EXTRA_LDFLAGS\""
           fi
           CC=${{ matrix.cc || 'gcc' }} eval ./configure $CONFIGURE_ARGS
+          # nproc is Linux-only; the fwtpm-macos-socket entry needs the fallback.
+          JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)
           MAKE_CFLAGS="${{ matrix.make_cflags }}"
           if [ -n "$MAKE_CFLAGS" ]; then
-            make CFLAGS="$MAKE_CFLAGS"
+            make -j"$JOBS" CFLAGS="$MAKE_CFLAGS"
           else
-            make
+            make -j"$JOBS"
           fi
 
       - name: Run tests (make check)
@@ -413,7 +395,7 @@ jobs:
           ./autogen.sh
           ./configure --enable-wolftpm --enable-pkcallbacks --enable-keygen \
               CFLAGS="-DWC_RSA_NO_PADDING"
-          make
+          make -j"$(nproc)"
           make install
           ldconfig
 
@@ -461,33 +443,23 @@ jobs:
       - name: Checkout wolfTPM
         uses: actions/checkout@v4
 
-      - name: Checkout wolfSSL
-        uses: actions/checkout@v4
-        with:
-          repository: wolfssl/wolfssl
-          path: wolfssl
-
       - name: Install valgrind + tpm2-tools
         run: |
           sudo apt-get update
           sudo apt-get install -y valgrind tpm2-tools libtss2-tcti-mssim0
 
-      - name: Build wolfSSL
-        working-directory: ./wolfssl
-        run: |
-          ./autogen.sh
-          ./configure --enable-wolftpm --enable-pkcallbacks --enable-keygen \
-              CFLAGS="-DWC_RSA_NO_PADDING -g -O1"
-          make
-          sudo make install
-          sudo ldconfig
+      - name: Setup wolfSSL
+        uses: ./.github/actions/setup-wolfssl
+        with:
+          configure-flags: --enable-wolftpm --enable-pkcallbacks --enable-keygen
+          cflags: -DWC_RSA_NO_PADDING -g -O1
 
       - name: Build wolfTPM (${{ matrix.name }})
         run: |
           ./autogen.sh
           ./configure --enable-fwtpm --enable-swtpm --enable-debug \
               CFLAGS="${{ matrix.extra_cflags }} -g -O1"
-          make
+          make -j"$(nproc)"
 
       - name: Run unit.test under valgrind
         run: |

--- a/.github/workflows/make-test-swtpm.yml
+++ b/.github/workflows/make-test-swtpm.yml
@@ -333,27 +333,16 @@ jobs:
       - name: Checkout wolfTPM
         uses: actions/checkout@master
 
-      - name: Checkout wolfSSL
-        uses: actions/checkout@master
-        with:
-          repository: wolfssl/wolfssl
-          path: wolfssl
-          ref: ${{ matrix.wolfssl_ref || 'master' }}
-
+      # Build (or restore from cache) + install wolfSSL. The action caches the
+      # built ./wolfssl tree keyed on the resolved wolfSSL commit + this config,
+      # so identical-config jobs (and repeat pushes) skip the rebuild. The ~40
+      # default-config matrix entries all share one cache entry.
       - name: Setup wolfSSL
-        working-directory: ./wolfssl
-        run: |
-          ./autogen.sh
-          WOLFSSL_CONFIG="${{ matrix.wolfssl_config || '--enable-wolftpm --enable-pkcallbacks' }}"
-          WOLFSSL_CFLAGS="${{ matrix.wolfssl_cflags || '' }}"
-          if [ -n "$WOLFSSL_CFLAGS" ]; then
-            ./configure $WOLFSSL_CONFIG CFLAGS="$WOLFSSL_CFLAGS"
-          else
-            ./configure $WOLFSSL_CONFIG
-          fi
-          make
-          sudo make install
-          sudo ldconfig
+        uses: ./.github/actions/setup-wolfssl
+        with:
+          ref: ${{ matrix.wolfssl_ref || 'master' }}
+          configure-flags: ${{ matrix.wolfssl_config || '--enable-wolftpm --enable-pkcallbacks' }}
+          cflags: ${{ matrix.wolfssl_cflags }}
 
       # For old-wolfssl test: checkout and build old wolfSSL for linking
       - name: Checkout old wolfSSL
@@ -400,7 +389,7 @@ jobs:
         if: matrix.needs_swtpm == true || matrix.needs_swtpm == null
         working-directory: ./ibmswtpm2/src
         run: |
-          make
+          make -j"$(nproc)"
           echo "Starting TPM simulator on port $TPM_PORT"
           ./tpm_server -port $TPM_PORT &
 
@@ -432,7 +421,7 @@ jobs:
               ./configure $WOLFTPM_CONFIG
             fi
           fi
-          make
+          make -j"$(nproc)"
 
       - name: Run tests
         if: matrix.test_command && matrix.test_command != 'true'

--- a/.github/workflows/pqc-examples.yml
+++ b/.github/workflows/pqc-examples.yml
@@ -23,29 +23,18 @@ jobs:
       - name: Checkout wolfTPM
         uses: actions/checkout@v4
 
-      - name: Checkout wolfSSL
-        uses: actions/checkout@v4
-        with:
-          repository: wolfssl/wolfssl
-          path: wolfssl
-          ref: master
-
       - name: Install build deps + tpm2-tools
         run: |
           sudo apt-get update
           sudo apt-get install -y tpm2-tools libtss2-tcti-mssim0
 
-      - name: Build wolfSSL with PQC
-        working-directory: ./wolfssl
-        run: |
-          ./autogen.sh
-          ./configure --enable-wolftpm --enable-pkcallbacks --enable-keygen \
-                      --enable-dilithium --enable-mlkem --enable-experimental \
-                      --enable-harden \
-                      CFLAGS="-DWC_RSA_NO_PADDING"
-          make
-          sudo make install
-          sudo ldconfig
+      - name: Setup wolfSSL with PQC
+        uses: ./.github/actions/setup-wolfssl
+        with:
+          configure-flags: >-
+            --enable-wolftpm --enable-pkcallbacks --enable-keygen
+            --enable-dilithium --enable-mlkem --enable-experimental --enable-harden
+          cflags: -DWC_RSA_NO_PADDING
 
       - name: Build wolfTPM with v1.85 + fwTPM + debug
         run: |
@@ -55,7 +44,7 @@ jobs:
           # --enable-debug=verbose: full client + fwTPM dispatch logs so
           # CI failures (e.g. keyload integrity) come with TPM-side trace.
           ./configure --enable-v185 --enable-fwtpm --enable-debug=verbose
-          make
+          make -j"$(nproc)"
 
       # ----- Tier 1: make check -----
       # Runs unit.test (wrapper) + fwtpm_unit.test (handler) + tpm2-tools

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -76,28 +76,19 @@ jobs:
       - name: Checkout wolfTPM
         uses: actions/checkout@v4
 
-      - name: Checkout wolfSSL
-        uses: actions/checkout@v4
-        with:
-          repository: wolfssl/wolfssl
-          path: wolfssl
-
       - name: Install tpm2-tools
         run: |
           sudo apt-get update
           sudo apt-get install -y tpm2-tools libtss2-tcti-mssim0
 
-      - name: Build and install wolfSSL with ${{ matrix.name }}
-        working-directory: ./wolfssl
-        run: |
-          ./autogen.sh
-          CC=${{ matrix.cc || 'gcc' }} ./configure --enable-wolftpm --enable-pkcallbacks --enable-keygen \
-              ${{ matrix.wolfssl_extra_config }} \
-              --prefix=/tmp/wolfssl-install \
-              CFLAGS="-DWC_RSA_NO_PADDING ${{ matrix.cflags }}" \
-              LDFLAGS="${{ matrix.ldflags }}"
-          make
-          make install
+      - name: Setup wolfSSL with ${{ matrix.name }}
+        uses: ./.github/actions/setup-wolfssl
+        with:
+          cc: ${{ matrix.cc || 'gcc' }}
+          configure-flags: --enable-wolftpm --enable-pkcallbacks --enable-keygen ${{ matrix.wolfssl_extra_config }}
+          cflags: -DWC_RSA_NO_PADDING ${{ matrix.cflags }}
+          ldflags: ${{ matrix.ldflags }}
+          prefix: /tmp/wolfssl-install
 
       - name: Build wolfTPM with fwTPM + ${{ matrix.name }}
         run: |
@@ -107,7 +98,7 @@ jobs:
               --with-wolfcrypt=/tmp/wolfssl-install \
               CFLAGS="${{ matrix.cflags }}" \
               LDFLAGS="${{ matrix.ldflags }}"
-          make
+          make -j"$(nproc)"
 
       - name: Run tests (make check)
         env:

--- a/.github/workflows/seal-test.yml
+++ b/.github/workflows/seal-test.yml
@@ -35,28 +35,17 @@ jobs:
       - name: Checkout wolfTPM
         uses: actions/checkout@v4
 
-      - name: Checkout wolfSSL
-        uses: actions/checkout@v4
+      - name: Setup wolfSSL
+        uses: ./.github/actions/setup-wolfssl
         with:
-          repository: wolfssl/wolfssl
-          ref: master
-          path: wolfssl
-
-      - name: Build and install wolfSSL
-        working-directory: ./wolfssl
-        run: |
-          ./autogen.sh
-          ./configure --enable-wolftpm --enable-pkcallbacks --enable-keygen \
-              CFLAGS="-DWC_RSA_NO_PADDING"
-          make
-          sudo make install
-          sudo ldconfig
+          configure-flags: --enable-wolftpm --enable-pkcallbacks --enable-keygen
+          cflags: -DWC_RSA_NO_PADDING
 
       - name: Build wolfTPM with fwTPM
         run: |
           ./autogen.sh
           ./configure --enable-fwtpm --enable-swtpm --enable-debug
-          make
+          make -j"$(nproc)"
 
       - name: Start fwtpm_server
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -55,21 +55,11 @@ jobs:
       - name: Checkout wolfTPM
         uses: actions/checkout@v4
 
-      - name: Checkout wolfSSL
-        uses: actions/checkout@v4
+      - name: Setup wolfSSL
+        uses: ./.github/actions/setup-wolfssl
         with:
-          repository: wolfssl/wolfssl
-          path: wolfssl
-
-      - name: Build wolfSSL
-        working-directory: ./wolfssl
-        run: |
-          ./autogen.sh
-          ./configure --enable-wolftpm --enable-pkcallbacks --enable-keygen \
-              CFLAGS="-DWC_RSA_NO_PADDING"
-          make -j"$(nproc)"
-          sudo make install
-          sudo ldconfig
+          configure-flags: --enable-wolftpm --enable-pkcallbacks --enable-keygen
+          cflags: -DWC_RSA_NO_PADDING
 
       - name: Setup ibmswtpm2 simulator
         if: matrix.config.needs_swtpm
@@ -82,7 +72,7 @@ jobs:
         if: matrix.config.needs_swtpm
         working-directory: ./ibmswtpm2/src
         run: |
-          make
+          make -j"$(nproc)"
           ./tpm_server &
 
       - name: Build wolfTPM (${{ matrix.config.name }})

--- a/.github/workflows/spdm-test.yml
+++ b/.github/workflows/spdm-test.yml
@@ -62,23 +62,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Checkout wolfSSL
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Setup wolfSSL
+        uses: ./.github/actions/setup-wolfssl
         with:
-          repository: wolfssl/wolfssl
-          path: wolfssl
-          persist-credentials: false
-
-      - name: Build & install wolfSSL
-        working-directory: ./wolfssl
-        run: |
-          ./autogen.sh
-          ./configure --prefix=$HOME/wolfssl-install \
-                      --enable-wolftpm --enable-pkcallbacks --enable-keygen \
-                      --enable-aescfb \
-                      CFLAGS="-DWC_RSA_NO_PADDING"
-          make -j"$(nproc)"
-          make install
+          configure-flags: --enable-wolftpm --enable-pkcallbacks --enable-keygen --enable-aescfb
+          cflags: -DWC_RSA_NO_PADDING
+          prefix: $HOME/wolfssl-install
 
       - name: Build wolfTPM (${{ matrix.name }})
         run: |
@@ -115,23 +104,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Checkout wolfSSL
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Setup wolfSSL
+        uses: ./.github/actions/setup-wolfssl
         with:
-          repository: wolfssl/wolfssl
-          path: wolfssl
-          persist-credentials: false
-
-      - name: Build & install wolfSSL
-        working-directory: ./wolfssl
-        run: |
-          ./autogen.sh
-          ./configure --prefix=$HOME/wolfssl-install \
-                      --enable-wolftpm --enable-pkcallbacks --enable-keygen \
-                      --enable-aescfb \
-                      CFLAGS="-DWC_RSA_NO_PADDING"
-          make -j"$(nproc)"
-          make install
+          configure-flags: --enable-wolftpm --enable-pkcallbacks --enable-keygen --enable-aescfb
+          cflags: -DWC_RSA_NO_PADDING
+          prefix: $HOME/wolfssl-install
 
       - name: Build wolfTPM with full SPDM + vendor support
         # spdm_ctrl's --connect/--status/--lock CLI dispatch is gated on


### PR DESCRIPTION
## Summary

Two logically separate changes, one per commit:

1. **Fuzzer scheduling** - move the 600s full fuzz runs to the nightly schedule / manual dispatch, keep 60s smoke runs on non-draft PRs and merges to master. Routing is done by a small `select` job that emits the matrix per event (the `matrix` context is not available in a job-level `if:`, so the earlier `matrix.smoke_only` condition there never matched and silently disabled PR smoke fuzzing).
2. **wolfSSL build caching + parallelism** - every wolfSSL-consuming workflow rebuilt wolfSSL from scratch, single-threaded and uncached. A single push fanned out to many jobs, most rebuilding an identical wolfSSL, wasting runner-minutes and slowing PR feedback.

## What changed (caching commit)

- New reusable composite action `.github/actions/setup-wolfssl`: resolves the wolfSSL ref to a commit, restores the previously built `./wolfssl` tree from `actions/cache` (key = OS + commit + a hash of the build-affecting inputs), otherwise shallow-clones and builds with `make -j`, then installs. It caches the whole built source tree because several jobs run `run_examples.sh`, which execs `$WOLFSSL_PATH/examples/server/server` from that tree.
- Adopted the action in 8 workflows (make-test-swtpm, fwtpm-test, sanitizer, smoke-test, seal-test, spdm-test, pqc-examples, fuzz), replacing the copy-pasted wolfSSL checkout+build block with one `uses:` call.
- `cmake-build`: cache the cmake `install/` prefix keyed on OS + commit (every entry builds the identical wolfSSL), skip checkout+build on a hit, and build with `--parallel`.
- Added `make -j` (portable `nproc` on the macOS entry) to the remaining single-threaded wolfTPM and ibmswtpm2 builds.

## Why it helps

- `make -j` roughly halves the dominant wolfSSL compile on every job.
- Caches created on `master` are readable by all PR branches, so a master/nightly run populating the wolfSSL-`<commit>` cache serves PRs on the same wolfSSL commit; repeat pushes and same-commit fan-out hit the cache instead of rebuilding.
- The action also deduplicates ~150 lines of repeated build logic across workflows.

## Scope / safety

- No matrix entries or test commands were removed; per-job behavior is unchanged apart from how wolfSSL is built and installed.
- The action supports both the `/usr/local` (sudo + ldconfig) and `--prefix` (`--with-wolfcrypt`) install styles, guards against passing an empty `CFLAGS=` (which would clobber wolfSSL's default optimization flags), and is macOS-portable.
- Left as-is: multi-compiler and release-checks (already share wolfSSL via artifact), coverity, win-test, zephyr.

## Verification

- actionlint, YAML parse, and shellcheck of the action scripts are clean (no new errors introduced by the caching change).
- The `eval`-based configure assembly was simulated for the sanitizer / fuzz / spdm / default cases: CFLAGS with spaces or commas land in a single arg, empty CFLAGS is omitted, and `$HOME` prefixes expand correctly.
- Not yet exercised on real CI - first run should confirm the cache populates on a miss, HITs on a second push, and that prefix-install consumers still link.
