### PR TITLE
Fix 4 Coverity findings (fwTPM PolicyNV, listen socket, secret_seal)

### DIFF
--- a/examples/boot/secret_seal.c
+++ b/examples/boot/secret_seal.c
@@ -116,7 +116,7 @@ int TPM2_Boot_SecretSeal_Example(void* userCtx, int argc, char *argv[])
     word32 secretSz = 0;
     const char* publicKeyFile = NULL;
     const char* outFile = "sealblob.bin";
-    const char* policyFile = "policyauth.bin";
+    const char* policyFile = NULL;
     byte policyDigest[WC_MAX_DIGEST_SIZE];
     word32 policyDigestSz = 0;
 
@@ -151,9 +151,16 @@ int TPM2_Boot_SecretSeal_Example(void* userCtx, int argc, char *argv[])
         else if (XSTRNCMP(argv[argc-1], "-secrethex=", XSTRLEN("-secrethex=")) == 0) {
             const char* secretStr = argv[argc-1] + XSTRLEN("-secrethex=");
             word32 secretStrSz = (word32)XSTRLEN(secretStr);
+            int secretHexSz;
             if (secretStrSz > (word32)(sizeof(secret)*2-1))
                 secretStrSz = (word32)(sizeof(secret)*2-1);
-            secretSz = hexToByte(secretStr, secret, secretStrSz);
+            secretHexSz = hexToByte(secretStr, secret, secretStrSz);
+            if (secretHexSz < 0) {
+                printf("Invalid secret hex string\n");
+                usage();
+                return -1;
+            }
+            secretSz = (word32)secretHexSz;
         }
         else if (XSTRNCMP(argv[argc-1], "-policy=",
                 XSTRLEN("-policy=")) == 0) {

--- a/src/fwtpm/fwtpm_command.c
+++ b/src/fwtpm/fwtpm_command.c
@@ -9948,14 +9948,24 @@ static TPM_RC FwCmd_PolicyNV(FWTPM_CTX* ctx, TPM2_Packet* cmd,
         }
     }
     if (rc == 0 && operandBSz > 0) {
-        wc_HashUpdate(hashCtx, wcHash, operandB, operandBSz);
+        if (wc_HashUpdate(hashCtx, wcHash, operandB, operandBSz) != 0)
+            rc = TPM_RC_FAILURE;
     }
     if (rc == 0) {
         FwStoreU16BE(tmpBuf, offset);
-        wc_HashUpdate(hashCtx, wcHash, tmpBuf, 2);
+        if (wc_HashUpdate(hashCtx, wcHash, tmpBuf, 2) != 0)
+            rc = TPM_RC_FAILURE;
+    }
+    if (rc == 0) {
         FwStoreU16BE(tmpBuf, operation);
-        wc_HashUpdate(hashCtx, wcHash, tmpBuf, 2);
-        wc_HashFinal(hashCtx, wcHash, argsHash);
+        if (wc_HashUpdate(hashCtx, wcHash, tmpBuf, 2) != 0)
+            rc = TPM_RC_FAILURE;
+    }
+    if (rc == 0) {
+        if (wc_HashFinal(hashCtx, wcHash, argsHash) != 0)
+            rc = TPM_RC_FAILURE;
+    }
+    if (rc == 0) {
         wc_HashFree(hashCtx, wcHash);
         hashCtxInit = 0;
     }
@@ -9972,15 +9982,28 @@ static TPM_RC FwCmd_PolicyNV(FWTPM_CTX* ctx, TPM2_Packet* cmd,
         }
     }
     if (rc == 0) {
-        wc_HashUpdate(hashCtx, wcHash,
-            sess->policyDigest.buffer, sess->policyDigest.size);
+        if (wc_HashUpdate(hashCtx, wcHash,
+                sess->policyDigest.buffer, sess->policyDigest.size) != 0)
+            rc = TPM_RC_FAILURE;
+    }
+    if (rc == 0) {
         FwStoreU32BE(ccBuf, cc);
-        wc_HashUpdate(hashCtx, wcHash, ccBuf, 4);
-        wc_HashUpdate(hashCtx, wcHash, argsHash, dSz);
-        if (nvNameSz > 0) {
-            wc_HashUpdate(hashCtx, wcHash, nvName, nvNameSz);
-        }
-        wc_HashFinal(hashCtx, wcHash, sess->policyDigest.buffer);
+        if (wc_HashUpdate(hashCtx, wcHash, ccBuf, 4) != 0)
+            rc = TPM_RC_FAILURE;
+    }
+    if (rc == 0) {
+        if (wc_HashUpdate(hashCtx, wcHash, argsHash, dSz) != 0)
+            rc = TPM_RC_FAILURE;
+    }
+    if (rc == 0 && nvNameSz > 0) {
+        if (wc_HashUpdate(hashCtx, wcHash, nvName, nvNameSz) != 0)
+            rc = TPM_RC_FAILURE;
+    }
+    if (rc == 0) {
+        if (wc_HashFinal(hashCtx, wcHash, sess->policyDigest.buffer) != 0)
+            rc = TPM_RC_FAILURE;
+    }
+    if (rc == 0) {
         sess->policyDigest.size = (UINT16)dSz;
         wc_HashFree(hashCtx, wcHash);
         hashCtxInit = 0;

--- a/src/fwtpm/fwtpm_io.c
+++ b/src/fwtpm/fwtpm_io.c
@@ -169,8 +169,12 @@ static SOCKET_T CreateListenSocket(int port)
         return FWTPM_INVALID_FD;
     }
 
-    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR,
-        (const char*)&optval, sizeof(optval));
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR,
+            (const char*)&optval, sizeof(optval)) != 0) {
+    #ifdef DEBUG_WOLFTPM
+        printf("fwTPM: setsockopt(SO_REUSEADDR) failed\n");
+    #endif
+    }
 
     XMEMSET(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;


### PR DESCRIPTION
Fixes four genuine Coverity findings from the latest scan. The remaining 19 outstanding CIDs were reviewed and dismissed as false positives (config-dependent dead-branch templates, and TPM/file values already bounded or MAC-authenticated before use).

## Fixes

- **CID 909308** `FwCmd_PolicyNV` (`src/fwtpm/fwtpm_command.c`) — logically dead error-cleanup. The `if (hashCtxInit) wc_HashFree(...)` block was unreachable because the intermediate `wc_HashUpdate`/`wc_HashFinal` return codes were ignored, so `rc` could never become non-zero between init and the inline free. Now every hash return is checked and the free is deferred on failure, making the bottom cleanup live and closing the unchecked-return gap.
- **CID 909295** `CreateListenSocket` (`src/fwtpm/fwtpm_io.c`) — unchecked `setsockopt(SO_REUSEADDR)` return. Checked with a non-fatal `DEBUG_WOLFTPM`-gated diagnostic (the option is advisory).
- **CID 483395** `TPM2_Boot_SecretSeal_Example` (`examples/boot/secret_seal.c`) — improper use of negative value. `hexToByte()` returns `-1` on malformed hex, which wrapped into `word32 secretSz` as `0xFFFFFFFF`; the `secretSz <= 0` guard could not catch it, leading to an over-read. Now captured in an `int` and rejected when negative.
- **CID 483392** `TPM2_Boot_SecretSeal_Example` (`examples/boot/secret_seal.c`) — logically dead code. `policyFile` defaulted to `"policyauth.bin"`, so the `-publickey=` branch (a documented README example) was unreachable. Default is now `NULL`, matching the `publicKeyFile` sibling, so all branches are reachable.

## Testing

All three modified files pass `gcc -fsyntax-only`.