### PR TITLE
Select session, RSA OAEP and PQC template hash algorithms via _ex wrappers

### DIFF
--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -1965,16 +1965,17 @@ int wolfTPM2_SetSessionHandle(WOLFTPM2_DEV* dev, int index,
 }
 
 
-int wolfTPM2_CreateAuthSession_EkPolicy(WOLFTPM2_DEV* dev,
-                                        WOLFTPM2_SESSION* tpmSession)
+int wolfTPM2_CreateAuthSession_EkPolicy_ex(WOLFTPM2_DEV* dev,
+                                        WOLFTPM2_SESSION* tpmSession,
+                                        TPMI_ALG_HASH authHash)
 {
     int rc = TPM_RC_FAILURE;
     PolicySecret_In policySecretIn;
     PolicySecret_Out policySecretOut;
 
     /* Endorsement Key requires authorization with Policy */
-    rc = wolfTPM2_StartSession(dev, tpmSession, NULL, NULL,
-                               TPM_SE_POLICY, TPM_ALG_NULL);
+    rc = wolfTPM2_StartSession_ex(dev, tpmSession, NULL, NULL,
+                               TPM_SE_POLICY, TPM_ALG_NULL, authHash);
     if (rc == TPM_RC_SUCCESS) {
         #ifdef DEBUG_WOLFTPM
         printf("TPM2_StartAuthSession: sessionHandle 0x%x\n",
@@ -1992,6 +1993,13 @@ int wolfTPM2_CreateAuthSession_EkPolicy(WOLFTPM2_DEV* dev,
         #endif
     }
     return rc;
+}
+
+int wolfTPM2_CreateAuthSession_EkPolicy(WOLFTPM2_DEV* dev,
+                                        WOLFTPM2_SESSION* tpmSession)
+{
+    return wolfTPM2_CreateAuthSession_EkPolicy_ex(dev, tpmSession,
+        WOLFTPM2_WRAP_DIGEST);
 }
 
 int wolfTPM2_Cleanup_ex(WOLFTPM2_DEV* dev, int doShutdown)
@@ -2474,28 +2482,39 @@ int wolfTPM2_EncryptSecret(WOLFTPM2_DEV* dev, const WOLFTPM2_KEY* tpmKey,
     return rc;
 }
 
-int wolfTPM2_StartSession(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* session,
+int wolfTPM2_StartSession_ex(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* session,
     WOLFTPM2_KEY* tpmKey, WOLFTPM2_HANDLE* bind, TPM_SE sesType,
-    int encDecAlg)
+    int encDecAlg, TPMI_ALG_HASH authHash)
 {
     int rc = TPM_RC_SUCCESS;
     StartAuthSession_In  authSesIn;
     StartAuthSession_Out authSesOut;
-    TPM2B_DATA keyIn;
-    TPMI_ALG_HASH authHash = WOLFTPM2_WRAP_DIGEST;
+    WOLFTPM2_HANDLE sessionHandle;
+    byte keyIn[TPM_MAX_DIGEST_SIZE * 2];
+    UINT16 keyInSz = 0;
     int hashDigestSz;
 
     if (dev == NULL || session == NULL)
         return BAD_FUNC_ARG;
 
+    /* TPM_ALG_NULL selects the wrapper default hash */
+    if (authHash == TPM_ALG_NULL)
+        authHash = WOLFTPM2_WRAP_DIGEST;
+
     XMEMSET(session, 0, sizeof(WOLFTPM2_SESSION));
     XMEMSET(&authSesIn, 0, sizeof(authSesIn));
+    XMEMSET(&authSesOut, 0, sizeof(authSesOut));
+    XMEMSET(keyIn, 0, sizeof(keyIn));
 
     authSesIn.authHash = authHash;
     hashDigestSz = TPM2_GetHashDigestSize(authHash);
     if (hashDigestSz <= 0 ||
         hashDigestSz > (int)sizeof(authSesIn.nonceCaller.buffer)) {
         return BUFFER_E;
+    }
+    /* reject session hashes weaker than the wrapper default */
+    if (hashDigestSz < TPM2_GetHashDigestSize(WOLFTPM2_WRAP_DIGEST)) {
+        return BAD_FUNC_ARG;
     }
 
     /* set session auth for key */
@@ -2580,19 +2599,17 @@ int wolfTPM2_StartSession(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* session,
 
     /* Calculate "key" and store into auth */
     /* key is bindAuthValue || salt */
-    XMEMSET(&keyIn, 0, sizeof(keyIn));
     if (bind && bind->auth.size > 0) {
         if (bind->auth.size > (UINT16)sizeof(bind->auth.buffer)) {
             rc = BUFFER_E;
         }
         if (rc == TPM_RC_SUCCESS) {
-            if ((keyIn.size + bind->auth.size) > (UINT16)sizeof(keyIn.buffer)) {
+            if ((keyInSz + bind->auth.size) > (UINT16)sizeof(keyIn)) {
                 rc = BUFFER_E;
             }
             else {
-                XMEMCPY(&keyIn.buffer[keyIn.size], bind->auth.buffer,
-                    bind->auth.size);
-                keyIn.size += bind->auth.size;
+                XMEMCPY(&keyIn[keyInSz], bind->auth.buffer, bind->auth.size);
+                keyInSz += bind->auth.size;
             }
         }
     }
@@ -2601,21 +2618,21 @@ int wolfTPM2_StartSession(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* session,
             rc = BUFFER_E;
         }
         if (rc == TPM_RC_SUCCESS) {
-            if ((keyIn.size + session->salt.size) > (UINT16)sizeof(keyIn.buffer)) {
+            if ((keyInSz + session->salt.size) > (UINT16)sizeof(keyIn)) {
                 rc = BUFFER_E;
             }
             else {
-                XMEMCPY(&keyIn.buffer[keyIn.size], session->salt.buffer,
+                XMEMCPY(&keyIn[keyInSz], session->salt.buffer,
                     session->salt.size);
-                keyIn.size += session->salt.size;
+                keyInSz += session->salt.size;
             }
         }
     }
 
-    if (rc == TPM_RC_SUCCESS && keyIn.size > 0) {
+    if (rc == TPM_RC_SUCCESS && keyInSz > 0) {
         session->handle.auth.size = hashDigestSz;
         rc = TPM2_KDFa_ex(authSesIn.authHash,
-            keyIn.buffer, keyIn.size, "ATH",
+            keyIn, keyInSz, "ATH",
             authSesOut.nonceTPM.buffer, authSesOut.nonceTPM.size,
             authSesIn.nonceCaller.buffer, authSesIn.nonceCaller.size,
             session->handle.auth.buffer, session->handle.auth.size);
@@ -2667,10 +2684,25 @@ int wolfTPM2_StartSession(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* session,
             TPM2_GetAlgName(authSesIn.symmetric.algorithm));
 #endif
     }
+    else {
+        /* flush the started session so a post-start failure does not leak
+         * a scarce TPM session slot */
+        XMEMSET(&sessionHandle, 0, sizeof(sessionHandle));
+        sessionHandle.hndl = authSesOut.sessionHandle;
+        (void)wolfTPM2_UnloadHandle(dev, &sessionHandle);
+    }
 
-    TPM2_ForceZero(&keyIn, sizeof(keyIn));
+    TPM2_ForceZero(keyIn, sizeof(keyIn));
 
     return rc;
+}
+
+int wolfTPM2_StartSession(WOLFTPM2_DEV* dev, WOLFTPM2_SESSION* session,
+    WOLFTPM2_KEY* tpmKey, WOLFTPM2_HANDLE* bind, TPM_SE sesType,
+    int encDecAlg)
+{
+    return wolfTPM2_StartSession_ex(dev, session, tpmKey, bind, sesType,
+        encDecAlg, WOLFTPM2_WRAP_DIGEST);
 }
 
 
@@ -6128,12 +6160,21 @@ int wolfTPM2_Decapsulate(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 
 #ifdef WOLFTPM_MLDSA
 /* GetKeyTemplate_MLDSA - Create a key template for ML-DSA signing keys */
-int wolfTPM2_GetKeyTemplate_MLDSA(TPMT_PUBLIC* publicTemplate,
+int wolfTPM2_GetKeyTemplate_MLDSA_ex(TPMT_PUBLIC* publicTemplate,
     TPMA_OBJECT objectAttributes, TPMI_MLDSA_PARAMETER_SET parameterSet,
-    int allowExternalMu)
+    int allowExternalMu, TPMI_ALG_HASH nameAlg)
 {
     if (publicTemplate == NULL)
         return BAD_FUNC_ARG;
+
+    /* TPM_ALG_NULL selects the wrapper default name algorithm */
+    if (nameAlg == TPM_ALG_NULL)
+        nameAlg = WOLFTPM2_WRAP_DIGEST;
+    /* reject object Name hashes weaker than the wrapper default */
+    if (TPM2_GetHashDigestSize(nameAlg) <
+            TPM2_GetHashDigestSize(WOLFTPM2_WRAP_DIGEST)) {
+        return BAD_FUNC_ARG;
+    }
 
     /* TCG v185: MLDSA is sign-only. Enforce correct attributes. */
     objectAttributes &= ~TPMA_OBJECT_decrypt;
@@ -6141,23 +6182,40 @@ int wolfTPM2_GetKeyTemplate_MLDSA(TPMT_PUBLIC* publicTemplate,
 
     XMEMSET(publicTemplate, 0, sizeof(TPMT_PUBLIC));
     publicTemplate->type = TPM_ALG_MLDSA;
-    publicTemplate->nameAlg = TPM_ALG_SHA256;
+    publicTemplate->nameAlg = nameAlg;
     publicTemplate->objectAttributes = objectAttributes;
     publicTemplate->parameters.mldsaDetail.parameterSet = parameterSet;
     publicTemplate->parameters.mldsaDetail.allowExternalMu =
         (allowExternalMu ? YES : NO);
     return TPM_RC_SUCCESS;
 }
+
+int wolfTPM2_GetKeyTemplate_MLDSA(TPMT_PUBLIC* publicTemplate,
+    TPMA_OBJECT objectAttributes, TPMI_MLDSA_PARAMETER_SET parameterSet,
+    int allowExternalMu)
+{
+    return wolfTPM2_GetKeyTemplate_MLDSA_ex(publicTemplate, objectAttributes,
+        parameterSet, allowExternalMu, WOLFTPM2_WRAP_DIGEST);
+}
 #endif /* WOLFTPM_MLDSA */
 
 #ifdef WOLFTPM_HASH_MLDSA
 /* GetKeyTemplate_HASH_MLDSA - Create a key template for Pre-Hash ML-DSA signing keys */
-int wolfTPM2_GetKeyTemplate_HASH_MLDSA(TPMT_PUBLIC* publicTemplate,
+int wolfTPM2_GetKeyTemplate_HASH_MLDSA_ex(TPMT_PUBLIC* publicTemplate,
     TPMA_OBJECT objectAttributes, TPMI_MLDSA_PARAMETER_SET parameterSet,
-    TPMI_ALG_HASH hashAlg)
+    TPMI_ALG_HASH hashAlg, TPMI_ALG_HASH nameAlg)
 {
     if (publicTemplate == NULL)
         return BAD_FUNC_ARG;
+
+    /* TPM_ALG_NULL selects the wrapper default name algorithm */
+    if (nameAlg == TPM_ALG_NULL)
+        nameAlg = WOLFTPM2_WRAP_DIGEST;
+    /* reject object Name hashes weaker than the wrapper default */
+    if (TPM2_GetHashDigestSize(nameAlg) <
+            TPM2_GetHashDigestSize(WOLFTPM2_WRAP_DIGEST)) {
+        return BAD_FUNC_ARG;
+    }
 
     /* TCG v185: HASH_MLDSA is sign-only. Enforce correct attributes. */
     objectAttributes &= ~TPMA_OBJECT_decrypt;
@@ -6165,21 +6223,39 @@ int wolfTPM2_GetKeyTemplate_HASH_MLDSA(TPMT_PUBLIC* publicTemplate,
 
     XMEMSET(publicTemplate, 0, sizeof(TPMT_PUBLIC));
     publicTemplate->type = TPM_ALG_HASH_MLDSA;
-    publicTemplate->nameAlg = TPM_ALG_SHA256;
+    publicTemplate->nameAlg = nameAlg;
     publicTemplate->objectAttributes = objectAttributes;
     publicTemplate->parameters.hash_mldsaDetail.parameterSet = parameterSet;
     publicTemplate->parameters.hash_mldsaDetail.hashAlg = hashAlg;
     return TPM_RC_SUCCESS;
 }
+
+int wolfTPM2_GetKeyTemplate_HASH_MLDSA(TPMT_PUBLIC* publicTemplate,
+    TPMA_OBJECT objectAttributes, TPMI_MLDSA_PARAMETER_SET parameterSet,
+    TPMI_ALG_HASH hashAlg)
+{
+    return wolfTPM2_GetKeyTemplate_HASH_MLDSA_ex(publicTemplate,
+        objectAttributes, parameterSet, hashAlg, WOLFTPM2_WRAP_DIGEST);
+}
 #endif /* WOLFTPM_HASH_MLDSA */
 
 #ifdef WOLFTPM_MLKEM
 /* GetKeyTemplate_MLKEM - Create a key template for ML-KEM decryption keys */
-int wolfTPM2_GetKeyTemplate_MLKEM(TPMT_PUBLIC* publicTemplate,
-    TPMA_OBJECT objectAttributes, TPMI_MLKEM_PARAMETER_SET parameterSet)
+int wolfTPM2_GetKeyTemplate_MLKEM_ex(TPMT_PUBLIC* publicTemplate,
+    TPMA_OBJECT objectAttributes, TPMI_MLKEM_PARAMETER_SET parameterSet,
+    TPMI_ALG_HASH nameAlg)
 {
     if (publicTemplate == NULL)
         return BAD_FUNC_ARG;
+
+    /* TPM_ALG_NULL selects the wrapper default name algorithm */
+    if (nameAlg == TPM_ALG_NULL)
+        nameAlg = WOLFTPM2_WRAP_DIGEST;
+    /* reject object Name hashes weaker than the wrapper default */
+    if (TPM2_GetHashDigestSize(nameAlg) <
+            TPM2_GetHashDigestSize(WOLFTPM2_WRAP_DIGEST)) {
+        return BAD_FUNC_ARG;
+    }
 
     /* TCG v185: MLKEM is decrypt-only. Enforce correct attributes. */
     objectAttributes &= ~TPMA_OBJECT_sign;
@@ -6187,12 +6263,19 @@ int wolfTPM2_GetKeyTemplate_MLKEM(TPMT_PUBLIC* publicTemplate,
 
     XMEMSET(publicTemplate, 0, sizeof(TPMT_PUBLIC));
     publicTemplate->type = TPM_ALG_MLKEM;
-    publicTemplate->nameAlg = TPM_ALG_SHA256;
+    publicTemplate->nameAlg = nameAlg;
     publicTemplate->objectAttributes = objectAttributes;
     publicTemplate->parameters.mlkemDetail.parameterSet = parameterSet;
     /* symmetric field: TPM_ALG_NULL for unrestricted key */
     publicTemplate->parameters.mlkemDetail.symmetric.algorithm = TPM_ALG_NULL;
     return TPM_RC_SUCCESS;
+}
+
+int wolfTPM2_GetKeyTemplate_MLKEM(TPMT_PUBLIC* publicTemplate,
+    TPMA_OBJECT objectAttributes, TPMI_MLKEM_PARAMETER_SET parameterSet)
+{
+    return wolfTPM2_GetKeyTemplate_MLKEM_ex(publicTemplate, objectAttributes,
+        parameterSet, WOLFTPM2_WRAP_DIGEST);
 }
 #endif /* WOLFTPM_MLKEM */
 
@@ -6423,8 +6506,9 @@ int wolfTPM2_ECDHEGenZ(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* parentKey,
 }
 
 
-int wolfTPM2_RsaEncrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
-    TPM_ALG_ID padScheme, const byte* msg, int msgSz, byte* out, int* outSz)
+int wolfTPM2_RsaEncrypt_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
+    TPM_ALG_ID padScheme, const byte* msg, int msgSz, byte* out, int* outSz,
+    TPMI_ALG_HASH hashAlg)
 {
     int rc;
     RSA_Encrypt_In  rsaEncIn;
@@ -6432,6 +6516,16 @@ int wolfTPM2_RsaEncrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 
     if (dev == NULL || key == NULL || msg == NULL || out == NULL ||
                                                                 outSz == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* TPM_ALG_NULL selects the wrapper default scheme hash */
+    if (hashAlg == TPM_ALG_NULL)
+        hashAlg = WOLFTPM2_WRAP_DIGEST;
+    /* OAEP MGF uses the scheme hash; reject weaker than the default */
+    if (padScheme == TPM_ALG_OAEP &&
+            TPM2_GetHashDigestSize(hashAlg) <
+            TPM2_GetHashDigestSize(WOLFTPM2_WRAP_DIGEST)) {
         return BAD_FUNC_ARG;
     }
 
@@ -6448,7 +6542,7 @@ int wolfTPM2_RsaEncrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     XMEMCPY(rsaEncIn.message.buffer, msg, rsaEncIn.message.size);
     /* TPM_ALG_NULL, TPM_ALG_OAEP, TPM_ALG_RSASSA or TPM_ALG_RSAPSS */
     rsaEncIn.inScheme.scheme = padScheme;
-    rsaEncIn.inScheme.details.anySig.hashAlg = WOLFTPM2_WRAP_DIGEST;
+    rsaEncIn.inScheme.details.anySig.hashAlg = hashAlg;
 
 #if 0
     /* Optional label */
@@ -6482,8 +6576,16 @@ int wolfTPM2_RsaEncrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     return rc;
 }
 
-int wolfTPM2_RsaDecrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
-    TPM_ALG_ID padScheme, const byte* in, int inSz, byte* msg, int* msgSz)
+int wolfTPM2_RsaEncrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
+    TPM_ALG_ID padScheme, const byte* msg, int msgSz, byte* out, int* outSz)
+{
+    return wolfTPM2_RsaEncrypt_ex(dev, key, padScheme, msg, msgSz, out, outSz,
+        WOLFTPM2_WRAP_DIGEST);
+}
+
+int wolfTPM2_RsaDecrypt_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
+    TPM_ALG_ID padScheme, const byte* in, int inSz, byte* msg, int* msgSz,
+    TPMI_ALG_HASH hashAlg)
 {
     int rc;
     RSA_Decrypt_In  rsaDecIn;
@@ -6491,6 +6593,16 @@ int wolfTPM2_RsaDecrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 
     if (dev == NULL || key == NULL || in == NULL || msg == NULL ||
                                                                 msgSz == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* TPM_ALG_NULL selects the wrapper default scheme hash */
+    if (hashAlg == TPM_ALG_NULL)
+        hashAlg = WOLFTPM2_WRAP_DIGEST;
+    /* OAEP MGF uses the scheme hash; reject weaker than the default */
+    if (padScheme == TPM_ALG_OAEP &&
+            TPM2_GetHashDigestSize(hashAlg) <
+            TPM2_GetHashDigestSize(WOLFTPM2_WRAP_DIGEST)) {
         return BAD_FUNC_ARG;
     }
 
@@ -6507,7 +6619,7 @@ int wolfTPM2_RsaDecrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     XMEMCPY(rsaDecIn.cipherText.buffer, in, inSz);
     /* TPM_ALG_NULL, TPM_ALG_OAEP, TPM_ALG_RSASSA or TPM_ALG_RSAPSS */
     rsaDecIn.inScheme.scheme = padScheme;
-    rsaDecIn.inScheme.details.anySig.hashAlg = WOLFTPM2_WRAP_DIGEST;
+    rsaDecIn.inScheme.details.anySig.hashAlg = hashAlg;
 
 #if 0
     /* Optional label */
@@ -6539,6 +6651,13 @@ int wolfTPM2_RsaDecrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     TPM2_ForceZero(&rsaDecOut, sizeof(rsaDecOut));
 
     return rc;
+}
+
+int wolfTPM2_RsaDecrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
+    TPM_ALG_ID padScheme, const byte* in, int inSz, byte* msg, int* msgSz)
+{
+    return wolfTPM2_RsaDecrypt_ex(dev, key, padScheme, in, inSz, msg, msgSz,
+        WOLFTPM2_WRAP_DIGEST);
 }
 
 int wolfTPM2_ResetPCR(WOLFTPM2_DEV* dev, int pcrIndex)

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -667,6 +667,56 @@ static void test_wolfTPM2_StartSession_SaltedEncryptAttrs(void)
 #endif
 }
 
+static void test_wolfTPM2_StartSession_ex_authHash(void)
+{
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && defined(WOLFSSL_SHA512)
+    int rc;
+    WOLFTPM2_DEV dev;
+    WOLFTPM2_SESSION session;
+
+    XMEMSET(&dev, 0, sizeof(dev));
+    XMEMSET(&session, 0, sizeof(session));
+
+    rc = wolfTPM2_Init(&dev, TPM2_IoCb, NULL);
+    if (rc != 0) {
+        printf("Test TPM Wrapper:\tStartSession_ex SHA512:\tSkipped\n");
+        return;
+    }
+
+    /* default (SHA-256) selected via TPM_ALG_NULL */
+    rc = wolfTPM2_StartSession_ex(&dev, &session, NULL, NULL,
+        TPM_SE_POLICY, TPM_ALG_NULL, TPM_ALG_NULL);
+    if (rc == TPM_RC_SUCCESS) {
+        AssertIntEQ(session.authHash, WOLFTPM2_WRAP_DIGEST);
+        wolfTPM2_UnloadHandle(&dev, &session.handle);
+    }
+
+    /* explicit SHA-512 selection */
+    rc = wolfTPM2_StartSession_ex(&dev, &session, NULL, NULL,
+        TPM_SE_POLICY, TPM_ALG_NULL, TPM_ALG_SHA512);
+    if (rc == TPM_RC_SUCCESS) {
+        AssertIntEQ(session.authHash, TPM_ALG_SHA512);
+        wolfTPM2_UnloadHandle(&dev, &session.handle);
+        printf("Test TPM Wrapper:\tStartSession_ex SHA512:\tPassed\n");
+    }
+    else {
+        printf("Test TPM Wrapper:\tStartSession_ex SHA512:\tSkipped\n");
+    }
+
+    /* a session hash weaker than the default is rejected (no TPM needed) */
+#ifndef NO_SHA
+    if (TPM2_GetHashDigestSize(TPM_ALG_SHA1) <
+            TPM2_GetHashDigestSize(WOLFTPM2_WRAP_DIGEST)) {
+        rc = wolfTPM2_StartSession_ex(&dev, &session, NULL, NULL,
+            TPM_SE_POLICY, TPM_ALG_NULL, TPM_ALG_SHA1);
+        AssertIntEQ(rc, BAD_FUNC_ARG);
+    }
+#endif
+
+    wolfTPM2_Cleanup(&dev);
+#endif
+}
+
 static void test_wolfTPM2_PolicyHash(void)
 {
 #ifndef WOLFTPM2_NO_WOLFCRYPT
@@ -2552,6 +2602,122 @@ static void test_wolfTPM2_RsaEncryptDecrypt_OversizedBufferE(void)
 
     printf("Test TPM Wrapper:\tRsaEncDec oversized:\t\tPassed\n");
 #endif
+}
+
+/* Exercise the _ex padding-scheme hash selection (e.g. SHA-512 OAEP). The
+ * BAD_FUNC_ARG and BUFFER_E paths fire before the TPM is contacted, so this
+ * does not require a working TPM connection. */
+static void test_wolfTPM2_RsaEncryptDecrypt_ex(void)
+{
+#if !defined(WOLFTPM2_NO_WOLFCRYPT) && !defined(NO_RSA)
+    int rc;
+    WOLFTPM2_DEV dev;
+    WOLFTPM2_KEY key;
+    byte oversized[MAX_RSA_KEY_BYTES + 16];
+    byte out[MAX_RSA_KEY_BYTES];
+    int outSz = (int)sizeof(out);
+
+    XMEMSET(&dev, 0, sizeof(dev));
+    XMEMSET(&key, 0, sizeof(key));
+    XMEMSET(oversized, 0xAB, sizeof(oversized));
+    key.handle.hndl = 0x80000000;
+
+    rc = wolfTPM2_RsaEncrypt_ex(NULL, &key, TPM_ALG_OAEP,
+        oversized, 1, out, &outSz, TPM_ALG_SHA512);
+    AssertIntEQ(rc, BAD_FUNC_ARG);
+
+    outSz = (int)sizeof(out);
+    rc = wolfTPM2_RsaEncrypt_ex(&dev, &key, TPM_ALG_OAEP,
+        oversized, (int)sizeof(oversized), out, &outSz, TPM_ALG_SHA512);
+    AssertIntEQ(rc, BUFFER_E);
+
+    outSz = (int)sizeof(out);
+    rc = wolfTPM2_RsaDecrypt_ex(&dev, &key, TPM_ALG_OAEP,
+        oversized, (int)sizeof(oversized), out, &outSz, TPM_ALG_SHA512);
+    AssertIntEQ(rc, BUFFER_E);
+
+#ifndef NO_SHA
+    /* OAEP with a hash weaker than the default is rejected */
+    if (TPM2_GetHashDigestSize(TPM_ALG_SHA1) <
+            TPM2_GetHashDigestSize(WOLFTPM2_WRAP_DIGEST)) {
+        outSz = (int)sizeof(out);
+        rc = wolfTPM2_RsaEncrypt_ex(&dev, &key, TPM_ALG_OAEP,
+            oversized, 1, out, &outSz, TPM_ALG_SHA1);
+        AssertIntEQ(rc, BAD_FUNC_ARG);
+    }
+#endif
+
+    printf("Test TPM Wrapper:\tRsaEncDec_ex SHA512:\t\tPassed\n");
+#endif
+}
+
+/* Verify the PQC key-template _ex wrappers select the object name algorithm
+ * and that the original wrappers keep the default. Pure struct population,
+ * no TPM required. */
+static void test_wolfTPM2_GetKeyTemplate_ex_nameAlg(void)
+{
+#if defined(WOLFTPM_PQC) && !defined(WOLFTPM2_NO_WOLFCRYPT)
+    int rc;
+    TPMT_PUBLIC pub;
+    TPMA_OBJECT attr = TPMA_OBJECT_fixedTPM | TPMA_OBJECT_fixedParent |
+        TPMA_OBJECT_sensitiveDataOrigin | TPMA_OBJECT_userWithAuth;
+
+#ifdef WOLFTPM_MLDSA
+    XMEMSET(&pub, 0, sizeof(pub));
+    rc = wolfTPM2_GetKeyTemplate_MLDSA(&pub, attr, TPM_MLDSA_65, 0);
+    AssertIntEQ(rc, TPM_RC_SUCCESS);
+    AssertIntEQ(pub.nameAlg, WOLFTPM2_WRAP_DIGEST);
+
+    rc = wolfTPM2_GetKeyTemplate_MLDSA_ex(&pub, attr, TPM_MLDSA_65, 0,
+        TPM_ALG_SHA512);
+    AssertIntEQ(rc, TPM_RC_SUCCESS);
+    AssertIntEQ(pub.nameAlg, TPM_ALG_SHA512);
+
+    rc = wolfTPM2_GetKeyTemplate_MLDSA_ex(&pub, attr, TPM_MLDSA_65, 0,
+        TPM_ALG_NULL);
+    AssertIntEQ(rc, TPM_RC_SUCCESS);
+    AssertIntEQ(pub.nameAlg, WOLFTPM2_WRAP_DIGEST);
+#endif
+
+#ifdef WOLFTPM_HASH_MLDSA
+    XMEMSET(&pub, 0, sizeof(pub));
+    rc = wolfTPM2_GetKeyTemplate_HASH_MLDSA(&pub, attr, TPM_MLDSA_65,
+        TPM_ALG_SHA256);
+    AssertIntEQ(rc, TPM_RC_SUCCESS);
+    AssertIntEQ(pub.nameAlg, WOLFTPM2_WRAP_DIGEST);
+
+    rc = wolfTPM2_GetKeyTemplate_HASH_MLDSA_ex(&pub, attr, TPM_MLDSA_65,
+        TPM_ALG_SHA256, TPM_ALG_SHA512);
+    AssertIntEQ(rc, TPM_RC_SUCCESS);
+    AssertIntEQ(pub.nameAlg, TPM_ALG_SHA512);
+#endif
+
+#ifdef WOLFTPM_MLKEM
+    XMEMSET(&pub, 0, sizeof(pub));
+    rc = wolfTPM2_GetKeyTemplate_MLKEM(&pub, attr, TPM_MLKEM_768);
+    AssertIntEQ(rc, TPM_RC_SUCCESS);
+    AssertIntEQ(pub.nameAlg, WOLFTPM2_WRAP_DIGEST);
+
+    rc = wolfTPM2_GetKeyTemplate_MLKEM_ex(&pub, attr, TPM_MLKEM_768,
+        TPM_ALG_SHA512);
+    AssertIntEQ(rc, TPM_RC_SUCCESS);
+    AssertIntEQ(pub.nameAlg, TPM_ALG_SHA512);
+
+#ifndef NO_SHA
+    /* a name algorithm weaker than the default is rejected */
+    if (TPM2_GetHashDigestSize(TPM_ALG_SHA1) <
+            TPM2_GetHashDigestSize(WOLFTPM2_WRAP_DIGEST)) {
+        rc = wolfTPM2_GetKeyTemplate_MLKEM_ex(&pub, attr, TPM_MLKEM_768,
+            TPM_ALG_SHA1);
+        AssertIntEQ(rc, BAD_FUNC_ARG);
+    }
+#endif
+#endif
+
+    (void)attr;
+    (void)rc;
+    printf("Test TPM Wrapper:\tGetKeyTemplate _ex nameAlg:\tPassed\n");
+#endif /* WOLFTPM_PQC */
 }
 
 /* TPM2_GetTpmCurve / TPM2_GetWolfCurve must map wolfCrypt's
@@ -5475,6 +5641,7 @@ int unit_tests(int argc, char *argv[])
     test_wolfTPM2_PolicyAuthValue_AuthOffset();
     test_wolfTPM2_SetAuthHandle_PolicyAuthOffset();
     test_wolfTPM2_StartSession_SaltedEncryptAttrs();
+    test_wolfTPM2_StartSession_ex_authHash();
     test_wolfTPM2_PolicyHash();
     test_wolfTPM2_SensitiveToPrivate();
     test_TPM2_KDFa();
@@ -5511,6 +5678,8 @@ int unit_tests(int argc, char *argv[])
     test_TPM2_BrainpoolCurveMapping();
     test_TPM2_EccDefaultCurveTemplate();
     test_wolfTPM2_RsaEncryptDecrypt_OversizedBufferE();
+    test_wolfTPM2_RsaEncryptDecrypt_ex();
+    test_wolfTPM2_GetKeyTemplate_ex_nameAlg();
     test_wolfTPM2_SignHashScheme_DigestSize();
     test_wolfTPM2_VerifyHashTicket_DigestSize();
     test_wolfTPM2_NVCreateAuthPolicy_NameAlg();

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -862,10 +862,35 @@ WOLFTPM_API int wolfTPM2_SetAuthHandleName(WOLFTPM2_DEV* dev, int index, const W
     \param encDecAlg integer value, specifying the algorithm in case of parameter encryption (TPM_ALG_CFB or TPM_ALG_XOR). Any value not CFB or XOR is considered NULL and parameter encryption is disabled.
 
     \sa wolfTPM2_SetAuthSession
+    \sa wolfTPM2_StartSession_ex
 */
 WOLFTPM_API int wolfTPM2_StartSession(WOLFTPM2_DEV* dev,
     WOLFTPM2_SESSION* session, WOLFTPM2_KEY* tpmKey,
     WOLFTPM2_HANDLE* bind, TPM_SE sesType, int encDecAlg);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Create a TPM session selecting the session auth/hash algorithm
+    \note Use this instead of wolfTPM2_StartSession when the session digest must match a non-default hash, such as SHA-512 policy digests in post-quantum environments
+
+    \return TPM_RC_SUCCESS: successful
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a TPM2_DEV struct
+    \param session pointer to an empty WOLFTPM2_SESSION struct
+    \param tpmKey pointer to a WOLFTPM2_KEY that will be used as a salt for the session
+    \param bind pointer to a WOLFTPM2_HANDLE that will be used to make the session bounded
+    \param sesType byte value, the session type (HMAC, Policy or Trial)
+    \param encDecAlg integer value, specifying the algorithm in case of parameter encryption (TPM_ALG_CFB or TPM_ALG_XOR). Any value not CFB or XOR is considered NULL and parameter encryption is disabled.
+    \param authHash hash algorithm for the session (for example TPM_ALG_SHA256 or TPM_ALG_SHA512). TPM_ALG_NULL selects the wrapper default.
+
+    \sa wolfTPM2_StartSession
+    \sa wolfTPM2_SetAuthSession
+*/
+WOLFTPM_API int wolfTPM2_StartSession_ex(WOLFTPM2_DEV* dev,
+    WOLFTPM2_SESSION* session, WOLFTPM2_KEY* tpmKey,
+    WOLFTPM2_HANDLE* bind, TPM_SE sesType, int encDecAlg,
+    TPMI_ALG_HASH authHash);
 
 /*!
     \ingroup wolfTPM2_Wrappers
@@ -884,6 +909,26 @@ WOLFTPM_API int wolfTPM2_StartSession(WOLFTPM2_DEV* dev,
 */
 WOLFTPM_API int wolfTPM2_CreateAuthSession_EkPolicy(WOLFTPM2_DEV* dev,
                                                     WOLFTPM2_SESSION* tpmSession);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Creates a TPM EK policy session selecting the session auth/hash algorithm
+    \note This wrapper can be used only if the EK authorization is not changed from default
+
+    \return TPM_RC_SUCCESS: successful
+    \return BAD_FUNC_ARG: check the provided arguments
+    \return TPM_RC_FAILURE: check TPM return code, check available handles, check TPM IO
+
+    \param dev pointer to a TPM2_DEV struct
+    \param tpmSession pointer to an empty WOLFTPM2_SESSION struct
+    \param authHash hash algorithm for the session (for example TPM_ALG_SHA256 or TPM_ALG_SHA512). TPM_ALG_NULL selects the wrapper default.
+
+    \sa wolfTPM2_CreateAuthSession_EkPolicy
+    \sa wolfTPM2_StartSession_ex
+*/
+WOLFTPM_API int wolfTPM2_CreateAuthSession_EkPolicy_ex(WOLFTPM2_DEV* dev,
+                                                    WOLFTPM2_SESSION* tpmSession,
+                                                    TPMI_ALG_HASH authHash);
 
 /*!
     \ingroup wolfTPM2_Wrappers
@@ -2373,6 +2418,24 @@ WOLFTPM_API int wolfTPM2_GetKeyTemplate_MLDSA(TPMT_PUBLIC* publicTemplate,
 
 /*!
     \ingroup wolfTPM2_Wrappers
+    \brief Create an ML-DSA key template selecting the name algorithm (TCG v185)
+    \return TPM_RC_SUCCESS on success, BAD_FUNC_ARG if publicTemplate is NULL
+    \param publicTemplate Pointer to TPMT_PUBLIC structure to populate
+    \param objectAttributes Key attributes (sign flag will be enforced, decrypt cleared)
+    \param parameterSet ML-DSA parameter set (TPM_MLDSA_44, TPM_MLDSA_65, or TPM_MLDSA_87)
+    \param allowExternalMu Non-zero to allow TPM2_SignDigest/VerifyDigestSignature
+    \param nameAlg Object name algorithm (e.g. TPM_ALG_SHA512). TPM_ALG_NULL selects the wrapper default.
+
+    \sa wolfTPM2_GetKeyTemplate_MLDSA
+*/
+#ifdef WOLFTPM_MLDSA
+WOLFTPM_API int wolfTPM2_GetKeyTemplate_MLDSA_ex(TPMT_PUBLIC* publicTemplate,
+    TPMA_OBJECT objectAttributes, TPMI_MLDSA_PARAMETER_SET parameterSet,
+    int allowExternalMu, TPMI_ALG_HASH nameAlg);
+#endif
+
+/*!
+    \ingroup wolfTPM2_Wrappers
     \brief Create a key template for Pre-Hash ML-DSA signing keys (TCG v185)
     \return TPM_RC_SUCCESS on success, BAD_FUNC_ARG if publicTemplate is NULL
     \param publicTemplate Pointer to TPMT_PUBLIC structure to populate
@@ -2389,6 +2452,24 @@ WOLFTPM_API int wolfTPM2_GetKeyTemplate_HASH_MLDSA(TPMT_PUBLIC* publicTemplate,
 
 /*!
     \ingroup wolfTPM2_Wrappers
+    \brief Create a Pre-Hash ML-DSA key template selecting the name algorithm (TCG v185)
+    \return TPM_RC_SUCCESS on success, BAD_FUNC_ARG if publicTemplate is NULL
+    \param publicTemplate Pointer to TPMT_PUBLIC structure to populate
+    \param objectAttributes Key attributes (sign flag will be enforced, decrypt cleared)
+    \param parameterSet ML-DSA parameter set (TPM_MLDSA_44, TPM_MLDSA_65, or TPM_MLDSA_87)
+    \param hashAlg Pre-hash algorithm (e.g., TPM_ALG_SHA256)
+    \param nameAlg Object name algorithm (e.g. TPM_ALG_SHA512). TPM_ALG_NULL selects the wrapper default.
+
+    \sa wolfTPM2_GetKeyTemplate_HASH_MLDSA
+*/
+#ifdef WOLFTPM_HASH_MLDSA
+WOLFTPM_API int wolfTPM2_GetKeyTemplate_HASH_MLDSA_ex(TPMT_PUBLIC* publicTemplate,
+    TPMA_OBJECT objectAttributes, TPMI_MLDSA_PARAMETER_SET parameterSet,
+    TPMI_ALG_HASH hashAlg, TPMI_ALG_HASH nameAlg);
+#endif
+
+/*!
+    \ingroup wolfTPM2_Wrappers
     \brief Create a key template for ML-KEM decryption keys (TCG v185)
     \return TPM_RC_SUCCESS on success, BAD_FUNC_ARG if publicTemplate is NULL
     \param publicTemplate Pointer to TPMT_PUBLIC structure to populate
@@ -2400,6 +2481,23 @@ WOLFTPM_API int wolfTPM2_GetKeyTemplate_HASH_MLDSA(TPMT_PUBLIC* publicTemplate,
 */
 WOLFTPM_API int wolfTPM2_GetKeyTemplate_MLKEM(TPMT_PUBLIC* publicTemplate,
     TPMA_OBJECT objectAttributes, TPMI_MLKEM_PARAMETER_SET parameterSet);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Create an ML-KEM key template selecting the name algorithm (TCG v185)
+    \return TPM_RC_SUCCESS on success, BAD_FUNC_ARG if publicTemplate is NULL
+    \param publicTemplate Pointer to TPMT_PUBLIC structure to populate
+    \param objectAttributes Key attributes (decrypt flag will be enforced, sign cleared)
+    \param parameterSet ML-KEM parameter set (TPM_MLKEM_512, TPM_MLKEM_768, or TPM_MLKEM_1024)
+    \param nameAlg Object name algorithm (e.g. TPM_ALG_SHA512). TPM_ALG_NULL selects the wrapper default.
+
+    \sa wolfTPM2_GetKeyTemplate_MLKEM
+*/
+#ifdef WOLFTPM_MLKEM
+WOLFTPM_API int wolfTPM2_GetKeyTemplate_MLKEM_ex(TPMT_PUBLIC* publicTemplate,
+    TPMA_OBJECT objectAttributes, TPMI_MLKEM_PARAMETER_SET parameterSet,
+    TPMI_ALG_HASH nameAlg);
+#endif
 #endif /* WOLFTPM_PQC */
 
 /*!
@@ -2538,6 +2636,30 @@ WOLFTPM_API int wolfTPM2_RsaEncrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 
 /*!
     \ingroup wolfTPM2_Wrappers
+    \brief Perform RSA encryption selecting the padding scheme hash algorithm
+
+    \return TPM_RC_SUCCESS: successful
+    \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a TPM2_DEV struct
+    \param key pointer to a struct of WOLFTPM2_KEY type, holding a TPM key material
+    \param padScheme integer value of TPM_ALG_ID type, specifying the padding scheme
+    \param msg pointer to a byte buffer, containing the arbitrary data for encryption
+    \param msgSz integer value, specifying the size of the arbitrary data buffer
+    \param out pointer to a byte buffer, where the encrypted data will be stored
+    \param outSz integer value, specifying the size of the encrypted data buffer
+    \param hashAlg hash for the padding scheme (e.g. TPM_ALG_SHA512 for OAEP). TPM_ALG_NULL selects the wrapper default.
+
+    \sa wolfTPM2_RsaEncrypt
+    \sa wolfTPM2_RsaDecrypt_ex
+*/
+WOLFTPM_API int wolfTPM2_RsaEncrypt_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
+    TPM_ALG_ID padScheme, const byte* msg, int msgSz, byte* out, int* outSz,
+    TPMI_ALG_HASH hashAlg);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
     \brief Perform RSA decryption using a TPM 2.0 key
 
     \return TPM_RC_SUCCESS: successful
@@ -2556,6 +2678,30 @@ WOLFTPM_API int wolfTPM2_RsaEncrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
 */
 WOLFTPM_API int wolfTPM2_RsaDecrypt(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
     TPM_ALG_ID padScheme, const byte* in, int inSz, byte* msg, int* msgSz);
+
+/*!
+    \ingroup wolfTPM2_Wrappers
+    \brief Perform RSA decryption selecting the padding scheme hash algorithm
+
+    \return TPM_RC_SUCCESS: successful
+    \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)
+    \return BAD_FUNC_ARG: check the provided arguments
+
+    \param dev pointer to a TPM2_DEV struct
+    \param key pointer to a struct of WOLFTPM2_KEY type, holding a TPM key material
+    \param padScheme integer value of TPM_ALG_ID type, specifying the padding scheme
+    \param in pointer to a byte buffer, containing the encrypted data
+    \param inSz integer value, specifying the size of the encrypted data buffer
+    \param msg pointer to a byte buffer, containing the decrypted data
+    \param[in,out] msgSz pointer to size of the encrypted data buffer, on return set actual size
+    \param hashAlg hash for the padding scheme (e.g. TPM_ALG_SHA512 for OAEP). TPM_ALG_NULL selects the wrapper default.
+
+    \sa wolfTPM2_RsaDecrypt
+    \sa wolfTPM2_RsaEncrypt_ex
+*/
+WOLFTPM_API int wolfTPM2_RsaDecrypt_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* key,
+    TPM_ALG_ID padScheme, const byte* in, int inSz, byte* msg, int* msgSz,
+    TPMI_ALG_HASH hashAlg);
 
 
 /*!


### PR DESCRIPTION
# Description 

- Add _ex wrapper so callers can easily pick hash algo instead of hard coded sha-256
- Session/policy: wolfTPM2_StartSession_ex, wolfTPM2_CreateAuthSession_EkPolicy_ex (adds authHash) — the original ask, so encrypted SHA-512
  policy sessions match
- RSA: wolfTPM2_RsaEncrypt_ex / RsaDecrypt_ex (adds OAEP hashAlg)
- PQC templates: wolfTPM2_GetKeyTemplate_MLDSA_ex / HASH_MLDSA_ex  /MLKEM_ex (adds nameAlg)

ZD 22037