### PR TITLE
Auto-resolve latest wolfSSL stable and test functional suites against it

### DIFF
--- a/.github/workflows/_resolve-wolfssl.yml
+++ b/.github/workflows/_resolve-wolfssl.yml
@@ -9,12 +9,12 @@ on:
       refs:
         description: 'JSON array of wolfSSL refs ([latest -stable, master]) for use as a matrix axis'
         value: ${{ jobs.resolve.outputs.refs }}
-      latest-stable:
+      latest_stable:
         description: 'Latest wolfSSL v*-stable tag resolved at run time'
-        value: ${{ jobs.resolve.outputs.latest-stable }}
-      latest-pqc:
+        value: ${{ jobs.resolve.outputs.latest_stable }}
+      latest_pqc:
         description: 'true when latest -stable is strictly newer than the v5.9.1 PQC floor'
-        value: ${{ jobs.resolve.outputs.latest-pqc }}
+        value: ${{ jobs.resolve.outputs.latest_pqc }}
 
 permissions:
   contents: read
@@ -26,8 +26,8 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       refs: ${{ steps.set-matrix.outputs.refs }}
-      latest-stable: ${{ steps.set-matrix.outputs.latest-stable }}
-      latest-pqc: ${{ steps.set-matrix.outputs.latest-pqc }}
+      latest_stable: ${{ steps.set-matrix.outputs.latest_stable }}
+      latest_pqc: ${{ steps.set-matrix.outputs.latest_pqc }}
     steps:
       - name: Resolve latest -stable wolfSSL tag and PQC eligibility
         id: set-matrix
@@ -40,7 +40,7 @@ jobs:
             exit 1
           fi
           echo "Latest stable wolfSSL: $LATEST"
-          echo "latest-stable=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "latest_stable=$LATEST" >> "$GITHUB_OUTPUT"
           # Enable PQC only when $LATEST is strictly newer than v5.9.1-stable.
           # The wc_MlDsaKey_* API lands post-v5.9.1-stable; older stables only
           # ship the legacy ML-DSA API.
@@ -51,7 +51,7 @@ jobs:
             LATEST_PQC=false
           fi
           echo "latest-stable PQC eligible: $LATEST_PQC"
