### PR TITLE
Refresh expired wolfSSL example CA certs and add a refresh script

### DIFF
--- a/certs/include.am
+++ b/certs/include.am
@@ -4,6 +4,7 @@
 
 EXTRA_DIST += \
         certs/certreq.sh \
+        certs/refresh-wolf-ca.sh \
         certs/ca-rsa.cnf \
         certs/ca-ecc.cnf \
         certs/wolf-ca-ecc-cert.pem \

--- a/certs/refresh-wolf-ca.sh
+++ b/certs/refresh-wolf-ca.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Refresh the wolfSSL example CA certificates used by the TLS examples.
+#
+# wolf-ca-rsa-cert.pem and wolf-ca-ecc-cert.pem are copies of wolfSSL's own
+# example CA certificates. The TLS examples load them to verify the wolfSSL
+# example peer, so they must match the wolfSSL tree the examples run against.
+# They expire when wolfSSL's do, so refresh them from a wolfSSL checkout.
+#
+# Usage: WOLFSSL_DIR=/path/to/wolfssl ./certs/refresh-wolf-ca.sh
+# WOLFSSL_DIR defaults to the wolfSSL checkout beside this repo.
+
+set -e
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+WOLFSSL_DIR="${WOLFSSL_DIR:-$SCRIPT_DIR/../../wolfssl}"
+
+if [ ! -f "$WOLFSSL_DIR/certs/ca-cert.pem" ]; then
+    echo "wolfSSL certs not found at $WOLFSSL_DIR/certs" >&2
+    echo "Set WOLFSSL_DIR to your wolfSSL checkout." >&2
+    exit 1
+fi
+
+cp "$WOLFSSL_DIR/certs/ca-cert.pem"     "$SCRIPT_DIR/wolf-ca-rsa-cert.pem"
+cp "$WOLFSSL_DIR/certs/ca-ecc-cert.pem" "$SCRIPT_DIR/wolf-ca-ecc-cert.pem"
+
+echo "Refreshed wolf-ca-rsa-cert.pem and wolf-ca-ecc-cert.pem from $WOLFSSL_DIR"
+openssl x509 -in "$SCRIPT_DIR/wolf-ca-rsa-cert.pem" -noout -enddate
+openssl x509 -in "$SCRIPT_DIR/wolf-ca-ecc-cert.pem" -noout -enddate

--- a/certs/wolf-ca-ecc-cert.pem
+++ b/certs/wolf-ca-ecc-cert.pem
@@ -2,13 +2,13 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            0f:17:46:70:fd:c2:70:d1:f9:42:49:9c:1a:c3:5d:dd:30:c8:5f:85
+            13:ad:2b:cb:23:10:9b:48:1f:5e:4d:02:bf:f4:f0:0f:66:aa:9b:25
         Signature Algorithm: ecdsa-with-SHA256
-        Issuer: C = US, ST = Washington, L = Seattle, O = wolfSSL, OU = Development, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL, OU=Development, CN=www.wolfssl.com, emailAddress=facts@wolfssl.com
         Validity
-            Not Before: Dec 13 22:19:28 2023 GMT
-            Not After : Sep  8 22:19:28 2026 GMT
-        Subject: C = US, ST = Washington, L = Seattle, O = wolfSSL, OU = Development, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
+            Not Before: Jun 11 21:44:28 2026 GMT
+            Not After : Mar  7 21:44:28 2029 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL, OU=Development, CN=www.wolfssl.com, emailAddress=facts@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: id-ecPublicKey
                 Public-Key: (256 bit)
@@ -24,30 +24,30 @@ Certificate:
             X509v3 Subject Key Identifier: 
                 56:8E:9A:C3:F0:42:DE:18:B9:45:55:6E:F9:93:CF:EA:C3:F3:A5:21
             X509v3 Authority Key Identifier: 
-                keyid:56:8E:9A:C3:F0:42:DE:18:B9:45:55:6E:F9:93:CF:EA:C3:F3:A5:21
-
+                56:8E:9A:C3:F0:42:DE:18:B9:45:55:6E:F9:93:CF:EA:C3:F3:A5:21
             X509v3 Basic Constraints: critical
                 CA:TRUE
             X509v3 Key Usage: critical
                 Digital Signature, Certificate Sign, CRL Sign
     Signature Algorithm: ecdsa-with-SHA256
