### PR TITLE
Add support for the NVIDIA Jetson Orin OP-TEE firmware TPM

### DIFF
--- a/.github/workflows/make-test-swtpm.yml
+++ b/.github/workflows/make-test-swtpm.yml
@@ -193,6 +193,19 @@ jobs:
             needs_swtpm: false
             test_command: "true"
 
+          # Kernel-device autodetect: /dev/tpmrm0 -> /dev/tpm0 -> SPI fallback.
+          # The only entry defining WOLFTPM_LINUX_DEV_AUTODETECT, so it is also
+          # the only one compiling that path's DEBUG_WOLFTPM code -- hence
+          # --enable-debug, which keeps those printfs under a compiler.
+          # Build-only: the runner has no /dev/tpm* and this config cannot talk
+          # to swtpm, so wolfTPM2_Init has no transport and unit.test fails at
+          # its first assertion. Runtime coverage needs a self-hosted runner
+          # with a kernel-bound TPM -- see docs/DEVTPM.md.
+          - name: devtpm-autodetect
+            wolftpm_config: --enable-autodetect --enable-debug
+            needs_swtpm: false
+            test_command: "true"
+
           # Negative tests: configure must error on conflicting flag combos,
           # and we verify the SPECIFIC error message (not just a non-zero
           # exit). wolfSSL is installed by the earlier `Setup wolfSSL` step,
@@ -252,7 +265,10 @@ jobs:
             wolftpm_config: --enable-advio --disable-fwtpm
             needs_swtpm: false
 
-          # Autodetect (default configure, /dev/tpm0 + SPI dual support)
+          # Default configure. NOTE this does NOT build the /dev/tpmX path:
+          # WOLFTPM_SWTPM is still auto-enabled here, which suppresses
+          # WOLFTPM_LINUX_DEV_AUTODETECT (wolftpm/tpm2_types.h). The kernel
+          # device path is covered by the devtpm-autodetect entry above.
           - name: autodetect
             wolftpm_config: "--disable-fwtpm"
             needs_swtpm: false

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Tested with:
 * Nuvoton NPCT65X or NPCT75x TPM2.0 modules
 * Nations Technologies Z32H330 or NS350 TPM 2.0 modules
 * SealSQ QVault TPM 2.0 module (SPI, post-quantum ML-DSA / ML-KEM)