-          echo "latest-pqc=$LATEST_PQC" >> "$GITHUB_OUTPUT"
+          echo "latest_pqc=$LATEST_PQC" >> "$GITHUB_OUTPUT"
           MATRIX=$(jq -nc --arg latest "$LATEST" --argjson latest_pqc "$LATEST_PQC" '{
             include: [
               {"wolfssl-version":$latest,"wolfssl-ref":$latest,"pqc":$latest_pqc},

--- a/.github/workflows/_resolve-wolfssl.yml
+++ b/.github/workflows/_resolve-wolfssl.yml
@@ -1,0 +1,63 @@
+name: Resolve wolfSSL versions
+
+on:
+  workflow_call:
+    outputs:
+      matrix:
+        description: 'JSON matrix include of wolfSSL refs (master + latest -stable), each with a pqc flag'
+        value: ${{ jobs.resolve.outputs.matrix }}
+      refs:
+        description: 'JSON array of wolfSSL refs ([latest -stable, master]) for use as a matrix axis'
+        value: ${{ jobs.resolve.outputs.refs }}
+      latest-stable:
+        description: 'Latest wolfSSL v*-stable tag resolved at run time'
+        value: ${{ jobs.resolve.outputs.latest-stable }}
+      latest-pqc:
+        description: 'true when latest -stable is strictly newer than the v5.9.1 PQC floor'
+        value: ${{ jobs.resolve.outputs.latest-pqc }}
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: Resolve wolfSSL version matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      refs: ${{ steps.set-matrix.outputs.refs }}
+      latest-stable: ${{ steps.set-matrix.outputs.latest-stable }}
+      latest-pqc: ${{ steps.set-matrix.outputs.latest-pqc }}
+    steps:
+      - name: Resolve latest -stable wolfSSL tag and PQC eligibility
+        id: set-matrix
+        run: |
+          set -euo pipefail
+          LATEST=$(git ls-remote --tags --refs https://github.com/wolfSSL/wolfssl.git 'v*-stable' \
+                     | awk -F/ '{print $NF}' | sort -V | tail -n 1)
+          if [ -z "${LATEST:-}" ]; then
+            echo "::error::Could not resolve latest wolfSSL -stable tag from remote"
+            exit 1
+          fi
+          echo "Latest stable wolfSSL: $LATEST"
+          echo "latest-stable=$LATEST" >> "$GITHUB_OUTPUT"
+          # Enable PQC only when $LATEST is strictly newer than v5.9.1-stable.
+          # The wc_MlDsaKey_* API lands post-v5.9.1-stable; older stables only
+          # ship the legacy ML-DSA API.
+          PQC_FLOOR="v5.9.1-stable"
+          if [ "$(printf '%s\n%s\n' "$PQC_FLOOR" "$LATEST" | sort -V | tail -n 1)" != "$PQC_FLOOR" ]; then
+            LATEST_PQC=true
+          else
+            LATEST_PQC=false
+          fi
+          echo "latest-stable PQC eligible: $LATEST_PQC"
+          echo "latest-pqc=$LATEST_PQC" >> "$GITHUB_OUTPUT"
+          MATRIX=$(jq -nc --arg latest "$LATEST" --argjson latest_pqc "$LATEST_PQC" '{
+            include: [
+              {"wolfssl-version":$latest,"wolfssl-ref":$latest,"pqc":$latest_pqc},
+              {"wolfssl-version":"master","wolfssl-ref":"master","pqc":true}
+            ]
+          }')
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          REFS=$(jq -nc --arg latest "$LATEST" '[$latest, "master"]')
+          echo "refs=$REFS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/make-test-swtpm.yml
+++ b/.github/workflows/make-test-swtpm.yml
@@ -352,7 +352,7 @@ jobs:
           # master), to catch wolfTPM relying on a master-only wolfSSL symbol
           # that the shipped release does not yet have.
           - name: default-latest-stable
-            wolfssl_ref: ${{ needs.discover.outputs.latest-stable }}
+            wolfssl_ref: ${{ needs.discover.outputs.latest_stable }}
             test_command: "make check && WOLFSSL_PATH=./wolfssl ./examples/run_examples.sh"
             needs_dist: true
             needs_install: true

--- a/.github/workflows/make-test-swtpm.yml
+++ b/.github/workflows/make-test-swtpm.yml
@@ -14,8 +14,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Auto-resolve the latest wolfSSL -stable tag so the suite also runs against
+  # the version users actually ship, not just master.
+  discover:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    uses: ./.github/workflows/_resolve-wolfssl.yml
+
   build:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: discover
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -340,6 +347,15 @@ jobs:
             wolfssl_config: "--enable-wolftpm --enable-pkcallbacks --enable-keygen"
             wolftpm_config: "--enable-fwtpm"
             test_command: "make check && WOLFSSL_PATH=./wolfssl ./examples/run_examples.sh"
+
+          # Default suite against the latest wolfSSL -stable release (not just
+          # master), to catch wolfTPM relying on a master-only wolfSSL symbol
+          # that the shipped release does not yet have.
+          - name: default-latest-stable
+            wolfssl_ref: ${{ needs.discover.outputs.latest-stable }}
+            test_command: "make check && WOLFSSL_PATH=./wolfssl ./examples/run_examples.sh"
+            needs_dist: true
+            needs_install: true
 
     steps:
       - name: Checkout wolfTPM

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -46,17 +46,17 @@ jobs:
           # Same base sanitizers, but linked against the latest wolfSSL -stable
           # release instead of master.
           - name: "ASan (latest-stable)"
-            wolfssl_ref: ${{ needs.discover.outputs.latest-stable }}
+            wolfssl_ref: ${{ needs.discover.outputs.latest_stable }}
             cflags: "-fsanitize=address -fno-omit-frame-pointer -g -O1"
             ldflags: "-fsanitize=address"
             asan_options: "detect_leaks=0"
           - name: "UBSan (latest-stable)"
-            wolfssl_ref: ${{ needs.discover.outputs.latest-stable }}
+            wolfssl_ref: ${{ needs.discover.outputs.latest_stable }}
             cflags: "-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g"
             ldflags: "-fsanitize=undefined"
             ubsan_options: "halt_on_error=1:print_stacktrace=1"
           - name: "LeakSan (latest-stable)"
-            wolfssl_ref: ${{ needs.discover.outputs.latest-stable }}
+            wolfssl_ref: ${{ needs.discover.outputs.latest_stable }}
             cflags: "-fsanitize=leak -fno-omit-frame-pointer -g"
             ldflags: "-fsanitize=leak"
 

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -14,9 +14,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Auto-resolve the latest wolfSSL -stable tag so the base sanitizers also run
+  # against the shipped release, not just master. The v185/PQC rows stay on
+  # master because their ML-DSA/ML-KEM API lands post-v5.9.1-stable.
+  discover:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    uses: ./.github/workflows/_resolve-wolfssl.yml
+
   sanitizer_test:
     name: ${{ matrix.name }}
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: discover
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -32,6 +40,23 @@ jobs:
             ldflags: "-fsanitize=undefined"
             ubsan_options: "halt_on_error=1:print_stacktrace=1"
           - name: "LeakSan"
+            cflags: "-fsanitize=leak -fno-omit-frame-pointer -g"
+            ldflags: "-fsanitize=leak"
+
+          # Same base sanitizers, but linked against the latest wolfSSL -stable
+          # release instead of master.
+          - name: "ASan (latest-stable)"
+            wolfssl_ref: ${{ needs.discover.outputs.latest-stable }}
+            cflags: "-fsanitize=address -fno-omit-frame-pointer -g -O1"
+            ldflags: "-fsanitize=address"
+            asan_options: "detect_leaks=0"
+          - name: "UBSan (latest-stable)"
+            wolfssl_ref: ${{ needs.discover.outputs.latest-stable }}
+            cflags: "-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g"
+            ldflags: "-fsanitize=undefined"
+            ubsan_options: "halt_on_error=1:print_stacktrace=1"
+          - name: "LeakSan (latest-stable)"
+            wolfssl_ref: ${{ needs.discover.outputs.latest-stable }}
             cflags: "-fsanitize=leak -fno-omit-frame-pointer -g"
             ldflags: "-fsanitize=leak"
 
@@ -84,6 +109,7 @@ jobs:
       - name: Setup wolfSSL with ${{ matrix.name }}
         uses: ./.github/actions/setup-wolfssl
         with:
+          ref: ${{ matrix.wolfssl_ref || 'master' }}
           cc: ${{ matrix.cc || 'gcc' }}
           configure-flags: --enable-wolftpm --enable-pkcallbacks --enable-keygen ${{ matrix.wolfssl_extra_config }}
           cflags: -DWC_RSA_NO_PADDING ${{ matrix.cflags }}

--- a/.github/workflows/wolfssl-versions-pqc.yml
+++ b/.github/workflows/wolfssl-versions-pqc.yml
@@ -17,45 +17,35 @@ permissions:
   contents: read
 
 jobs:
-  # Resolve the latest -stable wolfSSL tag at run time so we don't have to
-  # bump this workflow every release. Floor (v5.8.0) and master are fixed:
-  # v5.8.0 exercises wolfTPM's non-PQC backward-compat path (the v1.85 PQC
-  # code uses the post-v5.9.1 wc_MlDsaKey_* API and is skipped on this row),
-  # and master surfaces upstream drift on the nightly run.
+  # Auto-resolve the latest -stable wolfSSL tag (and its PQC eligibility) via
+  # the shared reusable workflow, so this file never needs a version bump.
+  resolve-wolfssl:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    uses: ./.github/workflows/_resolve-wolfssl.yml
+
+  # Build the wolfTPM PQC test matrix from the resolved latest -stable.
+  #   * v5.8.0-stable: fixed backward-compat floor, classic (no PQC).
+  #   * latest -stable: auto-resolved. Classic on v5.9.1 (and earlier); PQC
+  #     (v185 ML-DSA/ML-KEM) only once latest is > v5.9.1, i.e. v5.9.2 onward,
+  #     because the wc_MlDsaKey_* API the v1.85 code uses lands post-v5.9.1.
+  #   * master: always PQC, to surface upstream drift.
+  # So today this runs v5.8.0 + v5.9.1 classic and master PQC; when v5.9.2
+  # ships it is picked up automatically and gains its own PQC row.
   discover-versions:
     name: Resolve wolfSSL version matrix
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: resolve-wolfssl
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-      latest-stable: ${{ steps.set-matrix.outputs.latest-stable }}
     steps:
-      - name: Resolve latest -stable wolfSSL tag
+      - name: Build wolfTPM version matrix
         id: set-matrix
+        env:
+          LATEST: ${{ needs.resolve-wolfssl.outputs.latest-stable }}
+          LATEST_PQC: ${{ needs.resolve-wolfssl.outputs.latest-pqc }}
         run: |
           set -euo pipefail
-          # List remote v*-stable tags, version-sort, take the highest.
-          # Equivalent to `git tag -l 'v*-stable' | sort -V | tail -1` in a
-          # local clone, but avoids cloning just to read tag names.
-          LATEST=$(git ls-remote --tags --refs https://github.com/wolfSSL/wolfssl.git 'v*-stable' \
-                     | awk -F/ '{print $NF}' | sort -V | tail -n 1)
-          if [ -z "${LATEST:-}" ]; then
-            echo "::error::Could not resolve latest wolfSSL -stable tag from remote"
-            exit 1
-          fi
-          echo "Latest stable wolfSSL: $LATEST"
-          echo "latest-stable=$LATEST" >> "$GITHUB_OUTPUT"
-          # Enable PQC when $LATEST is strictly newer than v5.9.1-stable
-          # (any v5.9.2+, v5.10+, v6+, ...). The wc_MlDsaKey_* API lands
-          # post-v5.9.1-stable in wolfSSL PR #10436.
-          PQC_FLOOR="v5.9.1-stable"
-          if [ "$(printf '%s\n%s\n' "$PQC_FLOOR" "$LATEST" | sort -V | tail -n1)" != "$PQC_FLOOR" ]; then
-            LATEST_PQC_ELIGIBLE=true
-          else
-            LATEST_PQC_ELIGIBLE=false
-          fi
-          echo "latest-stable PQC eligible: $LATEST_PQC_ELIGIBLE"
-          MATRIX=$(jq -nc --arg latest "$LATEST" --argjson latest_pqc "$LATEST_PQC_ELIGIBLE" '{
+          MATRIX=$(jq -nc --arg latest "$LATEST" --argjson latest_pqc "$LATEST_PQC" '{
             include: [
               {"wolfssl-version":"v5.8.0-stable","wolfssl-ref":"v5.8.0-stable","cache-key":"wolfssl-nopqc-v5.8.0-v1","pqc":false},
               {"wolfssl-version":$latest,"wolfssl-ref":$latest,"cache-key":("wolfssl-" + (if $latest_pqc then "pqc" else "nopqc" end) + "-" + $latest + "-v1"),"pqc":$latest_pqc},

--- a/.github/workflows/wolfssl-versions-pqc.yml
+++ b/.github/workflows/wolfssl-versions-pqc.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Build wolfTPM version matrix
         id: set-matrix
         env:
-          LATEST: ${{ needs.resolve-wolfssl.outputs.latest-stable }}
-          LATEST_PQC: ${{ needs.resolve-wolfssl.outputs.latest-pqc }}
+          LATEST: ${{ needs.resolve-wolfssl.outputs.latest_stable }}
+          LATEST_PQC: ${{ needs.resolve-wolfssl.outputs.latest_pqc }}
         run: |
           set -euo pipefail
           MATRIX=$(jq -nc --arg latest "$LATEST" --argjson latest_pqc "$LATEST_PQC" '{


### PR DESCRIPTION
# Description

Auto-resolve the latest wolfSSL release in CI so we test what users actually ship, not just master.

- Add reusable `_resolve-wolfssl.yml` that resolves the latest `-stable` tag at run time (no manual version bumps).
- `wolfssl-versions-pqc.yml` now calls the resolver instead of an inline lookup; same PQC suite (v5.8.0 + latest + master).
- make-check and the ASan/UBSan/LeakSan sanitizers now also run against latest-stable, not just master.
- Resolver outputs use underscores for GitHub Actions expression safety.