-         30:45:02:21:00:c8:64:7f:ee:4b:be:83:48:13:ea:92:f8:1a:
-         82:1e:85:b1:5a:a4:1c:e3:e8:ea:25:44:6f:e7:70:fd:eb:f3:
-         76:02:20:44:02:a2:ec:c5:a1:ae:e2:a4:8a:d9:13:95:2b:a6:
-         5b:09:57:86:61:42:96:97:f0:95:62:0c:03:e6:53:04:25
+    Signature Value:
+        30:45:02:20:3d:16:c7:71:cf:9f:5d:72:7f:c2:7e:94:37:e4:
+        46:2f:58:03:77:54:c6:00:ac:0b:67:a9:89:df:db:30:18:c9:
+        02:21:00:96:61:1b:13:b2:0b:9b:8a:79:d6:a9:d9:36:fd:d3:
+        c9:4e:6c:ea:07:83:09:89:c4:f5:5d:58:64:ac:9e:d5:e1
 -----BEGIN CERTIFICATE-----
-MIIClTCCAjugAwIBAgIUDxdGcP3CcNH5QkmcGsNd3TDIX4UwCgYIKoZIzj0EAwIw
-gZcxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdT
+MIIClzCCAj2gAwIBAgIUE60ryyMQm0gfXk0Cv/TwD2aqmyUwCgYIKoZIzj0EAwIw
+gZgxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdT
 ZWF0dGxlMRAwDgYDVQQKDAd3b2xmU1NMMRQwEgYDVQQLDAtEZXZlbG9wbWVudDEY
-MBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdv
-bGZzc2wuY29tMB4XDTIzMTIxMzIyMTkyOFoXDTI2MDkwODIyMTkyOFowgZcxCzAJ
-BgNVBAYTAlVTMRMwEQYDVQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdTZWF0dGxl
-MRAwDgYDVQQKDAd3b2xmU1NMMRQwEgYDVQQLDAtEZXZlbG9wbWVudDEYMBYGA1UE
-AwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wu
-Y29tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAtPZbtYBjkXIuZAx5cBM456t
-KTiYuhDW6QkqgKkuFyq5ir8zg0bjlQvkd0C1O0NFMw9hU3w3RMHL/IDK6EPqp6Nj
-MGEwHQYDVR0OBBYEFFaOmsPwQt4YuUVVbvmTz+rD86UhMB8GA1UdIwQYMBaAFFaO
-msPwQt4YuUVVbvmTz+rD86UhMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQD
-AgGGMAoGCCqGSM49BAMCA0gAMEUCIQDIZH/uS76DSBPqkvgagh6FsVqkHOPo6iVE
-b+dw/evzdgIgRAKi7MWhruKkitkTlSumWwlXhmFClpfwlWIMA+ZTBCU=
+MBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMSAwHgYJKoZIhvcNAQkBFhFmYWN0c0B3
+b2xmc3NsLmNvbTAeFw0yNjA2MTEyMTQ0MjhaFw0yOTAzMDcyMTQ0MjhaMIGYMQsw
+CQYDVQQGEwJVUzETMBEGA1UECAwKV2FzaGluZ3RvbjEQMA4GA1UEBwwHU2VhdHRs
+ZTEQMA4GA1UECgwHd29sZlNTTDEUMBIGA1UECwwLRGV2ZWxvcG1lbnQxGDAWBgNV
+BAMMD3d3dy53b2xmc3NsLmNvbTEgMB4GCSqGSIb3DQEJARYRZmFjdHNAd29sZnNz
+bC5jb20wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQC09lu1gGORci5kDHlwEzj
+nq0pOJi6ENbpCSqAqS4XKrmKvzODRuOVC+R3QLU7Q0UzD2FTfDdEwcv8gMroQ+qn
+o2MwYTAdBgNVHQ4EFgQUVo6aw/BC3hi5RVVu+ZPP6sPzpSEwHwYDVR0jBBgwFoAU
+Vo6aw/BC3hi5RVVu+ZPP6sPzpSEwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8E
+BAMCAYYwCgYIKoZIzj0EAwIDSAAwRQIgPRbHcc+fXXJ/wn6UN+RGL1gDd1TGAKwL
+Z6mJ39swGMkCIQCWYRsTsgubinnWqdk2/dPJTmzqB4MJicT1XVhkrJ7V4Q==
 -----END CERTIFICATE-----

