### PR TITLE
Bound response parameterSize, fix SPI auto-detect off-by-one, document import dual-use default

### DIFF
--- a/hal/tpm_io_linux.c
+++ b/hal/tpm_io_linux.c
@@ -393,7 +393,7 @@
             else {
                 devLen = (int)XSTRLEN(TPM2_SPI_DEV);
                 /* tries spidev0.[0-4] */
-                if (TPM2_SPI_DEV[devLen-1] <= MAX_SPI_DEV_CS) {
+                if (TPM2_SPI_DEV[devLen-1] < MAX_SPI_DEV_CS) {
                     TPM2_SPI_DEV[devLen-1]++;
                     goto tryagain;
                 }

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -293,7 +293,7 @@ static int TPM2_CommandProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
     return rc;
 }
 
-static int TPM2_ResponseProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
+int TPM2_ResponseProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
     CmdInfo_t* info, TPM_CC cmdCode, UINT32 respSz)
 {
     int rc = TPM_RC_SUCCESS;
@@ -306,6 +306,11 @@ static int TPM2_ResponseProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
 
     /* Response Parameter Size */
     TPM2_Packet_ParseU32(packet, &paramSz);
+    /* Bound paramSz to the response so authPos cannot wrap past the buffer */
+    if ((UINT32)packet->pos > respSz ||
+            paramSz > respSz - (UINT32)packet->pos) {
+        return TPM_RC_SIZE;
+    }
     param = &packet->buf[packet->pos]; /* Mark parameter data */
     authPos = packet->pos + paramSz;
 

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -2874,6 +2874,79 @@ static void test_TPM2_Packet_RetryRestore(void)
 }
 #endif /* !WOLFTPM_NO_RETRY */
 