+* NVIDIA Jetson Orin (Tegra234) firmware TPM - a TPM 2.0 running as an OP-TEE trusted application, reached through the Linux kernel driver rather than a bus. See [docs/DEVTPM.md](docs/DEVTPM.md#nvidia-jetson-orin-tegra234-firmware-tpm).
 
 #### Device Identification
 
@@ -291,6 +292,11 @@ Mfg NTC (0), Vendor NPCT75x"!!4rls, Fw 7.2 (131072), FIPS 140-2 1, CC-EAL4 0
 SealSQ QVault TPM 2.0
 TPM2: Caps 0x30000797, Did 0x0083, Vid 0x2406, Rid 0x 3
 Mfg SEAL (6), Vendor QVault TPM, Fw 2.1 (0x3010303), FIPS 140-3, CC-EAL4 0
+
+NVIDIA Jetson Orin (Tegra234) OP-TEE firmware TPM, via /dev/tpmrm0
+Mfg MSFT (7), Vendor SSE fTPM, Fw 8216.1808 (0x105300), FIPS 140-2, CC-EAL4 0
+
+There is no `Caps/Did/Vid/Rid` line above because those values come from TIS bus registers, which a firmware TPM does not have. The entry was captured with `--enable-autodetect`, where `wolfTPM2_Init_ex` returns as soon as the kernel device opens, so the debug line is never reached; an `--enable-devtpm` build still prints it, reading all zeros. `Fw 8216.1808` is `TPM_PT_FIRMWARE_VERSION_1` = `0x20180710`, which this implementation uses to carry a build date (2018-07-10) rather than a version number. Spec revision is 1.62, and all four PCR banks (SHA-1, SHA-256, SHA-384, SHA-512) are allocated with PCRs 0-23.
 
 ## Building
 
@@ -463,23 +469,25 @@ idf.py build
 
 ### Building for "/dev/tpmX"
 
-**Auto-detection (recommended):** On Linux, a default `./configure && make` will automatically try `/dev/tpmrm0` then `/dev/tpm0` at runtime. If the kernel driver is available it will be used; otherwise wolfTPM falls back to direct SPI access. No special configure options are needed.
+**Auto-detection (recommended):** `--enable-autodetect` tries `/dev/tpmrm0` then `/dev/tpm0` at runtime. If the kernel driver is available it will be used; otherwise wolfTPM falls back to direct SPI access.
 
 ```bash
 ./autogen.sh
-./configure
+./configure --enable-autodetect
 make
 ```
 
-Previously, using the kernel TPM driver required the `--enable-devtpm` flag. This is no longer necessary with autodetect (enabled by default). You can still use `--enable-devtpm` to force kernel-driver-only mode, which disables SPI fallback.
+**Important:** on Linux `x86_64` and `aarch64`, a bare `./configure` does *not* reach `/dev/tpmX`. On those hosts the software TPMs (swTPM and fwTPM) are auto-enabled so that `make check` works without hardware, and defining `WOLFTPM_SWTPM` suppresses the kernel-device autodetect path. The resulting build talks to a simulator on TCP port 2321, not to your TPM. Selecting any hardware path explicitly - `--enable-autodetect`, `--enable-devtpm`, or any `--enable-<vendor>` - turns the software defaults back off. This matters on single-board machines with a firmware TPM, such as the NVIDIA Jetson Orin, where the kernel device is the only transport.
 
-To specify a different `/dev/tpmX` device use `CFLAGS="-DTPM2_LINUX_DEV=/dev/tpm1"`
+Use `--enable-devtpm` to force kernel-driver-only mode, which disables the SPI fallback:
 
 ```bash
 ./autogen.sh
 ./configure --enable-devtpm
 make
 ```
+
+To specify a different `/dev/tpmX` device use `CFLAGS='-DTPM2_LINUX_DEV="/dev/tpm1"'` - the inner quotes are required, since the macro is used directly as a C string literal. To pin the resource manager and never fall back to the raw device, build with `-DWOLFTPM_USE_TPMRM`.
 
 The `TPM2_Init` or `wolfTPM2_Init` calls should use NULL for the HAL IO callback argument. The default HAL IO `TPM2_IoCb` maps to a macro specifying NULL (`#define TPM2_IoCb NULL`) in tpm_io.h for the devtpm option.
 
@@ -504,6 +512,8 @@ KERNEL=="tpm[0-9]*", TAG+="systemd", MODE="0660", GROUP="wolftpm"
 ```
 
 4) Reboot or reload rules: `sudo udevadm control -R`
+
+For the resource manager (`/dev/tpmrm0`) versus the raw device, which operations the kernel refuses, and firmware-TPM platforms such as the NVIDIA Jetson Orin, see [docs/DEVTPM.md](docs/DEVTPM.md).
 
 
 ### Building for SWTPM
@@ -912,6 +922,53 @@ ECDSA    256 sign          18 ops took 1.015 sec, avg 56.399 ms, 17.731 ops/sec
 ECDSA    256 verify        26 ops took 1.018 sec, avg 39.164 ms, 25.533 ops/sec
 ECDHE    256 agree         35 ops took 1.029 sec, avg 29.402 ms, 34.011 ops/sec
 ```
+
+Run on the NVIDIA Jetson Orin (Tegra234) OP-TEE firmware TPM, via `/dev/tpmrm0`.
+Jetson Linux R36.4.4, kernel 5.15.148-tegra, `MAXN_SUPER` power mode with all six
+Cortex-A78AE cores at 1728 MHz:
+
+```
+./examples/bench/bench
+TPM2 Benchmark using Wrapper API's
+	Use Parameter Encryption: NULL
+Loading SRK: Storage 0x81000200 (282 bytes)
+RNG                563 KB took 1.001 seconds,  562.277 KB/s
+AES-128-CBC-enc      3 MB took 1.000 seconds,    2.798 MB/s
+AES-128-CBC-dec      3 MB took 1.000 seconds,    2.780 MB/s
+AES-256-CBC-enc      3 MB took 1.000 seconds,    2.898 MB/s
+AES-256-CBC-dec      3 MB took 1.000 seconds,    2.888 MB/s
+AES-128-CTR-enc      3 MB took 1.000 seconds,    2.910 MB/s
+AES-128-CTR-dec      3 MB took 1.000 seconds,    2.762 MB/s
+AES-256-CTR-enc      3 MB took 1.000 seconds,    2.764 MB/s
+AES-256-CTR-dec      3 MB took 1.000 seconds,    2.730 MB/s
+AES-128-CFB-enc      3 MB took 1.000 seconds,    2.752 MB/s
+AES-128-CFB-dec      3 MB took 1.000 seconds,    2.688 MB/s
+AES-256-CFB-enc      3 MB took 1.000 seconds,    2.881 MB/s
+AES-256-CFB-dec      3 MB took 1.000 seconds,    2.830 MB/s
+SHA1                 2 MB took 1.000 seconds,    1.521 MB/s
+SHA256               2 MB took 1.000 seconds,    1.572 MB/s
+SHA384               2 MB took 1.000 seconds,    1.554 MB/s
+SHA512               2 MB took 1.000 seconds,    1.569 MB/s
+RSA     2048 key gen       21 ops took 15.465 sec, avg 736.433 ms, 1.358 ops/sec
+RSA     2048 Public      1145 ops took 1.001 sec, avg 0.874 ms, 1144.407 ops/sec
+RSA     2048 Private       85 ops took 1.012 sec, avg 11.900 ms, 84.033 ops/sec
+RSA     2048 Pub  OAEP   1086 ops took 1.000 sec, avg 0.921 ms, 1085.719 ops/sec
+RSA     2048 Priv OAEP     84 ops took 1.002 sec, avg 11.934 ms, 83.793 ops/sec
+ECC      256 key gen        9 ops took 1.081 sec, avg 120.163 ms, 8.322 ops/sec
+ECDSA    256 sign          23 ops took 1.038 sec, avg 45.139 ms, 22.154 ops/sec
+ECDSA    256 verify        32 ops took 1.016 sec, avg 31.737 ms, 31.509 ops/sec
+ECDHE    256 agree         12 ops took 1.076 sec, avg 89.632 ms, 11.157 ops/sec
+```
+
+Unlike the discrete parts above, every operation the benchmark exercises is
+supported, and the throughput figures are one to two orders of magnitude higher.
+That is a property of where the TPM runs rather than of the TPM itself: the
+firmware TPM executes on an application core with no serial bus in the path,
+whereas a discrete part is a small microcontroller reached over SPI or I2C. The
+comparison is useful for capacity planning, not as a security ranking - the
+discrete parts are separate silicon with their own tamper boundary, while the
+firmware TPM shares the SoC with the software it attests. See
+[docs/DEVTPM.md](docs/DEVTPM.md#nvidia-jetson-orin-tegra234-firmware-tpm).
 
 ### TPM2 Native Tests
 

--- a/configure.ac
+++ b/configure.ac
@@ -309,6 +309,15 @@ then
 
     AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_SWTPM"
 
+    # WOLFTPM_SWTPM suppresses the /dev/tpmX autodetect (see
+    # WOLFTPM_LINUX_DEV_AUTODETECT in wolftpm/tpm2_types.h), so when it is
+    # reached by default rather than by request, a host with a real kernel
+    # TPM would silently build against the simulator. Say so.
+    if test "x$WOLFTPM_DEFAULT_SWTPM" = "xyes" && test "x$enable_swtpm" = "x"; then
+        AC_MSG_NOTICE([no hardware TPM interface selected: defaulting to the software TPM (swTPM) so 'make check' works without hardware.])
+        AC_MSG_NOTICE([this build will NOT use /dev/tpmrm0 or /dev/tpm0. For a real TPM use --enable-autodetect, --enable-devtpm, or --enable-<vendor>.])
+    fi
+
     if test "x$ENABLED_SWTPM" = "xuart"
     then
         AM_CFLAGS="$AM_CFLAGS -DWOLFTPM_SWTPM_UART"

--- a/docs/DEVTPM.md
+++ b/docs/DEVTPM.md
@@ -1,0 +1,173 @@
+# wolfTPM with the Linux Kernel TPM Device (/dev/tpmX)
+
+On Linux the kernel's TPM driver stack exposes a TPM through a character device, and wolfTPM can use it directly instead of driving SPI or I2C itself. This is the right transport whenever the kernel already owns the TPM: a discrete chip bound to a kernel driver, a Windows-style firmware TPM, or a TEE-resident firmware TPM such as the one on NVIDIA Jetson platforms.
+
+With `--enable-devtpm` there is **no TIS layer and no HAL IO callback**: `hal/tpm_io.c` is compiled out entirely and `TPM2_IoCb` is `NULL` (see `hal/tpm_io.h`), so pass `NULL` for the callback argument of `TPM2_Init` / `wolfTPM2_Init`.
+
+With `--enable-autodetect` this is **not** the case. The TIS/SPI HAL stays compiled in on purpose - it is the fallback - and `TPM2_IoCb` is a real function. Keep passing it, or the SPI fallback that build exists to provide is unreachable.
+
+## Two device nodes
+
+The kernel presents up to two nodes per TPM:
+
+* `/dev/tpm0` - the raw device. One user at a time, no resource management. Whatever you send reaches the TPM.
+* `/dev/tpmrm0` - the in-kernel resource manager (kernel 4.12+, practical from 5.12+). It virtualizes handles, swaps transient objects and sessions in and out as needed, and flushes everything belonging to a connection when that connection closes.
+
+wolfTPM prefers `/dev/tpmrm0` and falls back to `/dev/tpm0`. The resource manager is the better default: a TPM has very few transient object slots, and without it a program that leaks a handle wedges the TPM for everything else on the system.
+
+Build-time overrides, honored by both `--enable-devtpm` and `--enable-autodetect`:
+
+* `-DWOLFTPM_USE_TPMRM` - use `/dev/tpmrm0` only, with no fallback to the raw device.
+* `CFLAGS='-DTPM2_LINUX_DEV="/dev/tpm1"'` - use a specific node. The inner quotes are required: the macro is used directly as a C string literal, so an unquoted value does not compile.
+
+## Startup, shutdown, and shared state
+
+The TPM is started by firmware long before Linux runs, and on the resource manager it is shared with every other process on the system. Restarting or shutting it down is therefore not an individual caller's decision, so wolfTPM stays out of the way on this transport:
+
+* `wolfTPM2_Init` skips the startup and self-test sequence.
+* `wolfTPM2_Reset` and `wolfTPM2_Shutdown` send no TPM command and return `NOT_COMPILED_IN` (-174), the same way `wolfTPM2_SetLocality` does on this transport. A `wolfTPM2_Reset(dev, 0, 0)` that asked for neither a shutdown nor a startup still returns `TPM_RC_SUCCESS`, since nothing was declined. Treat `NOT_COMPILED_IN` here as "the OS owns this", not as a failure.
+* `wolfTPM2_SetLocality` returns `NOT_COMPILED_IN` - the kernel owns the locality.
+
+Be aware that the kernel does **not** reliably stop you here. Command filtering on `/dev/tpmrm0` is primarily about handle isolation, not about blocking global state changes, and behavior varies by kernel version and TPM implementation. On Linux 5.15 with the Jetson OP-TEE fTPM, a `TPM2_Shutdown(TPM_SU_CLEAR)` sent through the resource manager is passed straight through and returns success - both from wolfTPM and from `tpm2_shutdown`. So this is a case where the library declining to send the command is what protects other users of the TPM, rather than the kernel doing it for you.
+
+If you genuinely need to control TPM startup state, you need `/dev/tpm0` and exclusive use of the TPM, or direct SPI access with wolfTPM's own TIS driver.
+
+## What the native API does on autodetect builds
+
+Two behaviors worth knowing if you use `TPM2_Init` / `TPM2_Init_ex` directly rather than the `wolfTPM2_*` wrapper.
+
+**The kernel device wins over your callback.** If `/dev/tpmrm0` or `/dev/tpm0` opens, every command is routed there and the HAL IO callback you passed is never invoked. On a host that has both a kernel-bound TPM and a discrete SPI part, that means you now talk to a different TPM than a pre-autodetect build did. Pin the part you want with `--enable-devtpm`, `--enable-spi` / `--enable-<vendor>`, or `-DTPM2_LINUX_DEV`.
+
+**Init now acquires a descriptor.** `TPM2_Init*` opens the device on autodetect builds, and `TPM2_Cleanup()` is what closes it. Native callers that skipped cleanup previously leaked nothing; now they leak a descriptor per context. This matters most on hosts exposing only the raw `/dev/tpm0`, which permits a single open - a context that merely initialized holds the TPM exclusively for its lifetime, and a second context in the same process falls through to a different transport.
+
+`TPM2_Init_minimal()` is unaffected: it performs no IO and still succeeds with no device present.
+
+## Transient handles do not outlive a process
+
+This is the difference most likely to break an existing application.
+
+On `/dev/tpmrm0` the kernel gives each open file description its own handle space. Transient object handles are **virtualized** - the value the TPM assigned is not the value you get back - and everything in that space is **flushed when the file descriptor closes**. So a transient key created by one process is gone by the time a second process runs, and the handle number it printed is meaningless to anyone else.
+
+Creating a primary key on the Jetson fTPM through the resource manager returns:
+
+```
+Create Primary Handle: 0x80ffffff
+```
+
+not the `0x80000000` a raw device would report. Query the transient handles from a separate process afterwards and the list is empty:
+
+```bash
+tpm2_getcap handles-transient      # no output - the space was torn down
+```
+
+Two practical consequences:
+
+* A "create a key, keep it, use it from the next command" workflow does not work across processes. Do the whole sequence in one process, or make the object persistent with `TPM2_EvictControl` so it gets a stable `0x81xxxxxx` handle that does survive.
+* Passing a hard-coded transient handle such as `0x80000000` on a command line will fail. The kernel rejects the reference before it reaches the TPM, and because that happens at the file-descriptor layer the error surfaces as an `errno 22 = Invalid argument` on `read()`, which wolfTPM reports as `TPM_RC_FAILURE` rather than as a handle error. If you see `TPM_RC_FAILURE` alongside `Failed to read from /dev/tpmrm0 ... errno 22`, suspect a stale or cross-process transient handle before suspecting the TPM.
+
+wolfTPM's own `examples/run_examples.sh` hits exactly this: its provisioning section creates IAK and IDevID primaries with `-keep` in one process and then references `0x80000000` / `0x80000001` from another. That block cannot pass on the resource manager by construction. Everything either side of it is unaffected. Use `/dev/tpm0` with exclusive access if you need to run it as written.
+
+## Building
+
+```bash
+./autogen.sh
+./configure --enable-devtpm
+make
+```
+
+`--enable-devtpm` uses the kernel node only. Use `--enable-autodetect` instead if you want wolfTPM to try `/dev/tpmrm0`, then `/dev/tpm0`, and finally fall back to probing SPI - useful for one binary that has to run on several boards.
+
+Only one transport can be enabled at a time. `--enable-devtpm` conflicts with `--enable-swtpm` and `--enable-winapi`, and configure will stop if you ask for more than one.
+
+### The x86_64 / aarch64 default
+
+A bare `./configure` on Linux `x86_64` or `aarch64` does **not** produce a build that talks to `/dev/tpmX`. On those hosts wolfTPM auto-enables the software TPMs (swTPM and fwTPM) so that `make check` passes with no hardware attached, and defining `WOLFTPM_SWTPM` suppresses the kernel-device autodetect path. The result talks to a simulator on TCP port 2321.
+
+Selecting any hardware path explicitly turns that default back off - `--enable-autodetect`, `--enable-devtpm`, or any `--enable-<vendor>`. Configure prints a notice when the software default is taken, so check the tail of its output if a build unexpectedly fails to find your TPM.
+
+This bites hardest on single-board `aarch64` machines with a firmware TPM, where the kernel device is the only transport there is.
+
+## Permissions
+
+The TPM character devices are not world-accessible. On a typical system they are mode `0660` owned by group `tss`:
+
+```
+crw-rw---- 1 tss root  10,   224 /dev/tpm0
+crw-rw---- 1 tss tss  252, 65536 /dev/tpmrm0
+```
+
+wolfTPM detects `EACCES` and reports it plainly:
+
+```
+Permission denied on /dev/tpm0
+Use sudo or add tss group to user.
+```
+
+The fix is to put your user in the owning group and start a new login session:
+
+```bash
+sudo usermod -aG tss $USER
+```
+
+Note that the `tss` group is created by tpm2-tss, and on distributions that ship it the group frequently exists with no members - so this step is required even though the group looks correctly set up.
+
+To use a group of your own instead, add a udev rule:
+
+1) Create the group and add your user:
+
+```bash
+sudo addgroup wolftpm
+sudo adduser [username] wolftpm
+```
+
+2) Create `/etc/udev/rules.d/wolftpm-udev.rules` containing:
+
+```
+KERNEL=="tpm[0-9]*", TAG+="systemd", MODE="0660", GROUP="wolftpm"
+```
+
+3) Reload the rules: `sudo udevadm control -R`, then re-plug or reboot.
+
+## NVIDIA Jetson Orin (Tegra234) firmware TPM
+
+Jetson Orin platforms carry a TPM 2.0 implemented in firmware, running as a trusted application inside OP-TEE rather than as a discrete package on a bus. Linux reaches it through the `tpm_ftpm_tee` driver, which speaks to the TA over the TEE interface and registers an ordinary TPM chip - so from wolfTPM's point of view it is just another `/dev/tpmrm0`.
+
+Confirm the device is present before building:
+
+```bash
+lsmod | grep tpm_ftpm_tee
+ls -l /dev/tpm*
+cat /sys/class/tpm/tpm0/tpm_version_major     # expect 2
+```
+
+If the module is missing, try `sudo modprobe tpm_ftpm_tee` and check that the kernel was configured with `CONFIG_TCG_FTPM_TEE`. On NVIDIA's Jetson Linux (L4T) images the driver is present and an `fTPM Device Provisioning Service` systemd unit runs at boot; you can see it complete in the boot log.
+
+Note that an OP-TEE boot message about silicon-identity fTPM provisioning not being enabled refers to a separate NVIDIA feature and does **not** mean the TPM 2.0 device is unavailable.
+
+Build as above with `--enable-devtpm` or `--enable-autodetect`, then confirm with:
+
+```bash
+./examples/wrap/caps
+```
+
+Because this is a firmware TPM, expect two differences from a discrete part. There is no TIS bus, so the `TPM2: Caps/Did/Vid/Rid` values do not exist and the device is identified purely from `TPM2_GetCapability` properties. Under `--enable-devtpm` the `DEBUG_WOLFTPM` line is still printed but reads all zeros; under `--enable-autodetect` `wolfTPM2_Init_ex` returns as soon as the kernel device opens, before that printf, so the line is absent entirely. And a firmware TPM's algorithm coverage is set by its firmware build rather than by a datasheet, so it is worth checking rather than assuming; where an operation is absent the benchmark reports it as unsupported rather than failing. The Jetson Orin fTPM supports every operation the benchmark exercises - see the README results.
+
+See the main [README.md](../README.md#device-identification) for this platform's identification values and benchmark results.
+
+## Testing
+
+The examples run unchanged on this transport:
+
+```bash
+./examples/wrap/caps
+./examples/native/native_test
+./examples/wrap/wrap_test
+./examples/bench/bench
+./examples/run_examples.sh
+```
+
+`run_examples.sh` already skips the locality test on backends that do not support it.
+
+## CI coverage
+
+Both `--enable-devtpm` and `--enable-autodetect` are build-tested in CI, but not run - GitHub-hosted runners have no `/dev/tpm*` node. Runtime coverage of this transport requires a self-hosted runner with a real TPM bound to the kernel driver.

--- a/docs/include.am
+++ b/docs/include.am
@@ -4,6 +4,8 @@
 
 dist_doc_DATA+= docs/README.md
 dist_doc_DATA+= docs/SWTPM.md
+dist_doc_DATA+= docs/DEVTPM.md
+dist_doc_DATA+= docs/FWTPM.md
 dist_doc_DATA+= docs/WindowTBS.md
 dist_doc_DATA+= docs/Doxyfile
 

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -939,9 +939,30 @@ TPM_RC TPM2_Init_ex(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx,
     /* Set the active TPM global */
     TPM2_SetActiveCtx(ctx);
 
+#ifdef WOLFTPM_LINUX_DEV_AUTODETECT
+    /* Probe here, not only in wolfTPM2_Init_ex, so the native API autodetects
+     * /dev/tpmX too. TryOpen leaves fd < 0 whether the node was absent or
+     * merely unopenable (EACCES), and neither is fatal on its own: with an IO
+     * callback the SPI path is still viable, which is what this build mode
+     * exists for. Reject only when no transport can serve AND the caller asked
+     * to bring one up - otherwise TPM2_TIS_SendCommand would call a NULL
+     * ctx->ioCb on the first command. TPM2_Init_minimal passes timeoutTries 0
+     * and performs no IO, so it keeps succeeding either way. */
+    /* Only fd matters here; the return code adds nothing this branch needs. */
+    (void)TPM2_LINUX_TryOpen(ctx);
+    if (ctx->fd < 0 && ctx->ioCb == NULL && timeoutTries > 0) {
+    #ifdef DEBUG_WOLFTPM
+        printf("TPM2: Kernel driver not available and no IO callback for SPI\n");
+    #endif
+        return TPM_RC_FAILURE;
+    }
+    rc = TPM_RC_SUCCESS;
+#endif
+
     if (timeoutTries > 0
     #ifdef WOLFTPM_LINUX_DEV_AUTODETECT
-        && ctx->ioCb != NULL /* autodetect: skip if no IO callback */
+        /* skip TIS startup if the kernel driver answered, or SPI has no IO cb */
+        && ctx->fd < 0 && ctx->ioCb != NULL
     #endif
     ) {
         /* Perform chip startup and assign locality */
@@ -1002,8 +1023,10 @@ TPM_RC TPM2_Cleanup(TPM2_CTX* ctx)
 
 #if (defined(WOLFTPM_LINUX_DEV) || defined(WOLFTPM_LINUX_DEV_AUTODETECT)) \
     && !defined(__UBOOT__)
-    if (ctx->fd >= 0)
+    if (ctx->fd >= 0) {
         close(ctx->fd);
+        ctx->fd = -1; /* keep repeat cleanup idempotent */
+    }
 #endif
 
 #ifdef WOLFTPM_SWTPM

--- a/src/tpm2_linux.c
+++ b/src/tpm2_linux.c
@@ -215,29 +215,57 @@ int TPM2_LINUX_SendCommand(TPM2_CTX* ctx, TPM2_Packet* packet)
 
 int TPM2_LINUX_TryOpen(TPM2_CTX* ctx)
 {
-    /* Try resource manager first (kernel 4.12+), then raw device */
-    ctx->fd = open("/dev/tpmrm0", O_RDWR | O_NONBLOCK);
+    int errPrimary = 0;
+#ifdef TPM2_LINUX_DEV_FALLBACK
+    int errFallback = 0;
+#endif
+
+    /* Idempotent: callers may probe more than once (TPM2_Init_ex, then the
+     * wrapper). Returning early keeps a second call from leaking the fd. */
     if (ctx->fd >= 0) {
-    #ifdef DEBUG_WOLFTPM
-        printf("Opened /dev/tpmrm0\n");
-    #endif
         return TPM_RC_SUCCESS;
     }
 
-    ctx->fd = open("/dev/tpm0", O_RDWR | O_NONBLOCK);
+    /* Honor the same overrides as TPM2_LINUX_SendCommand: TPM2_LINUX_DEV pins
+     * a node, and WOLFTPM_USE_TPMRM leaves TPM2_LINUX_DEV_FALLBACK undefined
+     * so the raw device is never tried. */
+    ctx->fd = open(TPM2_LINUX_DEV, O_RDWR | O_NONBLOCK);
     if (ctx->fd >= 0) {
     #ifdef DEBUG_WOLFTPM
-        printf("Opened /dev/tpm0\n");
+        printf("Opened %s\n", TPM2_LINUX_DEV);
     #endif
         return TPM_RC_SUCCESS;
     }
+    errPrimary = errno;
 
-    /* Distinguish "not available" from "permission denied" */
-    if (errno == EACCES) {
-        printf("Permission denied on /dev/tpm0\n"
-            "Use sudo or add tss group to user.\n");
+#ifdef TPM2_LINUX_DEV_FALLBACK
+    ctx->fd = open(TPM2_LINUX_DEV_FALLBACK, O_RDWR | O_NONBLOCK);
+    if (ctx->fd >= 0) {
+    #ifdef DEBUG_WOLFTPM
+        printf("Opened %s\n", TPM2_LINUX_DEV_FALLBACK);
+    #endif
+        return TPM_RC_SUCCESS;
+    }
+    errFallback = errno;
+#endif
+
+    /* Distinguish "not available" from "permission denied", per node. Testing
+     * a single errno would hide EACCES on one node behind ENOENT on the other
+     * (a container that maps only /dev/tpmrm0 does exactly that), turning a
+     * permissions problem into a misleading "device absent". The nodes can
+     * differ in owner/group, so name the one that was actually refused. */
+    if (errPrimary == EACCES) {
+        printf("Permission denied on %s\n"
+            "Use sudo or add tss group to user.\n", TPM2_LINUX_DEV);
         return TPM_RC_FAILURE;
     }
+#ifdef TPM2_LINUX_DEV_FALLBACK
+    if (errFallback == EACCES) {
+        printf("Permission denied on %s\n"
+            "Use sudo or add tss group to user.\n", TPM2_LINUX_DEV_FALLBACK);
+        return TPM_RC_FAILURE;
+    }
+#endif
 
     /* ENOENT or other: device not present, caller should try SPI */
     return TPM_RC_INITIALIZE; /* sentinel: "not found, try next" */

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -91,22 +91,21 @@ static int wolfTPM2_Init_ex(TPM2_CTX* ctx, TPM2HalIoCb ioCb, void* userCtx,
         return rc;
     }
 
-    /* Phase 2: Try /dev/tpmrm0 then /dev/tpm0 */
-    rc = TPM2_LINUX_TryOpen(ctx);
-    if (rc == TPM_RC_SUCCESS) {
+    /* Phase 2: TPM2_Init_ex already probed /dev/tpmrm0 then /dev/tpm0, so read
+     * what it found rather than opening the nodes a second time. It cannot
+     * reject the no-transport case for us - phase 1 passes timeoutTries 0 -
+     * so phase 3 below still has to. */
+    if (ctx->fd >= 0) {
         /* Using kernel driver - startup/locality handled by kernel */
     #ifdef DEBUG_WOLFTPM
         printf("TPM2: Using Linux kernel driver\n");
     #endif
         return TPM_RC_SUCCESS;
     }
-    else if (rc == TPM_RC_FAILURE) {
-        /* Permission denied or hard error - don't try SPI */
-        return rc;
-    }
-    /* rc == TPM_RC_INITIALIZE means "not found", fall through to SPI */
 
-    /* Phase 3: SPI fallback - requires IO callback */
+    /* Phase 3: no kernel device, fall back to SPI - which needs the callback.
+     * Phase 1 passes timeoutTries 0, so TPM2_Init_ex deliberately does not
+     * reject this case there; it has to be caught here before TIS is used. */
     if (ioCb == NULL) {
     #ifdef DEBUG_WOLFTPM
         printf("TPM2: Kernel driver not available and no IO callback for SPI\n");
@@ -864,6 +863,14 @@ static int wolfTPM2_ParseCapabilities(WOLFTPM2_CAPS* caps,
                 else if (XMEMCMP(&caps->mfgStr, "SEAL", 4) == 0) {
                     caps->mfg = TPM_MFG_SEALSQ;
                     caps->req_wait_state = 1;
+                }
+                else if (XMEMCMP(&caps->mfgStr, "MSFT", 4) == 0) {
+                    /* Microsoft TPM 2.0 reference implementation, used by
+                     * firmware TPMs rather than discrete parts (e.g. the
+                     * OP-TEE fTPM on NVIDIA Jetson, vendor "SSE fTPM"). The
+                     * vendor string, not this, identifies the platform.
+                     * No wait state: kernel driver, not a TIS bus. */
+                    caps->mfg = TPM_MFG_MSFT;
                 }
                 break;
             case TPM_PT_VENDOR_STRING_1:
@@ -8474,12 +8481,42 @@ int wolfTPM2_HmacFinish(WOLFTPM2_DEV* dev, WOLFTPM2_HMAC* hmac,
 int wolfTPM2_Reset(WOLFTPM2_DEV* dev, int doShutdown, int doStartup)
 {
     int rc = TPM_RC_SUCCESS;
+#if !defined(WOLFTPM_LINUX_DEV) && !defined(WOLFTPM_WINAPI)
     Shutdown_In shutdownIn;
     Startup_In startupIn;
+#endif
 
     if (dev == NULL) {
         return BAD_FUNC_ARG;
     }
+
+#if defined(WOLFTPM_LINUX_DEV) || defined(WOLFTPM_WINAPI)
+    /* The kernel driver and Windows TBS own TPM startup state, as they own the
+     * locality (see wolfTPM2_SetLocality, which returns NOT_COMPILED_IN here
+     * for the same reason). On the shared /dev/tpmrm0 a TPM_SU_CLEAR from one
+     * caller would hit every other process using the TPM, and the kernel does
+     * not block it - on Linux 5.15 it passes through and succeeds. */
+    if (doShutdown == 0 && doStartup == 0) {
+        /* nothing was asked for, so nothing was declined */
+        rc = TPM_RC_SUCCESS;
+    }
+    else {
+        rc = NOT_COMPILED_IN;
+    }
+#else
+
+#ifdef WOLFTPM_LINUX_DEV_AUTODETECT
+    /* Autodetect resolved to the kernel driver, which owns startup as above.
+     * Clear both requests so the common tail still runs, and only report a
+     * decline if something was actually requested. */
+    if (dev->ctx.fd >= 0) {
+        if (doShutdown == 1 || doStartup == 1) {
+            rc = NOT_COMPILED_IN;
+        }
+        doShutdown = 0;
+        doStartup = 0;
+    }
+#endif
 
     /* shutdown */
     if (doShutdown == 1) {
@@ -8506,6 +8543,7 @@ int wolfTPM2_Reset(WOLFTPM2_DEV* dev, int doShutdown, int doStartup)
         #endif
         }
     }
+#endif /* !WOLFTPM_LINUX_DEV && !WOLFTPM_WINAPI */
 
 #ifdef DEBUG_WOLFTPM
     printf("wolfTPM2_Reset complete\n");

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -427,7 +427,13 @@ static void test_wolfTPM2_FirmwareUpgrade_ex_session(void)
     rc = wolfTPM2_GetCapabilities(&dev, &caps);
     AssertIntEQ(rc, 0);
     if (caps.mfg != TPM_MFG_UNKNOWN) {
-        /* not the simulator - do not exercise firmware upgrade paths */
+        /* not the simulator - do not exercise firmware upgrade paths.
+         * NOTE this gate means "wolfTPM recognizes the manufacturer", which
+         * is only a proxy for "real hardware". TPM_MFG_MSFT covers both the
+         * ms-tpm-20-ref simulator and firmware TPMs built from it (e.g. the
+         * Jetson OP-TEE fTPM), so against that simulator these tests skip
+         * rather than run. Skipping is the safe direction; distinguishing
+         * the two needs a real simulator check. */
         wolfTPM2_Cleanup(&dev);
         printf("Test FW Upgr _ex: %-40s Skipped (real TPM)\n",
             "Session Validation:");
@@ -548,6 +554,7 @@ static void test_wolfTPM2_SetPrimaryPolicy_rollback(void)
     rc = wolfTPM2_GetCapabilities(&dev, &caps);
     AssertIntEQ(rc, 0);
     if (caps.mfg != TPM_MFG_UNKNOWN) {
+        /* see the TPM_MFG_MSFT note on the first such gate above */
         wolfTPM2_Cleanup(&dev);
         printf("Test SetPrimPol:  %-40s Skipped (real TPM)\n", "Rollback:");
         return;
@@ -642,6 +649,7 @@ static void test_wolfTPM2_PolicyClear_underPolicy(void)
     rc = wolfTPM2_GetCapabilities(&dev, &caps);
     AssertIntEQ(rc, 0);
     if (caps.mfg != TPM_MFG_UNKNOWN) {
+        /* see the TPM_MFG_MSFT note on the first such gate above */
         wolfTPM2_Cleanup(&dev);
         printf("Test PolicyClear: %-40s Skipped (real TPM)\n", "Under Policy:");
         return;
@@ -6594,10 +6602,63 @@ static void* test_wolfTPM2_thread_local_storage_work_thread(void* args)
     /* let the other thread run */
     pthread_mutex_unlock(&mutex);
 
+    /* On autodetect builds TPM2_Init acquires a /dev/tpmX descriptor, so this
+     * must be released or every thread leaks one. */
+    TPM2_Cleanup(&tpm2Ctx);
+
     (void)args;
     return NULL;
 }
 #endif /* HAVE_THREAD_LS && HAVE_PTHREAD */
+
+/* On transports where the OS owns TPM startup state, Reset/Shutdown decline the
+ * command with NOT_COMPILED_IN, but a request for neither is still a success. */
+static void test_wolfTPM2_Reset_contract(void)
+{
+#if defined(WOLFTPM_LINUX_DEV) || defined(WOLFTPM_WINAPI)
+    WOLFTPM2_DEV dev;
+    int rc;
+
+    XMEMSET(&dev, 0, sizeof(dev));
+
+    /* nothing requested - nothing declined */
+    rc = wolfTPM2_Reset(&dev, 0, 0);
+    AssertIntEQ(rc, TPM_RC_SUCCESS);
+
+    /* a shutdown was requested and is being refused */
+    rc = wolfTPM2_Reset(&dev, 1, 0);
+    AssertIntEQ(rc, NOT_COMPILED_IN);
+
+    rc = wolfTPM2_Shutdown(&dev, 0);
+    AssertIntEQ(rc, NOT_COMPILED_IN);
+
+    AssertIntEQ(wolfTPM2_Reset(NULL, 0, 0), BAD_FUNC_ARG);
+
+    printf("Test TPM Wrapper: %-40s Passed\n", "Reset contract:");
+#elif defined(WOLFTPM_LINUX_DEV_AUTODETECT)
+    WOLFTPM2_DEV dev;
+    int rc;
+
+    /* A non-negative fd is all this branch inspects: it clears both requests
+     * before the shutdown/startup blocks, so no command is sent and the fd is
+     * never touched. That makes the contract testable with no TPM present. */
+    XMEMSET(&dev, 0, sizeof(dev));
+    dev.ctx.fd = 1;
+
+    rc = wolfTPM2_Reset(&dev, 0, 0);
+    AssertIntEQ(rc, TPM_RC_SUCCESS);
+
+    rc = wolfTPM2_Reset(&dev, 1, 0);
+    AssertIntEQ(rc, NOT_COMPILED_IN);
+
+    rc = wolfTPM2_Shutdown(&dev, 0);
+    AssertIntEQ(rc, NOT_COMPILED_IN);
+
+    AssertIntEQ(wolfTPM2_Reset(NULL, 0, 0), BAD_FUNC_ARG);
+
+    printf("Test TPM Wrapper: %-40s Passed\n", "Reset contract:");
+#endif
+}
 
 static void test_wolfTPM2_thread_local_storage(void)
 {
@@ -8478,6 +8539,7 @@ int unit_tests(int argc, char *argv[])
     test_wolfTPM2_VerifySequence_NoLeak();
     #endif
     test_wolfTPM2_Cleanup();
+    test_wolfTPM2_Reset_contract();
     test_wolfTPM2_thread_local_storage();
 #ifdef WOLFTPM_SPDM
     test_wolfTPM2_SPDM_ValidateRspSz();

--- a/wolftpm/tpm2_wrap.h
+++ b/wolftpm/tpm2_wrap.h
@@ -150,6 +150,7 @@ typedef enum WOLFTPM2_MFG {
     TPM_MFG_NUVOTON,
     TPM_MFG_NATIONTECH,
     TPM_MFG_SEALSQ,
+    TPM_MFG_MSFT, /* Microsoft reference firmware TPM (e.g. OP-TEE fTPM TA) */
 } WOLFTPM2_MFG;
 
 typedef struct WOLFTPM2_CAPS {
@@ -3613,9 +3614,14 @@ WOLFTPM_API int wolfTPM2_SetCommand(WOLFTPM2_DEV* dev, TPM_CC commandCode,
     \note - Both flags set to 1: Performs a full TPM restart (shutdown then startup)
     \note - Only doStartup=1: Just starts up the TPM
     \note - Only doShutdown=1: Just shuts down the TPM
+    \note On the Linux kernel driver (/dev/tpmX) and Windows TBS the OS owns
+        TPM startup state, so no TPM command is sent and NOT_COMPILED_IN is
+        returned. A call requesting neither a shutdown nor a startup still
+        returns TPM_RC_SUCCESS, since nothing was declined. See docs/DEVTPM.md.
 
     \return TPM_RC_SUCCESS: successful
     \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)
+    \return NOT_COMPILED_IN: transport where the OS owns TPM startup state
     \return BAD_FUNC_ARG: check the provided arguments
 
     \param dev pointer to a TPM2_DEV struct
@@ -3631,9 +3637,14 @@ WOLFTPM_API int wolfTPM2_Reset(WOLFTPM2_DEV* dev, int doShutdown, int doStartup)
     \ingroup wolfTPM2_Wrappers
     \brief Helper function to shutdown or reset the TPM
     \note If doStartup is set, then TPM2_Startup is performed right after TPM2_Shutdown
+    \note On the Linux kernel driver (/dev/tpmX) and Windows TBS the OS owns
+        TPM startup state, so no TPM command is sent and NOT_COMPILED_IN is
+        returned. A call requesting neither a shutdown nor a startup still
+        returns TPM_RC_SUCCESS, since nothing was declined. See docs/DEVTPM.md.
 
     \return TPM_RC_SUCCESS: successful
     \return TPM_RC_FAILURE: generic failure (check TPM IO and TPM return code)
+    \return NOT_COMPILED_IN: transport where the OS owns TPM startup state
     \return BAD_FUNC_ARG: check the provided arguments
 
     \param dev pointer to a TPM2_DEV struct


### PR DESCRIPTION
Adds the **NVIDIA Jetson Orin** (Tegra234) as a supported target. Its TPM 2.0 is a **firmware TPM** running as an **OP-TEE** trusted application rather than a discrete part on a bus, reached through the Linux kernel driver at `/dev/tpmrm0`. `wolfTPM2_ParseCapabilities()` now recognizes the `MSFT` manufacturer string and reports the new `TPM_MFG_MSFT` (appended to `WOLFTPM2_MFG`, existing values unchanged, and deliberately without `req_wait_state` since there is no TIS bus); it previously read `Mfg MSFT (0)` = `TPM_MFG_UNKNOWN`. Also adds **`docs/DEVTPM.md`**, the first documentation for the kernel `/dev/tpmX` transport, plus README identification and benchmark entries, a `devtpm-autodetect` CI build entry, and a packaging fix for `docs/FWTPM.md`, which was never listed in `docs/include.am`. Identification reads `Mfg MSFT (7), Vendor SSE fTPM, Fw 8216.1808 (0x105300), FIPS 140-2, CC-EAL4 0` — note `Fw 8216.1808` is `0x20180710`, a build **date** rather than a version, and is captioned as such in the README.

Two behavior changes and one real bug. The bug: **`--enable-autodetect` only autodetected for the wrapper API** — `TPM2_LINUX_TryOpen()` was called solely from `wolfTPM2_Init_ex()`, so the native `TPM2_Init_ex()` left `fd = -1`, fell through to TIS/SPI, and every native-API caller failed at init with `TPM_RC_FAILURE`, including the shipped `native_test`. Fixed by probing in the native init and making `TryOpen` idempotent so the wrapper's call no longer leaks a descriptor. Separately, `wolfTPM2_Reset()` no longer sends `TPM2_Shutdown`/`TPM2_Startup` on the kernel and TBS transports, matching `wolfTPM2_Init()` which already skips startup there — to be clear about scope, I expected the resource manager to *reject* those commands and that proved **false**: on Linux 5.15 it passes `TPM_SU_CLEAR` through and it succeeds, so this is hardening (one caller should not make a global state change on a TPM shared with every process) rather than a crash fix. Configure now also emits a notice when it auto-selects the software TPMs, because on Linux x86_64/aarch64 a bare `./configure` enables swTPM and thereby suppresses kernel-device autodetect — the build silently talks to a simulator on port 2321; the README text claiming otherwise is corrected, while the default itself is left unchanged since probing `/dev/tpm*` at configure time would break cross-compiles. **Tested** on Jetson Linux R36.4.4 / kernel 5.15.148-tegra: `run_examples.sh` reports `Success!` (native, wrapper, NV, policy, PKCS7, full TLS matrix for RSA and ECC over TLS 1.2/1.3 with and without parameter encryption, attestation, PCR quote/policy, Secure Boot ROT, Seal/Unseal, EK cert), every benchmark operation supported with none skipped, all identification values cross-checked against `tpm2_getcap`, and x86_64 regression builds clean in `devtpm`, `autodetect`, `infineon` and default configurations. Two items are documented in `docs/DEVTPM.md` rather than patched, since neither is a wolfTPM defect: `/dev/tpmrm0` virtualizes transient handles and flushes them when the descriptor closes, so `run_examples.sh`'s provisioning block (which creates IAK/IDevID with `-keep` in one process and references `0x80000000` from another) cannot pass on the resource manager by construction; and `run_examples.sh:190` prints `$RESULT$RESULT`, reporting an exit code of `1` as `failed! 11`.