--- a/certs/wolf-ca-rsa-cert.pem
+++ b/certs/wolf-ca-rsa-cert.pem
@@ -2,16 +2,16 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            33:44:1a:a8:6c:01:ec:f6:60:f2:70:51:0a:4c:d1:14:fa:bc:e9:44
+            67:19:d2:a8:7f:e3:2d:fa:75:7a:4f:e7:b2:02:d9:ad:c4:77:5e:f8
         Signature Algorithm: sha256WithRSAEncryption
-        Issuer: C = US, ST = Montana, L = Bozeman, O = Sawtooth, OU = Consulting, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
+        Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com, emailAddress=facts@wolfssl.com
         Validity
-            Not Before: Dec 13 22:19:28 2023 GMT
-            Not After : Sep  8 22:19:28 2026 GMT
-        Subject: C = US, ST = Montana, L = Bozeman, O = Sawtooth, OU = Consulting, CN = www.wolfssl.com, emailAddress = info@wolfssl.com
+            Not Before: Jun 11 21:44:28 2026 GMT
+            Not After : Mar  7 21:44:28 2029 GMT
+        Subject: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com, emailAddress=facts@wolfssl.com
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
                     00:bf:0c:ca:2d:14:b2:1e:84:42:5b:cd:38:1f:4a:
                     f2:4d:75:10:f1:b6:35:9f:df:ca:7d:03:98:d3:ac:
@@ -37,9 +37,8 @@ Certificate:
                 27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
             X509v3 Authority Key Identifier: 
                 keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
-                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
-                serial:33:44:1A:A8:6C:01:EC:F6:60:F2:70:51:0A:4C:D1:14:FA:BC:E9:44
-
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=facts@wolfssl.com
+                serial:67:19:D2:A8:7F:E3:2D:FA:75:7A:4F:E7:B2:02:D9:AD:C4:77:5E:F8
             X509v3 Basic Constraints: 
                 CA:TRUE
             X509v3 Subject Alternative Name: 
@@ -47,47 +46,48 @@ Certificate:
             X509v3 Extended Key Usage: 
                 TLS Web Server Authentication, TLS Web Client Authentication
     Signature Algorithm: sha256WithRSAEncryption
-         2d:fc:f9:32:5a:be:d6:9d:42:8b:86:4e:67:22:c3:50:2d:cb:
-         14:27:1d:94:f3:cd:88:42:da:41:1c:39:24:67:a7:92:4d:27:
-         ea:56:82:19:bf:11:b2:43:a4:8d:5d:87:b2:27:64:66:82:81:
-         df:c4:fd:5b:62:b0:c2:4d:9d:29:f2:41:32:cc:2e:b5:da:38:
-         06:1b:e8:7f:8c:6e:3d:80:1e:00:56:49:bf:39:e0:da:68:2f:
-         c4:fd:00:e6:d1:81:1a:d1:4a:bb:76:52:ce:4d:24:9d:c4:a3:
-         a7:f1:65:14:2f:1f:a8:2d:c6:cb:ce:b1:a7:89:74:26:27:c3:
-         f3:a3:84:4c:34:01:14:03:7d:16:3a:c8:8b:25:2e:7b:90:cc:
-         46:b1:52:34:ba:93:6e:ef:fe:43:a3:ad:c6:6f:51:fb:ba:ea:
-         38:e3:6f:d6:ee:63:62:36:ea:5e:08:b4:e2:2a:46:89:e3:ae:
-         b3:b4:06:ef:63:7a:6e:5d:dd:c9:ec:02:4f:f7:64:c0:27:07:
-         b4:6f:4a:18:72:5b:34:74:7c:d0:a9:04:8f:40:8b:6a:39:d2:
-         6b:1a:01:f2:01:a8:81:34:3a:e5:b0:55:d1:3c:95:ca:b0:82:
-         d6:ed:98:28:15:59:7e:95:a7:69:c7:b5:7b:ec:01:a7:4d:e6:
-         b9:a2:fe:35
+    Signature Value:
+        5d:a4:7f:06:52:54:b2:56:a9:f8:8d:fb:c9:13:ab:9c:16:4e:
+        72:a8:57:b2:8d:e7:b4:a9:3f:32:5c:21:08:ff:42:9f:41:47:
+        12:27:b5:45:9e:61:6e:b6:94:fe:f6:01:46:96:3e:f7:3d:79:
+        07:ac:a9:26:f5:77:f7:52:c3:ed:bd:5a:a0:17:4c:0e:9e:51:
+        57:ac:e3:a1:ef:7d:a3:fa:7c:c6:a5:57:84:dd:d0:aa:77:ab:
+        30:12:70:83:f9:41:ae:74:78:f0:54:73:ed:86:7f:66:a1:aa:
+        01:cd:41:5f:95:c7:6e:ce:3b:ab:2e:70:ff:3a:34:11:43:df:
+        4b:63:d5:3b:a5:9e:21:cb:9c:c8:a7:5c:a0:43:ec:73:98:c5:
+        25:d9:d4:ad:cc:11:66:83:51:8a:bd:33:65:a0:a3:a8:93:1e:
+        7b:b9:f7:6a:95:6a:a7:dd:ff:6f:3b:bb:24:5c:56:14:8d:b9:
+        84:d3:97:bf:57:71:0c:1e:b1:68:93:31:d6:34:38:77:94:da:
+        e2:b0:fe:82:18:b2:bb:bf:83:cf:bb:fe:08:fa:2a:17:10:3e:
+        06:b1:1c:b1:f9:12:97:87:cc:a8:4e:5e:0d:0c:26:3c:c2:e8:
+        be:2d:48:91:77:7f:1a:1d:ac:bf:c9:55:10:bf:2f:5f:60:53:
+        e7:b7:6a:72
 -----BEGIN CERTIFICATE-----
