### PR TITLE
fix edge case build with tis lock and no wolfcrypt

### DIFF
--- a/src/tpm2_tis.c
+++ b/src/tpm2_tis.c
@@ -96,6 +96,7 @@ enum tpm_tis_status {
         #include <fcntl.h>
         #include <sys/stat.h>
         #include <errno.h>
+        #include <time.h>
 
         #define SEM_NAME "/wolftpm"
         #define SEM_PERMS (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP)


### PR DESCRIPTION
Error was :

```
m_io_st.c' || echo '../git/'`hal/tpm_io_st.c
| ../git/src/tpm2_tis.c: In function 'TPM2_TIS_Lock':
| ../git/src/tpm2_tis.c:113:17: warning: implicit declaration of function 'clock_gettime' [-Wimplicit-function-declaration]
|   113 |                 clock_gettime(CLOCK_REALTIME, &timeoutTime);
|       |                 ^~~~~~~~~~~~~
| ../git/src/tpm2_tis.c:113:17: warning: nested extern declaration of 'clock_gettime' [-Wnested-externs]
| ../git/src/tpm2_tis.c:113:31: error: 'CLOCK_REALTIME' undeclared (first use in this function)
|   113 |                 clock_gettime(CLOCK_REALTIME, &timeoutTime);
|       |                               ^~~~~~~~~~~~~~
```

When building using Yocto recipe and configure of `EXTRA_OECONF = "--disable-wolfcrypt --enable-hal --enable-infineon=slb9670 --enable-tislock"`