+/* A sessioned response whose attacker-controlled parameterSize wraps UINT32
+ * when added to packet->pos must be rejected up front. Without the bounds
+ * check the wrapped authPos passes the "respSz > authPos" guard and the
+ * oversized parameterSize flows into TPM2_CalcRpHash as an out-of-bounds
+ * read length. The bounds check itself is build-independent. */
+static void test_TPM2_ResponseProcess_ParamSizeOverflow(void)
+{
+    TPM2_CTX ctx;
+    TPM2_AUTH_SESSION session[1];
+    TPM2_Packet packet;
+    CmdInfo_t info;
+    byte buf[128];
+    int rc;
+
+    XMEMSET(&ctx, 0, sizeof(ctx));
+    XMEMSET(session, 0, sizeof(session));
+    XMEMSET(&info, 0, sizeof(info));
+    XMEMSET(buf, 0, sizeof(buf));
+
+    /* parameterSize field at offset TPM2_HEADER_SIZE: 0xFFFFFFF8 makes
+     * authPos = pos + paramSz wrap to a small in-range value */
+    buf[TPM2_HEADER_SIZE + 0] = 0xFF;
+    buf[TPM2_HEADER_SIZE + 1] = 0xFF;
+    buf[TPM2_HEADER_SIZE + 2] = 0xFF;
+    buf[TPM2_HEADER_SIZE + 3] = 0xF8;
+
+    session[0].sessionHandle = HMAC_SESSION_FIRST;
+    session[0].authHash = TPM_ALG_SHA256;
+    ctx.session = session;
+
+    info.authCnt = 1;
+    info.inHandleCnt = 0;
+    info.outHandleCnt = 0;
+    info.flags = 0;
+
+    packet.buf = buf;
+    packet.pos = 0;
+    packet.size = (int)sizeof(buf);
+
+    rc = TPM2_ResponseProcess(&ctx, &packet, &info, (TPM_CC)0,
+        (UINT32)sizeof(buf));
+    AssertIntEQ(rc, TPM_RC_SIZE);
+
+    /* A valid in-range parameterSize must not be rejected */
+    XMEMSET(buf, 0, sizeof(buf));
+    buf[TPM2_HEADER_SIZE + 3] = 0x04;
+    info.authCnt = 0;
+    packet.pos = 0;
+    packet.size = (int)sizeof(buf);
+
+    rc = TPM2_ResponseProcess(&ctx, &packet, &info, (TPM_CC)0,
+        (UINT32)sizeof(buf));
+    AssertIntEQ(rc, TPM_RC_SUCCESS);
+
+    /* A response too small to hold the parsed parameterSize must be rejected */
+    packet.pos = 0;
+    packet.size = (int)sizeof(buf);
+    rc = TPM2_ResponseProcess(&ctx, &packet, &info, (TPM_CC)0,
+        (UINT32)(TPM2_HEADER_SIZE + 2));
+    AssertIntEQ(rc, TPM_RC_SIZE);
+
+    /* An exact-fit parameterSize (paramSz == respSz - pos) must be accepted */
+    XMEMSET(buf, 0, sizeof(buf));
+    buf[TPM2_HEADER_SIZE + 3] = (byte)(sizeof(buf) - (TPM2_HEADER_SIZE + 4));
+    packet.pos = 0;
+    packet.size = (int)sizeof(buf);
+    rc = TPM2_ResponseProcess(&ctx, &packet, &info, (TPM_CC)0,
+        (UINT32)sizeof(buf));
+    AssertIntEQ(rc, TPM_RC_SUCCESS);
+
+    printf("Test TPM Wrapper:\tResponseProcess paramSize overflow:\tPassed\n");
+}
+
 /* wolfTPM2_NVCreateAuthPolicy must derive nameAlg from authPolicySz so
  * the policy digest hash matches the index's nameAlg. Bug-mode hardcoded
  * SHA-256 nameAlg, which made SHA-384/SHA-512 policies unsatisfiable.
@@ -6069,6 +6142,7 @@ int unit_tests(int argc, char *argv[])
     test_TPM2_CommandRetries();
     test_TPM2_Packet_RetryRestore();
 #endif
+    test_TPM2_ResponseProcess_ParamSizeOverflow();
     test_wolfTPM2_NVCreateAuthPolicy_NameAlg();
     test_wolfTPM2_GetKeyTemplate_KeyedHash_Scheme();
     test_wolfTPM2_LoadEccPublicKey_Ex();

--- a/wolftpm/tpm2_packet.h
+++ b/wolftpm/tpm2_packet.h
@@ -248,6 +248,8 @@ WOLFTPM_TEST_API int TPM2_Packet_RetryRestore(TPM_RC rc, int* retries,
 
 
 WOLFTPM_LOCAL int TPM2_GetCmdAuthCount(TPM2_CTX* ctx, const CmdInfo_t* info);
+WOLFTPM_TEST_API int TPM2_ResponseProcess(TPM2_CTX* ctx, TPM2_Packet* packet,
+    CmdInfo_t* info, TPM_CC cmdCode, UINT32 respSz);
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -1237,6 +1237,10 @@ WOLFTPM_API int wolfTPM2_LoadRsaPublicKey_ex(WOLFTPM2_DEV* dev, WOLFTPM2_KEY* ke
     \param scheme value of TPMI_ALG_RSA_SCHEME type, specifying the RSA scheme
     \param hashAlg integer value of TPMI_ALG_HASH type, specifying a supported TPM 2.0 hash algorithm
 
+    \note The imported key is created with both sign and decrypt usage. To
+    import a single-purpose key, call wolfTPM2_ImportRsaPrivateKeySeed with a
+    restricted objectAttributes set.
+
     \sa wolfTPM2_ImportRsaPrivateKeySeed
     \sa wolfTPM2_LoadRsaPrivateKey
     \sa wolfTPM2_LoadRsaPrivateKey_ex
@@ -1427,6 +1431,10 @@ WOLFTPM_API int wolfTPM2_LoadEccPublicKey_ex(WOLFTPM2_DEV* dev,
     \param eccPubYSz integer value of word32 type, specifying the point Y buffer size
     \param eccPriv pointer to a byte buffer containing the private material
     \param eccPrivSz integer value of word32 type, specifying the private material size
+
+    \note The imported key is created with both sign and decrypt usage. To
+    import a single-purpose key, call wolfTPM2_ImportEccPrivateKeySeed with a
+    restricted objectAttributes set.
 
     \sa wolfTPM2_ImportEccPrivateKeySeed
     \sa wolfTPM2_LoadEccPrivateKey


### PR DESCRIPTION
```
F-6554, F-6551, F-6552
```