-MIIE/zCCA+egAwIBAgIUM0QaqGwB7PZg8nBRCkzRFPq86UQwDQYJKoZIhvcNAQEL
-BQAwgZQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdC
+MIIFAjCCA+qgAwIBAgIUZxnSqH/jLfp1ek/nsgLZrcR3XvgwDQYJKoZIhvcNAQEL
+BQAwgZUxCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdC
 b3plbWFuMREwDwYDVQQKDAhTYXd0b290aDETMBEGA1UECwwKQ29uc3VsdGluZzEY
-MBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdv
-bGZzc2wuY29tMB4XDTIzMTIxMzIyMTkyOFoXDTI2MDkwODIyMTkyOFowgZQxCzAJ
+MBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMSAwHgYJKoZIhvcNAQkBFhFmYWN0c0B3
+b2xmc3NsLmNvbTAeFw0yNjA2MTEyMTQ0MjhaFw0yOTAzMDcyMTQ0MjhaMIGVMQsw
+CQYDVQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjER
+MA8GA1UECgwIU2F3dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMM
+D3d3dy53b2xmc3NsLmNvbTEgMB4GCSqGSIb3DQEJARYRZmFjdHNAd29sZnNzbC5j
+b20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/DMotFLIehEJbzTgf
+SvJNdRDxtjWf38p9A5jTrN4DZu4q8diwfW4HVAsQmCFNgMsSIOfMT95FfclydzLq
+ypC7aVIQAy+o85XF8YtiVhvvZ2+kEEGVrQqb46XAsNJwdlAwW6joCCx87aeieo04
+KRysx+3yfJWwlYJ9SVw4zXcl772AdVOUPD3KY1ufFbXTHRMvGdE823Y6zLh9yeXC
+19pAb9gh3HMbQi1TnP4a/H2rejY/mN6EfAVnzmoUOIep8Yy1aMtof3EgK/WgY/VW
+L6Mm0rdvsVoX1ziZCP6TWG/+wxNJCBYLp01nAFIxZyNOmO1RRR25BNkL7Ngos0u9
+7TZ5AgMBAAGjggFGMIIBQjAdBgNVHQ4EFgQUJ45nEXTDJh0/7TNjs6TYHTDl6NUw
+gdUGA1UdIwSBzTCByoAUJ45nEXTDJh0/7TNjs6TYHTDl6NWhgZukgZgwgZUxCzAJ
 BgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREw
 DwYDVQQKDAhTYXd0b290aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwP
