### PR TITLE
Fix WOLFTPM_IS_COMMAND_UNAVAILABLE to handle vendor error code variants

### DIFF
--- a/wolftpm/tpm2.h
+++ b/wolftpm/tpm2.h
@@ -2151,9 +2151,9 @@ struct wolfTPM_winContext {
 #define TPM_E_COMMAND_BLOCKED (0x80280400)
 #endif
 
-#define WOLFTPM_IS_COMMAND_UNAVAILABLE(code) ((code) == (int)TPM_RC_COMMAND_CODE || (code) == (int)TPM_E_COMMAND_BLOCKED)
+#define WOLFTPM_IS_COMMAND_UNAVAILABLE(code) (((code) & 0x1FF) == (int)TPM_RC_COMMAND_CODE || (code) == (int)TPM_E_COMMAND_BLOCKED)
 #else
-#define WOLFTPM_IS_COMMAND_UNAVAILABLE(code) (code == (int)TPM_RC_COMMAND_CODE)
+#define WOLFTPM_IS_COMMAND_UNAVAILABLE(code) (((code) & 0x1FF) == (int)TPM_RC_COMMAND_CODE)
 #endif /* WOLFTPM_WINAPI */
 
 /* make sure advanced IO is enabled for I2C */


### PR DESCRIPTION
## Summary
Some TPM chips (e.g. Nations Technologies NS350) return TPM_RC_COMMAND_CODE
with additional vendor bits set (0xb0143 instead of the standard 0x143).
The `WOLFTPM_IS_COMMAND_UNAVAILABLE` macro previously used exact equality,
causing it to fail to recognize these vendor-extended error codes. This
resulted in the bench program treating the error as fatal and aborting
before reaching SHA/RSA/ECC benchmarks.
<img width="575" height="253" alt="图片" src="https://github.com/user-attachments/assets/bbff6e35-98eb-40ad-a2dd-9f12c87860a8" />
## Fix
Apply a `0x1FF` mask to compare only the base VER1 error code bits,
stripping any vendor-specific high bits. This matches the approach already
used elsewhere in the codebase (e.g. `(rc & TPM_RC_MODE) == TPM_RC_MODE`).
## Verified
Tested on Nations Technologies NS350 TPM 2.0 module. After this fix, the
bench program correctly skips symmetric encryption tests and continues
to produce SHA, RSA, and ECC benchmark results.

<img width="782" height="784" alt="图片" src="https://github.com/user-attachments/assets/8038ba77-cd12-4674-b8a7-77a70d429c6e" />

