### PR TITLE
Coverity CID 910531/910532: bound decrypted seed length and clamp packet parse offset

### DIFF
--- a/src/fwtpm/fwtpm_command.c
+++ b/src/fwtpm/fwtpm_command.c
@@ -8423,7 +8423,8 @@ static TPM_RC FwCmd_StartAuthSession(FWTPM_CTX* ctx, TPM2_Packet* cmd,
         }
         /* Then append salt if present */
         if (rc == 0 && saltSize > 0) {
-            if (keyInSz + saltSize <= (int)sizeof(keyIn)) {
+            if (keyInSz + saltSize <= (int)sizeof(keyIn) &&
+                saltSize <= (int)sizeof(salt)) {
                 XMEMCPY(keyIn + keyInSz, salt, saltSize);
                 keyInSz += saltSize;
             }

--- a/src/fwtpm/fwtpm_crypto.c
+++ b/src/fwtpm/fwtpm_crypto.c
@@ -2447,6 +2447,11 @@ TPM_RC FwDecryptSeed(FWTPM_CTX* ctx,
                 TPM2_ForceZero(seedBuf, seedBufSz);
                 rc = TPM_RC_FAILURE;
             }
+            else if (rc > seedBufSz) {
+                /* Bound output to caller buffer */
+                TPM2_ForceZero(seedBuf, seedBufSz);
+                rc = TPM_RC_FAILURE;
+            }
             else {
                 *seedSzOut = rc;
                 rc = 0;

--- a/src/tpm2_packet.c
+++ b/src/tpm2_packet.c
@@ -257,7 +257,13 @@ void TPM2_Packet_ParseBytes(TPM2_Packet* packet, byte* buf, int size)
                 XMEMCPY(buf, &packet->buf[packet->pos], sizeToCopy);
             }
         }
-        packet->pos += size;
+        if (size > 0 && packet->pos + size > packet->size) {
+            /* Clamp pos on truncated read */
+            packet->pos = packet->size;
+        }
+        else {
+            packet->pos += size;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes Coverity CID 910531 (OVERRUN) and CID 910532 (TAINTED_SCALAR). 
* 910531: FwDecryptSeed() now fails closed if a decrypted seed exceeds the caller's buffer, bounding saltSize in FwCmd_StartAuthSession() (covers all four seed-decrypt callers). 
* 910532: TPM2_Packet_ParseBytes() clamps pos to size on a truncated read so a tainted length can't run the parse offset past the buffer.