-d3d3LndvbGZzc2wuY29tMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29t
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvwzKLRSyHoRCW804H0ry
-TXUQ8bY1n9/KfQOY06zeA2buKvHYsH1uB1QLEJghTYDLEiDnzE/eRX3Jcncy6sqQ
-u2lSEAMvqPOVxfGLYlYb72dvpBBBla0Km+OlwLDScHZQMFuo6AgsfO2nonqNOCkc
-rMft8nyVsJWCfUlcOM13Je+9gHVTlDw9ymNbnxW10x0TLxnRPNt2Osy4fcnlwtfa
-QG/YIdxzG0ItU5z+Gvx9q3o2P5jehHwFZ85qFDiHqfGMtWjLaH9xICv1oGP1Vi+j
-JtK3b7FaF9c4mQj+k1hv/sMTSQgWC6dNZwBSMWcjTpjtUUUduQTZC+zYKLNLve02
-eQIDAQABo4IBRTCCAUEwHQYDVR0OBBYEFCeOZxF0wyYdP+0zY7Ok2B0w5ejVMIHU
-BgNVHSMEgcwwgcmAFCeOZxF0wyYdP+0zY7Ok2B0w5ejVoYGapIGXMIGUMQswCQYD
-VQQGEwJVUzEQMA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8G
-A1UECgwIU2F3dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3
-dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIU
-M0QaqGwB7PZg8nBRCkzRFPq86UQwDAYDVR0TBAUwAwEB/zAcBgNVHREEFTATggtl
-eGFtcGxlLmNvbYcEfwAAATAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw
-DQYJKoZIhvcNAQELBQADggEBAC38+TJavtadQouGTmciw1AtyxQnHZTzzYhC2kEc
-OSRnp5JNJ+pWghm/EbJDpI1dh7InZGaCgd/E/VtisMJNnSnyQTLMLrXaOAYb6H+M
-bj2AHgBWSb854NpoL8T9AObRgRrRSrt2Us5NJJ3Eo6fxZRQvH6gtxsvOsaeJdCYn
-w/OjhEw0ARQDfRY6yIslLnuQzEaxUjS6k27v/kOjrcZvUfu66jjjb9buY2I26l4I
-tOIqRonjrrO0Bu9jem5d3cnsAk/3ZMAnB7RvShhyWzR0fNCpBI9Ai2o50msaAfIB
-qIE0OuWwVdE8lcqwgtbtmCgVWX6Vp2nHtXvsAadN5rmi/jU=
+d3d3LndvbGZzc2wuY29tMSAwHgYJKoZIhvcNAQkBFhFmYWN0c0B3b2xmc3NsLmNv
+bYIUZxnSqH/jLfp1ek/nsgLZrcR3XvgwDAYDVR0TBAUwAwEB/zAcBgNVHREEFTAT
+ggtleGFtcGxlLmNvbYcEfwAAATAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUH
+AwIwDQYJKoZIhvcNAQELBQADggEBAF2kfwZSVLJWqfiN+8kTq5wWTnKoV7KN57Sp
+PzJcIQj/Qp9BRxIntUWeYW62lP72AUaWPvc9eQesqSb1d/dSw+29WqAXTA6eUVes
+46HvfaP6fMalV4Td0Kp3qzAScIP5Qa50ePBUc+2Gf2ahqgHNQV+Vx27OO6sucP86
+NBFD30tj1TulniHLnMinXKBD7HOYxSXZ1K3MEWaDUYq9M2Wgo6iTHnu592qVaqfd
+/287uyRcVhSNuYTTl79XcQwesWiTMdY0OHeU2uKw/oIYsru/g8+7/gj6KhcQPgax
+HLH5EpeHzKhOXg0MJjzC6L4tSJF3fxodrL/JVRC/L19gU+e3anI=
 -----END CERTIFICATE-----

--- a/examples/README.md
+++ b/examples/README.md
@@ -171,6 +171,9 @@ cp ../wolfssl/certs/ca-cert.pem ./certs/wolf-ca-rsa-cert.pem
 cp ../wolfssl/certs/ca-ecc-cert.pem ./certs/wolf-ca-ecc-cert.pem
 ```
 
+Or run `./certs/refresh-wolf-ca.sh` (set `WOLFSSL_DIR` if wolfSSL is not
+at `../wolfssl`) to refresh them when they expire.
+
 ### TLS Client
 
 Examples show using a TPM key and certificate for TLS mutual authentication (client authentication).


### PR DESCRIPTION
certs/wolf-ca-rsa-cert.pem and certs/wolf-ca-ecc-cert.pem expired on Sep 8 2026 22:19 GMT updates cert - update the CA certs so CI doesnt fail