### PR TITLE
Fix Coverity CID 912593 and CID 912594 in wolfTPM2_PolicyPCRMake

### DIFF
--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -11091,8 +11091,13 @@ int wolfTPM2_PolicyPCRMake(TPM_ALG_ID pcrAlg, byte* pcrArray, word32 pcrArraySz,
         pcrDigestSz > (word32)sizeof(buf) - (word32)packet.pos) {
         return BUFFER_E;
     }
-    XMEMCPY(buf + packet.pos, pcrDigest, pcrDigestSz);
-    packet.pos += pcrDigestSz;
+    if (pcrDigestSz > 0) {
+        if (pcrDigest == NULL) {
+            return BAD_FUNC_ARG;
+        }
+        XMEMCPY(buf + packet.pos, pcrDigest, pcrDigestSz);
+        packet.pos += pcrDigestSz;
+    }
 
     rc = wolfTPM2_PolicyHash(pcrAlg, digest, digestSz, TPM_CC_PolicyPCR,
         buf, packet.pos);

--- a/src/tpm2_wrap.c
+++ b/src/tpm2_wrap.c
@@ -11087,7 +11087,7 @@ int wolfTPM2_PolicyPCRMake(TPM_ALG_ID pcrAlg, byte* pcrArray, word32 pcrArraySz,
     TPM2_Packet_AppendPCR(&packet, &pcr);
 
     /* Copy the pcrDigest to the end of buffer */
-    if (packet.pos < 0 || (word32)packet.pos > (word32)sizeof(buf) ||
+    if ((word32)packet.pos > (word32)sizeof(buf) ||
         pcrDigestSz > (word32)sizeof(buf) - (word32)packet.pos) {
         return BUFFER_E;
     }


### PR DESCRIPTION
Fixes both Coverity findings in `wolfTPM2_PolicyPCRMake`.

> **Scope note:** this PR originally covered only CID 912593 and said 912594 was
> out of scope. Analysis showed both come from the same root cause in the same
> three lines, so 912594 is now fixed here too. Nothing else changed.

| | CID 912593 | CID 912594 |
|---|---|---|
| Checker | `OVERRUN` (Memory - illegal accesses) | `REVERSE_NEGATIVE` (Integer handling) |
| Impact | High | Medium |
| First detected | 2026-08-10 | 2026-08-10 |
| Status | New / Unclassified / Unassigned | New / Unclassified / Unassigned |

Project: https://scan.coverity.com/projects/wolftpm
Defects (SSO): https://scan.coverity.com/projects/wolftpm/view_defects

Coverity's annotations, verbatim:

- **912593** — *"Overrunning array of 100 bytes at byte offset 100 by dereferencing pointer `buf + packet.pos`."*
- **912594** — *"You might be using variable `packet.pos` before verifying that it is >= 0."*

## Root cause

Both come from Coverity being unable to bound `packet.pos` across the
`TPM2_Packet_AppendPCR` call, which returns `void` and mutates the packet in
place. With `pos` unbounded, the guard that PR #565 added reads as both
"possibly negative" and "possibly equal to `sizeof(buf)`".

```c
byte buf[sizeof(TPML_PCR_SELECTION)+WC_MAX_DIGEST_SIZE];   /* 100 bytes */
...
TPM2_Packet_AppendPCR(&packet, &pcr);

if (packet.pos < 0 || (word32)packet.pos > (word32)sizeof(buf) ||
    pcrDigestSz > (word32)sizeof(buf) - (word32)packet.pos) {
    return BUFFER_E;
}
XMEMCPY(buf + packet.pos, pcrDigest, pcrDigestSz);
```

**Neither condition is actually reachable.** `packet.pos` starts at 0 and the
`TPM2_Packet_Append*` helpers advance it only when the write fits, so after
`TPM2_Packet_AppendPCR` it is bounded by
`4 + HASH_COUNT*(2 + 1 + PCR_SELECT_MIN)`. Measured on this tree:

```
sizeof(TPML_PCR_SELECTION) = 36     WC_MAX_DIGEST_SIZE = 64
sizeof(buf)                = 100    (matches Coverity's "100 bytes")
HASH_COUNT = 5   PCR_SELECT_MIN = 3   PCR_SELECT_MAX = 3
max serialized AppendPCR   = 34
headroom                   = 66 bytes
```

So `packet.pos` is always in `[4, 34]`. I am not claiming a live memory-safety
bug here, and the fixes below are chosen to be provably behavior-preserving
rather than to chase the severity label.

## CID 912593 — `OVERRUN`

The capacity check uses `>` rather than `>=`, so `packet.pos == sizeof(buf)` is
accepted; with `pcrDigestSz == 0` the third clause is `0 > 0`, false, and
control reaches `XMEMCPY(buf + 100, pcrDigest, 0)`. `buf + 100` is a
one-past-the-end pointer, and passing it to `memcpy` is undefined behavior even
with `n == 0`, since the standard requires valid pointer arguments regardless of
length.

Fix — only copy when there is something to copy:

```c
if (pcrDigestSz > 0) {
    if (pcrDigest == NULL) {
        return BAD_FUNC_ARG;
    }
    XMEMCPY(buf + packet.pos, pcrDigest, pcrDigestSz);
    packet.pos += pcrDigestSz;
}
```

Inside the branch `pcrDigestSz >= 1`, and the capacity check gives
`pcrDigestSz <= sizeof(buf) - packet.pos`, therefore
`packet.pos <= sizeof(buf) - 1` and `buf + packet.pos` is strictly in bounds.

I chose this over `>` → `>=` deliberately: `>=` would make a
buffer-exactly-full-with-nothing-to-append call return `BUFFER_E`, changing
behavior for a case that succeeds today.

**The NULL check** is inside the branch, not hoisted to the argument validation
at the top, so the valid `(NULL, 0)` "no PCR digest" call still works.
`pcrDigest` is currently the only pointer parameter not validated — `digest`,
`digestSz` and `pcrArray` all are. Happy to hoist it if you would rather forbid
`(NULL, 0)` outright; that is an API decision, not a correctness one.

## CID 912594 — `REVERSE_NEGATIVE`

`TPM2_Packet_AppendPCR` indexes `packet.buf[packet.pos]` internally, so by the
time `packet.pos < 0` runs the value has already been used as an index. The
checker is correct about the ordering, and the check cannot be moved earlier
because `pos` is only meaningful after the append.

It is also redundant: any negative `int` cast to `word32` is at least 2^31, so
the very next comparison `(word32)packet.pos > (word32)sizeof(buf)` already
rejects every negative value. Dropping `packet.pos < 0` removes the reversed
check without weakening the guard:

```c
if ((word32)packet.pos > (word32)sizeof(buf) ||
    pcrDigestSz > (word32)sizeof(buf) - (word32)packet.pos) {
    return BUFFER_E;
}
```

The remaining bounds check is kept as defense in depth, not because it can
currently fail.

## Separate observation, deliberately not fixed here

`TPM2_Packet_AppendPCR` reports failure only by setting `packet.overflow`, and
`src/tpm2_wrap.c` never reads that flag anywhere — `grep -c overflow
src/tpm2_wrap.c` is 0, while `src/fwtpm/fwtpm_command.c` does test it. If a PCR
selection ever failed to fit, this function would silently build a policy digest
over a truncated selection.

With 66 bytes of headroom that is unreachable today, so I have left it alone
rather than add a check for a condition that cannot occur. Flagging it because
it is only unreachable by arithmetic that nothing asserts — if `HASH_COUNT` or
`PCR_SELECT_MIN` ever grow, this becomes silent and wrong. Say the word and I
will add the `overflow` check in a follow-up.

## Provenance

The flagged lines came from 6c3c356 (PR #565, 2026-08-06), *"F-7596 - Compare
pcrDigestSz against remaining buffer capacity"* — itself a Fenrir-driven
hardening fix. It replaced a guard that could overflow with one that cannot, and
Coverity flagged the replacement four days later. That fix was right; this is
the boundary it left behind.

## Testing

- `./autogen.sh && ./configure --enable-swtpm && make` — clean, exit 0, no new
  warnings in `tpm2_wrap.c`.
- No new test. This matches the precedent of the previous Coverity fix here,
  e79d060f *"Guard tainted PCR select copy in fwTPM PCR_PROPERTIES test
  (Coverity CID 911493)"*, which was likewise source-only and single-file. The
  triggering conditions are not reachable through the public API, since
  `packet.pos` is produced internally by `TPM2_Packet_AppendPCR`, so a
  regression test could not exercise them honestly. If you want a unit test for
  the `(NULL, non-zero)` rejection specifically, I will add one to
  `tests/unit_tests.c`.
